### PR TITLE
Add Ottawa open data coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ versioned Statistics Canada SGC hierarchy powers place-first discovery, and
 spatial resources can be explored through bounded maps before their CSV snapshot
 is loaded. Toronto's official CKAN catalogue is included as one canonical city,
 with its GeoJSON DataStore layers rebuilt into a local PostGIS viewport index.
-The featured local directory also covers Durham Region
-and all eight lower-tier municipalities, with direct feeds from Durham, Ajax,
+Ottawa's official ArcGIS catalogue is included as a second standalone city, with
+the City portal-wide licence and explicit Ottawa Police licensing preserved, plus
+live maps served through bounded upstream viewports. The featured local directory
+also covers Durham Region and all eight lower-tier municipalities, with direct
+feeds from Durham, Ajax,
 Oshawa, Pickering and the explicitly open-licensed subset of Whitby.
 Clarington is represented through Durham’s regional coverage only: its current
 public web-map terms are personal/non-commercial, so no direct adapter is enabled.
@@ -56,6 +59,7 @@ npm install
 npm run migrate               # idempotent, applies sql/migrations/*.sql
 node scripts/catalog-sync.js --limit 200   # small real harvest (~2 min, polite)
 npm run sync:places                       # Statistics Canada SGC hierarchy
+npm run sync:source -- --source=ottawa-hub --dry-run
 npm run sync:source -- --source=durham-hub --dry-run
 npm run sync:source -- --source=peel-hub --dry-run
 npm run sync:municipal                    # sync every enabled local source
@@ -156,7 +160,7 @@ be excluded from backups; the queue reindexes missing feature data after restore
 
 The SPA (`client/`) starts with a search plus an optional remembered place
 (All Canada remains the default). Its grouped selector shows featured regions,
-their municipalities, and standalone featured cities such as Toronto;
+their municipalities, and standalone featured cities such as Ottawa and Toronto;
 search on `/places` still reaches the complete Canadian SGC hierarchy. Place
 pages combine directly local datasets with records whose parent jurisdiction
 explicitly covers that place, and label regional-only coverage instead of

--- a/client/src/components/PlaceSelect.test.jsx
+++ b/client/src/components/PlaceSelect.test.jsx
@@ -11,12 +11,14 @@ describe('PlaceSelect', () => {
       { id: 'ca-on-oshawa', slug: 'oshawa-on', kind: 'municipality', name: { en: 'Oshawa' }, parent: { id: 'ca-on-durham' }, dataset_count: 10 },
       { id: 'sgc-cd-3521', slug: 'peel-on', kind: 'region', name: { en: 'Peel' }, dataset_count: 901 },
       { id: 'sgc-csd-3521005', slug: 'mississauga-on', kind: 'municipality', name: { en: 'Mississauga' }, parent: { id: 'sgc-cd-3521' }, dataset_count: 429 },
+      { id: 'sgc-cd-3506', slug: 'ottawa-on', kind: 'municipality', name: { en: 'Ottawa' }, parent: { id: 'ca-on' }, dataset_count: 392 },
       { id: 'sgc-cd-3520', slug: 'toronto-on', kind: 'municipality', name: { en: 'Toronto' }, parent: { id: 'ca-on' }, dataset_count: 556 },
     ]} />);
     const select = screen.getByRole('combobox', { name: 'Choose a place' });
     expect(select).toHaveDisplayValue('All Canada');
     fireEvent.change(select, { target: { value: 'oshawa-on' } });
     expect(onChange).toHaveBeenCalledWith('oshawa-on');
