### PR TITLE
Document Search Console cron activation

### DIFF
--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -165,6 +165,33 @@ configured vintage changes). The ingest worker is the systemd service from step
 4, not cron. The map worker is also a systemd service; `maps:drain` is useful for
 an initial source launch or controlled rebuild.
 
+The two Search Console entries are intentionally commented out in the generic
+cron template. Before enabling them, create a Google Desktop OAuth client owned
+by the site operator, enable the Search Console API, and set the OAuth app to a
+durable publishing status. External apps left in Testing receive seven-day
+refresh tokens, which are not suitable for unattended cron jobs. Run the
+authorization flow on an operator workstation so its loopback callback can open
+in the same browser session, then copy only the resulting mode-0600 credential
+file to the server path configured by `GSC_OAUTH_PATH`:
+
+```bash
+# On the operator workstation:
+cd server
+node scripts/authorize-search-console.js \
+  --client-secret /private/path/desktop-oauth-client.json \
+  --output /private/path/canquery-gsc-oauth.json
+
+# Securely copy that output to GSC_OAUTH_PATH on the server, then run there:
+sudo -u canquery npm run gsc:sync --prefix /home/canquery/canquery/server -- --days=90
+sudo -u canquery npm run gsc:report --prefix /home/canquery/canquery/server
+```
+
+The client requests only `webmasters.readonly`. The first sync imports 90
+finalized Pacific-time days; later runs replace a seven-day overlap. Serve the
+file configured by `GSC_REPORT_PATH` only through an authenticated, noindex
+operator route. Once the initial import and protected report are verified,
+uncomment the 06:15 UTC sync and 06:30 UTC report entries.
+
 Incremental sync advances its persisted checkpoint only after a complete
 overlap-window traversal. Reaching its safety page cap records an incomplete run
 and does not advance that checkpoint. A successful unlimited full sync also sweeps

--- a/deploy/canquery.cron.d
+++ b/deploy/canquery.cron.d
@@ -20,3 +20,9 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # Rebuild the Top 100 leaderboard from the latest analytics snapshot
 # (ingests + pins each dataset's representative resource; cheap once warmed)
 15 5 * * * root /usr/local/sbin/canquery-run-job.sh seed-top100
+
+# Optional private Search Console reporting. Configure GSC_OAUTH_PATH,
+# GSC_SITE_URL, and GSC_REPORT_PATH, complete a durable OAuth grant, run the
+# first 90-day import, then uncomment both entries.
+# 15 6 * * * root /usr/local/sbin/canquery-run-job.sh sync-search-console
+# 30 6 * * * root /usr/local/sbin/canquery-run-job.sh build-search-growth-report


### PR DESCRIPTION
## What & why

Documents the production-tested Search Console scheduling workflow. The generic cron template now includes disabled 06:15 UTC sync and 06:30 UTC report examples, and the deployment guide explains durable Desktop OAuth, the first 90-day import, seven-day overlap behavior, and authenticated/noindex report exposure.

The entries remain commented by default so deployments without private Search Console credentials do not generate failing jobs.

## Checklist

- [x] `server`: not required (documentation/deployment-template-only change)
- [x] `client`: not required (documentation/deployment-template-only change)
- [x] Added/updated validation for the changed behavior: filenames and cron fields checked; `git diff --check` passed
- [x] No user-facing application strings changed
- [x] No secrets, credentials, or production-specific details added

## Notes

Production has already validated both wrapper commands with a durable read-only OAuth token. The first import stored 90 days, and a subsequent seven-day overlap sync completed successfully.