### PR TITLE
Handle mixed CKAN CSV record delimiters

### DIFF
--- a/server/__tests__/mapIndexPipeline.test.js
+++ b/server/__tests__/mapIndexPipeline.test.js
@@ -1,4 +1,6 @@
 const { once } = require('node:events');
+const { parse } = require('csv-parse');
+const { csvParseOptions } = require('../services/csvLoad');
 const {
     MapSkipError,
     geometryVertexCount,
@@ -47,5 +49,27 @@ describe('bounded local-map conversion', () => {
 
         expect(() => validateCandidate({ expectedRows: 11 }, { maxRows: 10, maxVertices: 100 }))
             .toThrow(MapSkipError);
+    });
+
+    test('accepts CKAN exports that mix CRLF headers with LF records', async () => {
+        const csv = '_id,Name,Description,geometry\r\n' +
+            '1,Park,"first line\nsecond line","{""type"":""Point"",""coordinates"":[-79.38,43.65]}"\n' +
+            '2,Trail,short,"{""type"":""LineString"",""coordinates"":[[-79.4,43.6],[-79.3,43.7]]}"\n';
+        let metadata;
+        const parser = parse(csvParseOptions({ columns: true, delimiter: ',' }));
+        const transform = stagingTransform({
+            caps: { maxRows: 10, maxVertices: 10 },
+            onMetadata: value => { metadata = value; }
+        });
+        transform.on('data', () => {});
+        const ended = once(transform, 'end');
+        parser.pipe(transform);
+        parser.end(csv);
+        await ended;
+
+        expect(transform.result()).toEqual(expect.objectContaining({
+            rowCount: 2, featureCount: 2, vertexCount: 3
+        }));
+        expect(metadata.geometryColumn).toBe('geometry');
     });
 });

--- a/server/db/catalogWriteQueries.js
+++ b/server/db/catalogWriteQueries.js
@@ -15,10 +15,10 @@ function dedupeById(rows) {
     return Array.from(byId.values());
 }
 