+    expect(screen.getByRole('option', { name: /Ottawa/ })).toBeInTheDocument();
     expect([...container.querySelectorAll('optgroup')].map(group => group.label)).toEqual([
       'Featured regions', 'Municipalities in Durham', 'Municipalities in Peel', 'Featured cities', 'Other places'
     ]);

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -42,6 +42,12 @@ beforeEach(() => {
       name: { en: 'Toronto' }, type: { en: 'City' },
       parent: { id: 'ca-on', name: { en: 'Ontario' } },
       dataset_count: 556, direct_dataset_count: 556, mappable_resource_count: 187
+    },
+    {
+      id: 'sgc-cd-3506', slug: 'ottawa-on', kind: 'municipality',
+      name: { en: 'Ottawa' }, type: { en: 'City' },
+      parent: { id: 'ca-on', name: { en: 'Ontario' } },
+      dataset_count: 392, direct_dataset_count: 392, mappable_resource_count: 191
     }
   ] });
 });
@@ -54,6 +60,7 @@ describe('PlacesPage', () => {
     expect(screen.getByRole('heading', { name: 'Municipalities in Durham' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Municipalities in Peel' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Featured cities' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Ottawa/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Toronto/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Clarington/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -234,10 +234,12 @@ curl -s 'https://<your-domain>/api/v1/datasets?q=housing&limit=3'
 curl -s 'https://<your-domain>/api/v1/places?featured=true'
 curl -s 'https://<your-domain>/api/v1/places?q=Oshawa'
 curl -s 'https://<your-domain>/api/v1/places?q=Toronto'
+curl -s 'https://<your-domain>/api/v1/places?q=Ottawa'
 curl -s 'https://<your-domain>/api/v1/places?q=Mississauga'
 curl -s 'https://<your-domain>/api/v1/places?q=Brampton'
 curl -s 'https://<your-domain>/api/v1/sources?place=clarington-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=caledon-on'
+curl -s 'https://<your-domain>/api/v1/sources?place=ottawa-on'
 # UI: search by place, open a mapped dataset, pan/zoom the live Map tab, then load its table snapshot
 ```
 

--- a/server/__tests__/arcgisHubAdapter.test.js
+++ b/server/__tests__/arcgisHubAdapter.test.js
@@ -167,6 +167,46 @@ describe('ArcGIS Hub adapter', () => {
         expect(census.value.source.licenseUrl).toBe('https://www.statcan.gc.ca/en/reference/licence');
     });
 
+    test('applies Ottawa portal terms while preserving explicit Police licensing', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'open.ouvert@ottawa.ca', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const source = getSource('ottawa-hub');
+        const cityRecord = record({
+            landingPage: 'https://open.ottawa.ca/datasets/ottawa::parks',
+            publisher: { name: 'City of Ottawa' },
+            license: null
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+        expect(city.status).toBe('included');
+        expect(city.value.places[0].placeId).toBe('sgc-cd-3506');
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseUrl: expect.stringContaining('/open-data-licence-version-20')
+        }));
+
+        const police = await adapter.enrichRecord({
+            ...cityRecord,
+            title: 'Ottawa Police Service Neighbourhoods',
+            license: 'https://data.ottawapolice.ca/pages/open-data-licence'
+        }, source, { fetchJson });
+        expect(police.value.source).toEqual(expect.objectContaining({
+            licenseTitleEn: 'Open Government Licence – Ottawa Police Service',
+            licenseUrl: 'https://data.ottawapolice.ca/pages/open-data-licence'
+        }));
+
+        const placeholderFetch = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'ExternalPublisher', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const placeholder = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: '{{source}}' }
+        }, source, { fetchJson: placeholderFetch });
+        expect(placeholder).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+    });
+
     test('admits only explicit Brampton CC BY or Statistics Canada records', async () => {
         const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
             ? { owner: 'Brampton', type: 'Feature Service' }

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -3,10 +3,32 @@ const { sources, getSource } = require('../config/catalogSources');
 describe('configured municipal catalogue sources', () => {
     test('syncs city portals before the authoritative portal in each regional cluster', () => {
         expect(sources.map(source => source.id)).toEqual([
-            'toronto-open-data',
+            'toronto-open-data', 'ottawa-hub',
             'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
             'mississauga-hub', 'brampton-hub', 'peel-hub'
         ]);
+    });
+
+    test('configures Ottawa as a canonical city with Police licence precedence', () => {
+        const ottawa = getSource('ottawa-hub');
+        expect(ottawa).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'open.ottawa.ca'
+        }));
+        expect(ottawa.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3506', relationship: 'direct', includesDescendants: false
+        }));
+        expect(ottawa.licenseRules[0]).toEqual(expect.objectContaining({
+            licensePattern: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://data.ottawapolice.ca/pages/open-data-licence'
+            })
+        }));
+        expect(ottawa.licenseRules[1]).toEqual(expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: expect.stringContaining('/open-data-licence-version-20')
+            })
+        }));
     });
 
     test('configures Toronto as an authoritative CKAN city source', () => {

--- a/server/__tests__/opsApi.test.js
+++ b/server/__tests__/opsApi.test.js
@@ -55,6 +55,7 @@ describe('ops API', () => {
         expect(res.status).toBe(200);
         expect(res.body.data.jobs.full.status).toBe('pending');
         expect(res.body.data.jobs.evict.status).toBe('pending');
+        expect(res.body.data.jobs['source:ottawa-hub'].status).toBe('pending');
         expect(res.body.data.ok).toBe(true);
     });
 

--- a/server/__tests__/seoApi.test.js
+++ b/server/__tests__/seoApi.test.js
@@ -114,11 +114,13 @@ describe('dataset sitemap chunk', () => {
 describe('place sitemap', () => {
     it('emits only place rows supplied by the active-dataset query', async () => {
         catalogRead.listPlaceSitemap.mockResolvedValue([
-            { slug: 'oshawa-on', metadata_modified: '2026-08-01T00:00:00Z' }
+            { slug: 'oshawa-on', metadata_modified: '2026-08-01T00:00:00Z' },
+            { slug: 'ottawa-on', metadata_modified: '2026-08-23T00:00:00Z' }
         ]);
         const res = await request(app).get('/sitemap-places.xml');
         expect(res.status).toBe(200);
         expect(res.text).toContain('<loc>https://canquery.com/places/oshawa-on</loc>');
+        expect(res.text).toContain('<loc>https://canquery.com/places/ottawa-on</loc>');
         expect(res.text).toContain('<lastmod>2026-08-01T00:00:00.000Z</lastmod>');
     });
 });

--- a/server/__tests__/seoMeta.test.js
+++ b/server/__tests__/seoMeta.test.js
@@ -122,12 +122,12 @@ describe('seoMeta - site + static meta', () => {
 
     it('builds indexable metadata for place pages', () => {
         const meta = seo.placeMeta({
-            id: 'ca-on-oshawa', slug: 'oshawa-on', name_en: 'Oshawa',
-            type_en: 'City', latitude: 43.897, longitude: -78.866
+            id: 'sgc-cd-3506', slug: 'ottawa-on', name_en: 'Ottawa',
+            type_en: 'City', latitude: 45.4215, longitude: -75.6972
         });
-        expect(meta.canonical).toBe('https://canquery.com/places/oshawa-on');
+        expect(meta.canonical).toBe('https://canquery.com/places/ottawa-on');
         expect(meta.jsonLd[0]['@type']).toBe('AdministrativeArea');
-        expect(meta.jsonLd[0].geo.latitude).toBeCloseTo(43.897);
+        expect(meta.jsonLd[0].geo.latitude).toBeCloseTo(45.4215);
     });
 
     it('static sections get a title and a clean canonical', () => {

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -46,4 +46,37 @@ spatialDescribe('PostGIS viewport integration', () => {
         expect(Math.min(...coordinates.filter(value => value < 0))).toBeGreaterThanOrEqual(-79.800001);
         expect(Math.max(...coordinates.filter(value => value < 0))).toBeLessThanOrEqual(-79.199999);
     });
+
+    test('migrations expose one canonical Ottawa city with durable aliases', async () => {
+        const place = await client.query(`
+            SELECT id, slug, kind, type_en, type_fr, parent_id, featured,
+                   latitude, longitude, default_zoom
+            FROM places WHERE id = 'sgc-cd-3506'
+        `);
+        expect(place.rows).toEqual([expect.objectContaining({
+            id: 'sgc-cd-3506', slug: 'ottawa-on', kind: 'municipality',
+            type_en: 'City', type_fr: 'Ville', parent_id: 'ca-on', featured: true,
+            latitude: 45.4215, longitude: -75.6972, default_zoom: 9
+        })]);
+
+        const identifiers = await client.query(`
+            SELECT scheme, value FROM place_identifiers
+            WHERE place_id = 'sgc-cd-3506' ORDER BY scheme
+        `);
+        expect(identifiers.rows).toEqual([
+            { scheme: 'sgc-cd', value: '3506' },
+            { scheme: 'sgc-csd', value: '3506008' }
+        ]);
+
+        const aliases = await client.query(`
+            SELECT slug FROM place_aliases
+            WHERE place_id = 'sgc-cd-3506' ORDER BY slug
+        `);
+        expect(aliases.rows).toEqual([
+            { slug: 'ottawa-on-3506008' },
+            { slug: 'sgc-csd-3506008' }
+        ]);
+        const duplicate = await client.query("SELECT 1 FROM places WHERE id = 'sgc-csd-3506008'");
+        expect(duplicate.rowCount).toBe(0);
+    });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -96,6 +96,26 @@ describe('Statistics Canada SGC place normalization', () => {
         expect(slugify('Montréal')).toBe('montreal');
     });
 
+    test('merges Ottawa census-division and subdivision identities into one city', () => {
+        const en = [
+            { Level: '2', Code: '35', 'Class title': 'Ontario' },
+            { Level: '3', Code: '3506', 'Class title': 'Ottawa' },
+            { Level: '4', Code: '3506008', 'Class title': 'Ottawa' }
+        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
+        const result = normalize(en, fr);
+        const ottawa = result.places.filter(place => place.nameEn === 'Ottawa');
+        expect(ottawa).toEqual([expect.objectContaining({
+            id: 'sgc-cd-3506', slug: 'ottawa-on', kind: 'municipality',
+            parentId: 'ca-on', typeEn: 'City', featured: true,
+            latitude: 45.4215, longitude: -75.6972, defaultZoom: 9
+        })]);
+        expect(result.identifiers.filter(item => item.placeId === 'sgc-cd-3506')).toEqual([
+            expect.objectContaining({ scheme: 'sgc-cd', value: '3506' }),
+            expect.objectContaining({ scheme: 'sgc-csd', value: '3506008' })
+        ]);
+    });
+
     test('merges Toronto census-division and subdivision identities into one city', () => {
         const en = [
             { Level: '2', Code: '35', 'Class title': 'Ontario' },

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -62,6 +62,22 @@ const TORONTO_LICENSE = {
     attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Toronto.'
 };
 
+const OTTAWA_LICENSE = {
+    titleEn: 'Open Government Licence – City of Ottawa',
+    titleFr: 'Licence du gouvernement ouvert – Ville d’Ottawa',
+    url: 'https://ottawa.ca/en/city-hall/open-transparent-and-accountable-government/open-data/open-data-licence-version-20',
+    attributionEn: 'Contains information licensed under the Open Government Licence – City of Ottawa.',
+    attributionFr: 'Contient de l’information visée par la Licence du gouvernement ouvert – Ville d’Ottawa.'
+};
+
+const OTTAWA_POLICE_LICENSE = {
+    titleEn: 'Open Government Licence – Ottawa Police Service',
+    titleFr: 'Licence du gouvernement ouvert – Service de police d’Ottawa',
+    url: 'https://data.ottawapolice.ca/pages/open-data-licence',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Ottawa Police Service.',
+    attributionFr: 'Contient de l’information visée par la Licence du gouvernement ouvert – Service de police d’Ottawa.'
+};
+
 const MISSISSAUGA_LICENSE = {
     titleEn: 'City of Mississauga Open Data Terms of Use',
     titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Mississauga',
@@ -132,6 +148,36 @@ const sources = [{
     defaultLicenseUrl: TORONTO_LICENSE.url,
     defaultAttributionEn: TORONTO_LICENSE.attributionEn,
     defaultAttributionFr: TORONTO_LICENSE.attributionFr
+}, {
+    id: 'ottawa-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Ottawa Open Data',
+    nameFr: 'Données ouvertes de la Ville d’Ottawa',
+    homepageUrl: 'https://open.ottawa.ca/',
+    catalogUrl: 'https://open.ottawa.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open.ottawa.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of ottawa$/i, name: 'City of Ottawa' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of ottawa$/i }],
+    // The City licence applies portal-wide. Explicit Ottawa Police licence
+    // evidence wins first so those records retain their own attribution.
+    licenseRules: [
+        {
+            licensePattern: /data\.ottawapolice\.ca\/pages\/open-data-licence/i,
+            license: OTTAWA_POLICE_LICENSE
+        },
+        { publisher: /^city of ottawa$/i, license: OTTAWA_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /^city of ottawa$/i,
+        placeId: 'sgc-cd-3506',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
 }, {
     id: 'oshawa-hub',
     kind: 'arcgis-hub',
@@ -381,6 +427,8 @@ module.exports = {
     CLOCA_LICENSE,
     ONTARIO_LICENSE,
     TORONTO_LICENSE,
+    OTTAWA_LICENSE,
+    OTTAWA_POLICE_LICENSE,
     MISSISSAUGA_LICENSE,
     CC_BY_4_LICENSE,
     STATCAN_LICENSE,

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -11,6 +11,7 @@ const PROVINCES = {
 };
 const TERRITORIES = new Set(['60', '61', '62']);
 const FEATURED_PLACE_IDS = new Set([
+    'sgc-cd-3506',
     'sgc-cd-3520',
     'ca-on-durham',
     'sgc-csd-3518005',
@@ -40,6 +41,7 @@ const MUNICIPAL_TYPES = {
     '3521024': ['Town', 'Ville']
 };
 const PLACE_VIEWPORTS = {
+    '3506': [45.4215, -75.6972, 9],
     '3518': [44.0569, -78.8570, 9],
     '3518013': [43.8971, -78.8658, 11],
     '3520': [43.6532, -79.3832, 10],
@@ -78,11 +80,12 @@ function normalize(enRows, frRows) {
         const fr = frByCode.get(code) || {};
         const nameEn = String(row['Class title'] || '').trim();
         const nameFr = String(fr['Titres de classes'] || nameEn).trim();
-        // Toronto's census division and census subdivision describe the same
-        // single-tier city. Keep the CSD identifier, but do not create a second
-        // user-facing place.
-        if (level === 4 && code === '3520005') {
-            identifiers.push({ placeId: 'sgc-cd-3520', scheme: 'sgc-csd', vintage: '2021', value: code });
+        // Ottawa and Toronto are each simultaneously a census division and a
+        // census subdivision. Keep both official identifiers while exposing
+        // one canonical single-tier city for each.
+        if (level === 4 && ['3506008', '3520005'].includes(code)) {
+            const placeId = code === '3506008' ? 'sgc-cd-3506' : 'sgc-cd-3520';
+            identifiers.push({ placeId, scheme: 'sgc-csd', vintage: '2021', value: code });
             continue;
         }
         let id, kind, parentId, scheme, typeEn, typeFr, baseSlug;
@@ -96,11 +99,11 @@ function normalize(enRows, frRows) {
             baseSlug = slugify(nameEn);
         } else if (level === 3) {
             id = code === '3518' ? 'ca-on-durham' : 'sgc-cd-' + code;
-            kind = code === '3520' ? 'municipality' : 'region';
+            kind = ['3506', '3520'].includes(code) ? 'municipality' : 'region';
             parentId = code.slice(0, 2) === '35' ? 'ca-on' : 'sgc-pr-' + code.slice(0, 2);
             scheme = 'sgc-cd';
-            typeEn = code === '3520' ? 'City' : 'Census division';
-            typeFr = code === '3520' ? 'Ville' : 'Division de recensement';
+            typeEn = ['3506', '3520'].includes(code) ? 'City' : 'Census division';
+            typeFr = ['3506', '3520'].includes(code) ? 'Ville' : 'Division de recensement';
             baseSlug = slugify(nameEn) + '-' + provinceAbbr;
         } else {
             id = code === '3518013' ? 'ca-on-oshawa' : 'sgc-csd-' + code;
@@ -116,6 +119,7 @@ function normalize(enRows, frRows) {
         if (code === '35') baseSlug = 'ontario';
         let slug = baseSlug;
         if (code === '3518') slug = 'durham-on';
+        if (code === '3506') slug = 'ottawa-on';
         if (code === '3520') slug = 'toronto-on';
         if (code === '3518013') slug = 'oshawa-on';
         if (code === '3518') {

--- a/server/sql/migrations/012_ottawa_place.sql
+++ b/server/sql/migrations/012_ottawa_place.sql
@@ -1,0 +1,62 @@
+-- Ottawa is simultaneously a Statistics Canada census division and a census
+-- subdivision. CanQuery exposes one stable city entry and keeps both official
+-- identifiers, plus the former subdivision URL/id, as aliases.
+
+UPDATE places
+SET slug = 'ottawa-on-3506008', updated_at = now()
+WHERE id = 'sgc-csd-3506008' AND slug = 'ottawa-on';
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-3506', 'ottawa-on', 'municipality', 'Ottawa', 'Ottawa',
+    'City', 'Ville', 'ca-on', 45.4215, -75.6972, 9, true, true
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+-- Merge links created by an earlier SGC import before deleting the duplicate
+-- subdivision place. Insert first so overlapping links remain harmless.
+INSERT INTO dataset_places (
+    source_id, dataset_id, place_id, relationship,
+    includes_descendants, assignment_method
+)
+SELECT source_id, dataset_id, 'sgc-cd-3506', relationship,
+       includes_descendants, assignment_method
+FROM dataset_places
+WHERE place_id = 'sgc-csd-3506008'
+ON CONFLICT (source_id, dataset_id, place_id, relationship) DO UPDATE SET
+    includes_descendants = EXCLUDED.includes_descendants,
+    assignment_method = EXCLUDED.assignment_method;
+
+DELETE FROM dataset_places WHERE place_id = 'sgc-csd-3506008';
+UPDATE organizations SET place_id = 'sgc-cd-3506'
+WHERE place_id = 'sgc-csd-3506008';
+DELETE FROM place_identifiers WHERE place_id = 'sgc-csd-3506008';
+
+INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+VALUES
+    ('sgc-cd-3506', 'sgc-cd', '2021', '3506'),
+    ('sgc-cd-3506', 'sgc-csd', '2021', '3506008')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;
+
+INSERT INTO place_aliases (slug, place_id)
+VALUES
+    ('ottawa-on-3506008', 'sgc-cd-3506'),
+    ('sgc-csd-3506008', 'sgc-cd-3506')
+ON CONFLICT (slug) DO UPDATE SET place_id = EXCLUDED.place_id;
+
+DELETE FROM places WHERE id = 'sgc-csd-3506008';


### PR DESCRIPTION
## Summary
- add the official City of Ottawa ArcGIS Hub as a fail-closed source
- preserve the City portal-wide licence and the 12 explicitly licensed Ottawa Police records separately
- canonicalize Ottawa census division/subdivision identities into one featured city
- cover the generic place UI, SEO, operations, deployment docs, and migration path with regression tests

## Validation
- live Ottawa dry-run: 685 discovered, 392 included, 293 excluded, 0 failed, 191 mappable
- server: 51 suites / 350 default-run tests passed
- client: 25 files / 106 tests passed
- server and client lint passed
- production Vite build passed
- migrations 001-012 and 2 PostGIS integration tests passed on postgis/postgis:16-3.5