### PR TITLE
Add Peel Region open data cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ and all eight lower-tier municipalities, with direct feeds from Durham, Ajax,
 Oshawa, Pickering and the explicitly open-licensed subset of Whitby.
 Clarington is represented through Durham’s regional coverage only: its current
 public web-map terms are personal/non-commercial, so no direct adapter is enabled.
+Peel Region is included alongside direct Mississauga and Brampton feeds; Caledon
+is represented honestly through Peel's regional coverage. Each portal is gated
+to its recognized open licences, so generic website terms, blank licence records
+where no portal-wide grant applies, and non-commercial data stay excluded.
 
 ## Layout
 
@@ -53,6 +57,7 @@ npm run migrate               # idempotent, applies sql/migrations/*.sql
 node scripts/catalog-sync.js --limit 200   # small real harvest (~2 min, polite)
 npm run sync:places                       # Statistics Canada SGC hierarchy
 npm run sync:source -- --source=durham-hub --dry-run
+npm run sync:source -- --source=peel-hub --dry-run
 npm run sync:municipal                    # sync every enabled local source
 npm run maps:drain                        # build all queued local map indexes
 npm run dev                   # API on :3100
@@ -76,9 +81,11 @@ curl 'http://localhost:3100/api/v1/datasets?q=housing&place=oshawa-on&format=CSV
 # browse featured regions/cities (or search every SGC place with q)
 curl 'http://localhost:3100/api/v1/places?featured=true'
 curl 'http://localhost:3100/api/v1/places?q=Oshawa'
+curl 'http://localhost:3100/api/v1/places?q=Mississauga'
 
 # place-filtered sources are authoritative; counts expose total + authoritative
 curl 'http://localhost:3100/api/v1/sources?place=clarington-on'
+curl 'http://localhost:3100/api/v1/sources?place=mississauga-on'
 
 # dataset detail - resources tagged datastore | ingested | ingestable | file-only
 curl 'http://localhost:3100/api/v1/datasets/<idOrName>'

--- a/client/src/components/PlaceSelect.test.jsx
+++ b/client/src/components/PlaceSelect.test.jsx
@@ -9,6 +9,8 @@ describe('PlaceSelect', () => {
       { id: 'ca-on', slug: 'ontario', kind: 'province', name: { en: 'Ontario' }, dataset_count: 5 },
       { id: 'ca-on-durham', slug: 'durham-on', kind: 'region', name: { en: 'Durham' }, dataset_count: 12 },
       { id: 'ca-on-oshawa', slug: 'oshawa-on', kind: 'municipality', name: { en: 'Oshawa' }, parent: { id: 'ca-on-durham' }, dataset_count: 10 },
+      { id: 'sgc-cd-3521', slug: 'peel-on', kind: 'region', name: { en: 'Peel' }, dataset_count: 901 },
+      { id: 'sgc-csd-3521005', slug: 'mississauga-on', kind: 'municipality', name: { en: 'Mississauga' }, parent: { id: 'sgc-cd-3521' }, dataset_count: 429 },
       { id: 'sgc-cd-3520', slug: 'toronto-on', kind: 'municipality', name: { en: 'Toronto' }, parent: { id: 'ca-on' }, dataset_count: 556 },
     ]} />);
     const select = screen.getByRole('combobox', { name: 'Choose a place' });