-function upsertOrganizations(db, orgsRaw) {
+async function upsertOrganizations(db, orgsRaw) {
     const orgs = dedupeById(orgsRaw);
     if (orgs.length === 0) {
-        return Promise.resolve();
+        return;
     }
     const chunkSize = 500;
     const chunks = [];
@@ -26,7 +26,7 @@ function upsertOrganizations(db, orgsRaw) {
         chunks.push(orgs.slice(i, i + chunkSize));
     }
 
-    return Promise.all(chunks.map(chunk => {
+    for (const chunk of chunks) {
         const placeholders = [];
         const values = [];
         let paramIndex = 1;
@@ -45,14 +45,14 @@ function upsertOrganizations(db, orgsRaw) {
                 title_fr = EXCLUDED.title_fr,
                 place_id = EXCLUDED.place_id
         `;
-        return db.query(sql, values);
-    }));
+        await db.query(sql, values);
+    }
 }
 
-function upsertDatasets(db, datasetsRaw) {
+async function upsertDatasets(db, datasetsRaw) {
     const datasets = dedupeById(datasetsRaw);
     if (datasets.length === 0) {
-        return Promise.resolve();
+        return;
     }
     const chunkSize = 500;
     const chunks = [];
@@ -60,7 +60,7 @@ function upsertDatasets(db, datasetsRaw) {
         chunks.push(datasets.slice(i, i + chunkSize));
     }
 
-    return Promise.all(chunks.map(chunk => {
+    for (const chunk of chunks) {
         const placeholders = [];
         const values = [];
         let paramIndex = 1;
@@ -97,16 +97,16 @@ function upsertDatasets(db, datasetsRaw) {
                 metadata_modified = EXCLUDED.metadata_modified,
                 raw = EXCLUDED.raw
         `;
-        return db.query(sql, values);
-    }));
+        await db.query(sql, values);
+    }
 }
 
-function upsertDatasetSources(db, rowsRaw) {
+async function upsertDatasetSources(db, rowsRaw) {
     const rows = Array.from(new Map((rowsRaw || []).map(row => [row.sourceId + '\0' + row.externalId, row])).values());
-    if (rows.length === 0) return Promise.resolve();
+    if (rows.length === 0) return;
     const chunks = [];
     for (let i = 0; i < rows.length; i += 250) chunks.push(rows.slice(i, i + 250));
-    return Promise.all(chunks.map(chunk => {
+    for (const chunk of chunks) {
         const values = [];
         const tuples = chunk.map((row, index) => {
             const p = index * 12 + 1;
@@ -118,7 +118,7 @@ function upsertDatasetSources(db, rowsRaw) {
             );
             return `($${p},$${p + 1},$${p + 2},$${p + 3},$${p + 4},$${p + 5},$${p + 6},$${p + 7},$${p + 8},$${p + 9},$${p + 10},$${p + 11})`;
         });
-        return db.query(`
+        await db.query(`
             INSERT INTO dataset_sources (
                 source_id, external_id, dataset_id, landing_url,
                 license_title_en, license_title_fr, license_url,
@@ -136,7 +136,7 @@ function upsertDatasetSources(db, rowsRaw) {
                 raw = EXCLUDED.raw,
                 last_seen_at = EXCLUDED.last_seen_at
         `, values);
-    }));
+    }
 }
 
 async function replaceDatasetPlaces(db, sourceId, datasetIds, linksRaw) {

--- a/server/services/csvLoad.js
+++ b/server/services/csvLoad.js
@@ -6,6 +6,21 @@ const { pipeline } = require('node:stream/promises');
 const { inferColumns, pgTypeFor, detectHeaderIndex, mergeTwoRowHeader } = require('../utils/csvTypes');
 const { quoteIdent } = require('../utils/filterGrammar');
 
+// Some CKAN exports use CRLF for the header and LF for later records. Let the
+// parser accept every conventional record delimiter explicitly; otherwise it
+// locks onto CRLF and rejects a correctly quoted field followed by a lone LF.
+const CSV_RECORD_DELIMITERS = ['\r\n', '\n', '\r'];
+
+function csvParseOptions(options = {}) {
+    return {
+        bom: true,
+        relax_column_count: true,
+        skip_empty_lines: true,
+        record_delimiter: CSV_RECORD_DELIMITERS,
+        ...options
+    };
+}
+
 function escapeCsvValue(v) {
     if (v === null || v === undefined) return '';
     return '"' + String(v).replace(/"/g, '""') + '"';
@@ -16,7 +31,7 @@ async function readSample(filePath, { delimiter, encoding }) {
         const records = [];
         let settled = false;
         const readStream = fs.createReadStream(filePath, { encoding });
-        const parser = parse({ bom: true, delimiter, relax_column_count: true, skip_empty_lines: true });
+        const parser = parse(csvParseOptions({ delimiter }));
 
         const finish = () => {
             const headerIndex = detectHeaderIndex(records);
@@ -100,7 +115,7 @@ async function loadCsvIntoStore(client, { filePath, tableName, delimiter, encodi
 
     await pipeline(
         fs.createReadStream(filePath, { encoding }),
-        parse({ bom: true, delimiter, relax_column_count: true, skip_empty_lines: true }),
+        parse(csvParseOptions({ delimiter })),
         toCsv,
         client.query(copyFrom(copySql))
     );
@@ -122,4 +137,4 @@ async function loadCsvIntoStore(client, { filePath, tableName, delimiter, encodi
     return { rowCount, columns };
 }
 
-module.exports = { loadCsvIntoStore, escapeCsvValue };
+module.exports = { loadCsvIntoStore, escapeCsvValue, csvParseOptions, CSV_RECORD_DELIMITERS };

--- a/server/services/mapIndexPipeline.js
+++ b/server/services/mapIndexPipeline.js
@@ -7,7 +7,7 @@ const { from: copyFrom } = require('pg-copy-streams');
 const metadataPool = require('../db/pool');
 const indexPool = require('../db/longRunningPool');
 const { downloadToTempFile, sniffCsvMeta } = require('./csvDownload');
-const { escapeCsvValue } = require('./csvLoad');
+const { escapeCsvValue, csvParseOptions } = require('./csvLoad');
 const { assertDiskHeadroom } = require('./ingestPipeline');
 
 const GB = 1024 * 1024 * 1024;
@@ -234,7 +234,7 @@ async function indexMapResource(resource, job, workerId, capsRaw = {}, options =
             const transform = stagingTransform({ caps, onMetadata: value => { metadata = value; } });
             await pipeline(
                 fs.createReadStream(filePath, { encoding }),
-                parse({ columns: true, bom: true, delimiter, relax_column_count: true, skip_empty_lines: true }),
+                parse(csvParseOptions({ columns: true, delimiter })),
                 transform,
                 client.query(copyFrom('COPY map_stage (feature_id, geom_json, properties) FROM STDIN WITH (FORMAT csv)'))
             );


### PR DESCRIPTION
## What & why

Toronto CKAN DataStore dumps use CRLF for the header and LF for subsequent records. Automatic record-delimiter detection locked onto CRLF, so valid quoted GeoJSON fields were rejected when their record ended with LF.

Explicitly accepts CRLF, LF, and CR across both local map indexing and normal CSV ingestion. Also serializes chunked catalogue writes on a transaction client to avoid node-postgres's concurrent-query deprecation warning during the 556-dataset Toronto sync.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: unaffected; prior release checks pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

- Reproduced against the official Toronto CKAN dump and added a fixture with a CRLF header, LF records, a multiline quoted field, and quoted GeoJSON.
- Local result: 48 suites and 325 tests pass; the Docker-only spatial test is skipped locally and remains covered by CI.
- The production map worker was stopped after first attempts and all 187 jobs are pending with at most one attempt; no job exhausted retries.