@@ -16,7 +18,7 @@ describe('PlaceSelect', () => {
     fireEvent.change(select, { target: { value: 'oshawa-on' } });
     expect(onChange).toHaveBeenCalledWith('oshawa-on');
     expect([...container.querySelectorAll('optgroup')].map(group => group.label)).toEqual([
-      'Featured regions', 'Municipalities in Durham', 'Featured cities', 'Other places'
+      'Featured regions', 'Municipalities in Durham', 'Municipalities in Peel', 'Featured cities', 'Other places'
     ]);
   });
 });

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -21,6 +21,23 @@ beforeEach(() => {
       dataset_count: 350, direct_dataset_count: 0, mappable_resource_count: 300
     },
     {
+      id: 'sgc-cd-3521', slug: 'peel-on', kind: 'region',
+      name: { en: 'Peel' }, type: { en: 'Regional municipality' },
+      dataset_count: 901, direct_dataset_count: 139, mappable_resource_count: 609
+    },
+    {
+      id: 'sgc-csd-3521005', slug: 'mississauga-on', kind: 'municipality',
+      name: { en: 'Mississauga' }, type: { en: 'City' },
+      parent: { id: 'sgc-cd-3521', name: { en: 'Peel' } },
+      dataset_count: 429, direct_dataset_count: 290, mappable_resource_count: 222
+    },
+    {
+      id: 'sgc-csd-3521024', slug: 'caledon-on', kind: 'municipality',
+      name: { en: 'Caledon' }, type: { en: 'Town' },
+      parent: { id: 'sgc-cd-3521', name: { en: 'Peel' } },
+      dataset_count: 139, direct_dataset_count: 0, mappable_resource_count: 106
+    },
+    {
       id: 'sgc-cd-3520', slug: 'toronto-on', kind: 'municipality',
       name: { en: 'Toronto' }, type: { en: 'City' },
       parent: { id: 'ca-on', name: { en: 'Ontario' } },
@@ -35,10 +52,13 @@ describe('PlacesPage', () => {
 
     expect(await screen.findByRole('heading', { name: 'Featured regions' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Municipalities in Durham' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Municipalities in Peel' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Featured cities' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Toronto/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Clarington/ })).toBeInTheDocument();
-    expect(screen.getByText('Broader-area coverage')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Caledon/ })).toBeInTheDocument();
+    expect(screen.getAllByText('Broader-area coverage')).toHaveLength(2);
     await waitFor(() => expect(fetchPlaces).toHaveBeenCalledWith({
       q: undefined, featured: true, limit: 100
     }));

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -207,7 +207,10 @@ curl -s 'https://<your-domain>/api/v1/datasets?q=housing&limit=3'
 curl -s 'https://<your-domain>/api/v1/places?featured=true'
 curl -s 'https://<your-domain>/api/v1/places?q=Oshawa'
 curl -s 'https://<your-domain>/api/v1/places?q=Toronto'
+curl -s 'https://<your-domain>/api/v1/places?q=Mississauga'
+curl -s 'https://<your-domain>/api/v1/places?q=Brampton'
 curl -s 'https://<your-domain>/api/v1/sources?place=clarington-on'
+curl -s 'https://<your-domain>/api/v1/sources?place=caledon-on'
 # UI: search by place, open a mapped dataset, pan/zoom the live Map tab, then load its table snapshot
 ```
 

--- a/server/__tests__/arcgisHubAdapter.test.js
+++ b/server/__tests__/arcgisHubAdapter.test.js
@@ -142,6 +142,100 @@ describe('ArcGIS Hub adapter', () => {
         }));
     });
 
+    test('applies Mississauga portal terms while preserving explicit Statistics Canada licensing', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'Mississauga', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+        const source = getSource('mississauga-hub');
+        const cityRecord = record({
+            landingPage: 'https://data.mississauga.ca/datasets/mississauga::wards',
+            publisher: { name: 'City Of Mississauga' },
+            license: null
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+        expect(city.status).toBe('included');
+        expect(city.value.places[0].placeId).toBe('sgc-csd-3521005');
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseUrl: 'https://www.mississauga.ca/file/COM/CityOfMississaugaTermsOfUse.pdf'
+        }));
+
+        const census = await adapter.enrichRecord({
+            ...cityRecord,
+            license: 'https://www.statcan.gc.ca/en/reference/licence'
+        }, source, { fetchJson });
+        expect(census.value.source.licenseUrl).toBe('https://www.statcan.gc.ca/en/reference/licence');
+    });
+
+    test('admits only explicit Brampton CC BY or Statistics Canada records', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'Brampton', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const source = getSource('brampton-hub');
+        const bramptonRecord = record({
+            landingPage: 'https://geohub.brampton.ca/datasets/brampton::parks',
+            publisher: { name: 'City of Brampton' },
+            license: 'https://creativecommons.org/licenses/by/4.0'
+        });
+        const allowed = await adapter.enrichRecord(bramptonRecord, source, { fetchJson });
+        expect(allowed.status).toBe('included');
+        expect(allowed.value.places[0].placeId).toBe('sgc-csd-3521010');
+        expect(allowed.value.source.licenseUrl).toBe('https://creativecommons.org/licenses/by/4.0/');
+
+        const missing = await adapter.enrichRecord({ ...bramptonRecord, license: null }, source, { fetchJson });
+        expect(missing).toEqual({ status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2' });
+
+        const restricted = await adapter.enrichRecord({
+            ...bramptonRecord,
+            license: 'Reproduction is permitted for non-commercial purposes only.'
+        }, source, { fetchJson });
+        expect(restricted).toEqual({ status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2' });
+    });
+
+    test('uses recognized Peel licences and keeps regional third-party records non-authoritative', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'RegionOfPeel', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
+        const source = getSource('peel-hub');
+        const peelRecord = record({
+            landingPage: 'https://data.peelregion.ca/datasets/RegionofPeel::roads',
+            publisher: { name: 'Region of Peel - Corporate Services' },
+            license: 'https://data.peelregion.ca/pages/license'
+        });
+        const regional = await adapter.enrichRecord(peelRecord, source, { fetchJson });
+        expect(regional.status).toBe('included');
+        expect(regional.value.organization.titleEn).toBe('Regional Municipality of Peel');
+        expect(regional.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3521', relationship: 'direct', includesDescendants: true
+        }));
+        expect(regional.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true, licenseUrl: 'https://data.peelregion.ca/pages/license'
+        }));
+
+        const census = await adapter.enrichRecord({
+            ...peelRecord,
+            publisher: { name: 'Statistics Canada' },
+            license: 'Statistics Canada Open License'
+        }, source, { fetchJson });
+        expect(census.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: false,
+            licenseUrl: 'https://www.statcan.gc.ca/en/reference/licence'
+        }));
+
+        const custom = await adapter.enrichRecord({
+            ...peelRecord,
+            publisher: { name: 'Canada Mortgage and Housing Corporation' },
+            license: 'https://www.cmhc-schl.gc.ca/en/data-and-research/cmhc-licence-agreement-use-of-data'
+        }, source, { fetchJson });
+        expect(custom).toEqual({ status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2' });
+
+        const websiteTerms = await adapter.enrichRecord({
+            ...peelRecord,
+            license: 'https://www.peelregion.ca/privacy/terms-of-use.asp'
+        }, source, { fetchJson });
+        expect(websiteTerms).toEqual({ status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2' });
+    });
+
     test('rejects group layers instead of presenting them as downloadable tables', async () => {
         const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
             ? { owner: 'OshawaGIS', type: 'Feature Service' }

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -1,9 +1,11 @@
 const { sources, getSource } = require('../config/catalogSources');
 
 describe('configured municipal catalogue sources', () => {
-    test('syncs municipal mirrors before the authoritative Durham portal', () => {
+    test('syncs city portals before the authoritative portal in each regional cluster', () => {
         expect(sources.map(source => source.id)).toEqual([
-            'toronto-open-data', 'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub'
+            'toronto-open-data',
+            'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
+            'mississauga-hub', 'brampton-hub', 'peel-hub'
         ]);
     });
 
@@ -32,5 +34,37 @@ describe('configured municipal catalogue sources', () => {
         expect(whitby.licenseMode).toBe('record-explicit');
         expect(whitby.restrictedLicensePatterns).toHaveLength(1);
         expect(whitby.licenseRules[0].licensePattern).toBeInstanceOf(RegExp);
+    });
+
+    test('configures the Peel cluster with direct city and descendant regional coverage', () => {
+        expect(getSource('mississauga-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3521005', relationship: 'direct', includesDescendants: false
+        }));
+        expect(getSource('brampton-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3521010', relationship: 'direct', includesDescendants: false
+        }));
+        expect(getSource('peel-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3521', relationship: 'direct', includesDescendants: true
+        }));
+    });
+
+    test('keeps Brampton and Peel fail-closed while allowing Mississauga portal-wide terms', () => {
+        const mississauga = getSource('mississauga-hub');
+        const brampton = getSource('brampton-hub');
+        const peel = getSource('peel-hub');
+
+        expect(mississauga.licenseRules[1]).toEqual(expect.objectContaining({
+            publisher: expect.any(RegExp), license: expect.objectContaining({
+                url: 'https://www.mississauga.ca/file/COM/CityOfMississaugaTermsOfUse.pdf'
+            })
+        }));
+        expect(brampton).toEqual(expect.objectContaining({
+            licenseMode: 'record-explicit', restrictedLicensePatterns: expect.any(Array)
+        }));
+        expect(peel).toEqual(expect.objectContaining({
+            licenseMode: 'record-explicit', restrictedLicensePatterns: expect.any(Array)
+        }));
+        expect(brampton.licenseRules.some(rule => rule.license.url === 'https://creativecommons.org/licenses/by/4.0/')).toBe(true);
+        expect(peel.licenseRules.some(rule => rule.license.url === 'https://data.peelregion.ca/pages/license')).toBe(true);
     });
 });

--- a/server/__tests__/opsApi.test.js
+++ b/server/__tests__/opsApi.test.js
@@ -58,6 +58,24 @@ describe('ops API', () => {
         expect(res.body.data.ok).toBe(true);
     });
 
+    it('keeps the newest source success across legacy and current run kinds', async () => {
+        const now = new Date();
+        const legacy = new Date(Date.now() - 72 * 3600 * 1000).toISOString();
+        catalogReadQueries.getJobHealth.mockResolvedValue({
+            syncRows: [
+                { kind: 'source', source_id: 'oshawa-hub', last_ok_at: now.toISOString() },
+                { kind: 'municipal', source_id: 'oshawa-hub', last_ok_at: legacy }
+            ],
+            evictLastOkAt: null
+        });
+
+        const res = await request(app).get('/api/v1/ops');
+        expect(res.status).toBe(200);
+        expect(res.body.data.jobs['source:oshawa-hub']).toEqual({
+            last_ok_at: now.toISOString(), status: 'ok'
+        });
+    });
+
     it('reports expected map skips but alarms on a stale map lease', async () => {
         const now = new Date();
         catalogReadQueries.getJobHealth.mockResolvedValue({

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -52,6 +52,44 @@ describe('Statistics Canada SGC place normalization', () => {
         }
     });
 
+    test('features Peel and all three lower-tier municipalities with curated viewports', () => {
+        const rows = [
+            ['3521', 'Peel'],
+            ['3521005', 'Mississauga'],
+            ['3521010', 'Brampton'],
+            ['3521024', 'Caledon']
+        ];
+        const en = [
+            { Level: '2', Code: '35', 'Class title': 'Ontario' },
+            ...rows.map(([Code, name]) => ({
+                Level: Code.length === 4 ? '3' : '4', Code, 'Class title': name
+            }))
+        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
+        const result = normalize(en, fr);
+        const peel = result.places.find(place => place.id === 'sgc-cd-3521');
+        const mississauga = result.places.find(place => place.id === 'sgc-csd-3521005');
+        const brampton = result.places.find(place => place.id === 'sgc-csd-3521010');
+        const caledon = result.places.find(place => place.id === 'sgc-csd-3521024');
+
+        expect(peel).toEqual(expect.objectContaining({
+            slug: 'peel-on', kind: 'region', parentId: 'ca-on', featured: true,
+            typeEn: 'Regional municipality', latitude: 43.75, longitude: -79.78, defaultZoom: 9
+        }));
+        expect(mississauga).toEqual(expect.objectContaining({
+            slug: 'mississauga-on', parentId: 'sgc-cd-3521', featured: true,
+            typeEn: 'City', defaultZoom: 10
+        }));
+        expect(brampton).toEqual(expect.objectContaining({
+            slug: 'brampton-on', parentId: 'sgc-cd-3521', featured: true,
+            typeEn: 'City', defaultZoom: 10
+        }));
+        expect(caledon).toEqual(expect.objectContaining({
+            slug: 'caledon-on', parentId: 'sgc-cd-3521', featured: true,
+            typeEn: 'Town', defaultZoom: 9
+        }));
+    });
+
     test('decodes CSV buffers and produces URL-safe accents', () => {
         const parsed = rowsFrom(Buffer.from('Level,Code,Class title\n2,35,Ontario\n'), 'utf-8');
         expect(parsed[0].Code).toBe('35');

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -62,6 +62,38 @@ const TORONTO_LICENSE = {
     attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Toronto.'
 };
 
+const MISSISSAUGA_LICENSE = {
+    titleEn: 'City of Mississauga Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Mississauga',
+    url: 'https://www.mississauga.ca/file/COM/CityOfMississaugaTermsOfUse.pdf',
+    attributionEn: 'Contains information made available under the City of Mississauga Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Mississauga.'
+};
+
+const CC_BY_4_LICENSE = {
+    titleEn: 'Creative Commons Attribution 4.0 International',
+    titleFr: 'Creative Commons Attribution 4.0 International',
+    url: 'https://creativecommons.org/licenses/by/4.0/',
+    attributionEn: 'Licensed under Creative Commons Attribution 4.0 International.',
+    attributionFr: 'Sous licence Creative Commons Attribution 4.0 International.'
+};
+
+const STATCAN_LICENSE = {
+    titleEn: 'Statistics Canada Open Licence',
+    titleFr: 'Licence ouverte de Statistique Canada',
+    url: 'https://www.statcan.gc.ca/en/reference/licence',
+    attributionEn: 'Contains information licensed under the Statistics Canada Open Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence ouverte de Statistique Canada.'
+};
+
+const PEEL_LICENSE = {
+    titleEn: 'Open Data Licence for The Regional Municipality of Peel v1.0',
+    titleFr: 'Licence de données ouvertes de la municipalité régionale de Peel v1.0',
+    url: 'https://data.peelregion.ca/pages/license',
+    attributionEn: 'Contains information made available under the Open Data Licence for The Regional Municipality of Peel.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la municipalité régionale de Peel.'
+};
+
 const DURHAM_PUBLISHER = /(regional municipality of durham|region of durham)/i;
 const ONTARIO_PUBLISHER = /(ontario|ministry of natural resources|aviation, forest fire)/i;
 const CONSERVATION_PUBLISHER = /(conservation ontario|central lake ontario)/i;
@@ -80,9 +112,9 @@ const regionalRules = {
     ]
 };
 
-// Daily sync order is intentional. Municipal/syndicating portals run first and
-// the Durham portal runs last, so a shared ArcGIS item keeps the authoritative
-// regional copy of its catalogue metadata while retaining every provenance row.
+// Daily sync order is intentional. Within each regional cluster, municipal
+// portals run before the regional portal so a future shared ArcGIS item keeps
+// the authoritative regional metadata while retaining every provenance row.
 const sources = [{
     id: 'toronto-open-data',
     kind: 'ckan',
@@ -245,6 +277,93 @@ const sources = [{
         },
         { publisher: ONTARIO_PUBLISHER, placeId: 'ca-on', relationship: 'coverage', includesDescendants: true }
     ]
+}, {
+    id: 'mississauga-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Mississauga Open Data',
+    nameFr: 'Données ouvertes de Mississauga',
+    homepageUrl: 'https://data.mississauga.ca/',
+    catalogUrl: 'https://data.mississauga.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data.mississauga.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of mississauga$/i, name: 'City of Mississauga' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of mississauga$/i }],
+    // The portal-wide terms apply to City datasets even when an ArcGIS item
+    // omits its per-record licence. More specific third-party terms win first.
+    licenseRules: [
+        { licensePattern: /statcan\.gc\.ca|statistics canada open licen[cs]e/i, license: STATCAN_LICENSE },
+        { publisher: /^city of mississauga$/i, license: MISSISSAUGA_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /^city of mississauga$/i,
+        placeId: 'sgc-csd-3521005',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'brampton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Brampton GeoHub',
+    nameFr: 'Géoportail de Brampton',
+    homepageUrl: 'https://geohub.brampton.ca/',
+    catalogUrl: 'https://geohub.brampton.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'geohub.brampton.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    licenseMode: 'record-explicit',
+    restrictedLicensePatterns: [/non.?commercial/i, /elections\.on\.ca/i],
+    publisherAliases: [
+        { publisher: /^city of brampton$/i, name: 'City of Brampton' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of brampton$/i }],
+    licenseRules: [
+        { licensePattern: /statcan\.gc\.ca|statistics canada open licen[cs]e/i, license: STATCAN_LICENSE },
+        {
+            licensePattern: /creativecommons\.org\/licenses\/by\/4\.0|creative commons attribution|creative commons by-law/i,
+            license: CC_BY_4_LICENSE
+        }
+    ],
+    placeRules: [{
+        publisher: /^city of brampton$/i,
+        placeId: 'sgc-csd-3521010',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'peel-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Peel Region Data Portal',
+    nameFr: 'Portail de données de la région de Peel',
+    homepageUrl: 'https://data.peelregion.ca/',
+    catalogUrl: 'https://data.peelregion.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data.peelregion.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    licenseMode: 'record-explicit',
+    restrictedLicensePatterns: [/peelregion\.ca\/privacy\/terms-of-use/i],
+    publisherAliases: [
+        { publisher: /regional municipality of peel|region of peel/i, name: 'Regional Municipality of Peel' }
+    ],
+    authoritativePublishers: [{ publisher: /^regional municipality of peel$/i }],
+    licenseRules: [
+        { licensePattern: /statcan\.gc\.ca|statistics canada open licen[cs]e/i, license: STATCAN_LICENSE },
+        {
+            licensePattern: /data\.peelregion\.ca\/pages\/license|open data licence for the regional municipality of peel/i,
+            license: PEEL_LICENSE
+        },
+        { licensePattern: /ontario\.ca\/page\/open-government-licence/i, license: ONTARIO_LICENSE }
+    ],
+    placeRules: [{
+        placeId: 'sgc-cd-3521',
+        relationship: 'direct',
+        includesDescendants: true
+    }]
 }];
 
 function getSource(id) {
@@ -261,5 +380,9 @@ module.exports = {
     WHITBY_LICENSE,
     CLOCA_LICENSE,
     ONTARIO_LICENSE,
-    TORONTO_LICENSE
+    TORONTO_LICENSE,
+    MISSISSAUGA_LICENSE,
+    CC_BY_4_LICENSE,
+    STATCAN_LICENSE,
+    PEEL_LICENSE
 };

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -20,9 +20,13 @@ const FEATURED_PLACE_IDS = new Set([
     'sgc-csd-3518001',
     'sgc-csd-3518020',
     'sgc-csd-3518029',
-    'sgc-csd-3518009'
+    'sgc-csd-3518009',
+    'sgc-cd-3521',
+    'sgc-csd-3521005',
+    'sgc-csd-3521010',
+    'sgc-csd-3521024'
 ]);
-const DURHAM_TYPES = {
+const MUNICIPAL_TYPES = {
     '3518005': ['Town', 'Ville'],
     '3518039': ['Township', 'Canton'],
     '3518017': ['Municipality', 'Municipalité'],
@@ -30,7 +34,19 @@ const DURHAM_TYPES = {
     '3518001': ['City', 'Ville'],
     '3518020': ['Township', 'Canton'],
     '3518029': ['Township', 'Canton'],
-    '3518009': ['Town', 'Ville']
+    '3518009': ['Town', 'Ville'],
+    '3521005': ['City', 'Ville'],
+    '3521010': ['City', 'Ville'],
+    '3521024': ['Town', 'Ville']
+};
+const PLACE_VIEWPORTS = {
+    '3518': [44.0569, -78.8570, 9],
+    '3518013': [43.8971, -78.8658, 11],
+    '3520': [43.6532, -79.3832, 10],
+    '3521': [43.7500, -79.7800, 9],
+    '3521005': [43.5890, -79.6440, 10],
+    '3521010': [43.7315, -79.7624, 10],
+    '3521024': [43.8668, -79.8670, 9]
 };
 
 function slugify(value) {
@@ -106,15 +122,20 @@ function normalize(enRows, frRows) {
             typeEn = 'Regional municipality';
             typeFr = 'Municipalité régionale';
         }
-        if (DURHAM_TYPES[code]) [typeEn, typeFr] = DURHAM_TYPES[code];
+        if (code === '3521') {
+            typeEn = 'Regional municipality';
+            typeFr = 'Municipalité régionale';
+        }
+        if (MUNICIPAL_TYPES[code]) [typeEn, typeFr] = MUNICIPAL_TYPES[code];
         if (usedSlugs.has(slug)) slug += '-' + code;
         usedSlugs.add(slug);
+        const viewport = PLACE_VIEWPORTS[code] || [];
         places.push({
             id, slug, kind, nameEn, nameFr, typeEn, typeFr, parentId,
             featured: FEATURED_PLACE_IDS.has(id),
-            latitude: code === '3520' ? 43.6532 : null,
-            longitude: code === '3520' ? -79.3832 : null,
-            defaultZoom: code === '3520' ? 10 : null
+            latitude: viewport[0] ?? null,
+            longitude: viewport[1] ?? null,
+            defaultZoom: viewport[2] ?? null
         });
         identifiers.push({ placeId: id, scheme, vintage: '2021', value: code });
     }

--- a/server/services/catalogService.js
+++ b/server/services/catalogService.js
@@ -397,7 +397,14 @@ const opsStatus = async () => {
     const lastOkByJob = {};
     for (const row of health.syncRows) {
         const name = ['municipal', 'source'].includes(row.kind) && row.source_id ? 'source:' + row.source_id : row.kind;
-        lastOkByJob[name] = row.last_ok_at;
+        // `municipal` was renamed to `source`. Both kinds can exist for the
+        // same source in production history, so keep the newest row instead of
+        // depending on PostgreSQL's unspecified GROUP BY result order.
+        const current = lastOkByJob[name];
+        if (current == null || (row.last_ok_at != null &&
+            new Date(row.last_ok_at).getTime() > new Date(current).getTime())) {
+            lastOkByJob[name] = row.last_ok_at;
+        }
         if (name.startsWith('source:')) JOB_MAX_AGE_HOURS[name] = 48;
     }
     lastOkByJob.evict = health.evictLastOkAt;

--- a/server/sql/migrations/010_featured_peel_places.sql
+++ b/server/sql/migrations/010_featured_peel_places.sql
@@ -1,0 +1,49 @@
+-- Curated place discovery for the Peel Region launch. The complete SGC place
+-- hierarchy already exists; this migration makes the region and its three
+-- lower-tier municipalities first-class browse destinations.
+
+UPDATE places
+SET featured = true,
+    updated_at = now()
+WHERE id IN (
+    'sgc-cd-3521',
+    'sgc-csd-3521005',
+    'sgc-csd-3521010',
+    'sgc-csd-3521024'
+);
+
+UPDATE places
+SET type_en = 'Regional municipality',
+    type_fr = 'Municipalité régionale',
+    latitude = 43.7500,
+    longitude = -79.7800,
+    default_zoom = 9,
+    updated_at = now()
+WHERE id = 'sgc-cd-3521';
+
+UPDATE places
+SET type_en = 'City',
+    type_fr = 'Ville',
+    latitude = 43.5890,
+    longitude = -79.6440,
+    default_zoom = 10,
+    updated_at = now()
+WHERE id = 'sgc-csd-3521005';
+
+UPDATE places
+SET type_en = 'City',
+    type_fr = 'Ville',
+    latitude = 43.7315,
+    longitude = -79.7624,
+    default_zoom = 10,
+    updated_at = now()
+WHERE id = 'sgc-csd-3521010';
+
+UPDATE places
+SET type_en = 'Town',
+    type_fr = 'Ville',
+    latitude = 43.8668,
+    longitude = -79.8670,
+    default_zoom = 9,
+    updated_at = now()
+WHERE id = 'sgc-csd-3521024';


### PR DESCRIPTION
## What & why

Adds the Peel Region city cluster so users can browse official open data for Mississauga, Brampton, Peel Region, and Caledon alongside the existing Durham and Toronto coverage.

- Adds official ArcGIS Hub sources for Mississauga, Brampton, and Peel with conservative, fail-closed licence policies.
- Adds featured place records and curated map viewports for Peel Region, Mississauga, Brampton, and Caledon. Caledon correctly inherits regional Peel coverage.
- Fixes `/api/v1/ops` so older legacy `municipal` sync rows cannot mask newer successful `source` runs.
- Adds migration `010_featured_peel_places.sql`, source-policy/adapter/place/ops tests, and deployment smoke checks.

Pre-release source dry runs:

- Mississauga: 321 discovered, 290 included, 116 mappable, 0 failed.
- Brampton: 615 discovered, 472 included, 387 mappable, 0 failed.
- Peel: 154 discovered, 139 included, 106 mappable, 0 failed.
- Combined: 901 loadable datasets and 609 map-capable resources.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

- Server validation: 333 passing tests including the isolated PostGIS spatial integration test.
- Client validation: 91 passing tests.
- Migration 010 is metadata-only and idempotently upserts the four featured Peel-area places.
- No new user-facing copy was required.