### PR TITLE
Add Montréal open data and projected GeoJSON maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ is loaded. Toronto's official CKAN catalogue is included as one canonical city,
 with its GeoJSON DataStore layers rebuilt into a local PostGIS viewport index.
 Ottawa's official ArcGIS catalogue is included as a second standalone city, with
 the City portal-wide licence and explicit Ottawa Police licensing preserved, plus
-live maps served through bounded upstream viewports. The featured local directory
+live maps served through bounded upstream viewports. Montréal's official CKAN
+catalogue is included as a French-first standalone city: record-level CC BY 4.0
+and Open Government Licence - Canada terms are preserved, while selected direct
+GeoJSON files are streamed and reprojected into the local PostGIS index. The
+featured local directory
 also covers Durham Region and all eight lower-tier municipalities, with direct
 feeds from Durham, Ajax,
 Oshawa, Pickering and the explicitly open-licensed subset of Whitby.
@@ -59,6 +63,7 @@ npm install
 npm run migrate               # idempotent, applies sql/migrations/*.sql
 node scripts/catalog-sync.js --limit 200   # small real harvest (~2 min, polite)
 npm run sync:places                       # Statistics Canada SGC hierarchy
+npm run sync:source -- --source=montreal-open-data --dry-run
 npm run sync:source -- --source=ottawa-hub --dry-run
 npm run sync:source -- --source=durham-hub --dry-run
 npm run sync:source -- --source=peel-hub --dry-run
@@ -86,6 +91,7 @@ curl 'http://localhost:3100/api/v1/datasets?q=housing&place=oshawa-on&format=CSV
 curl 'http://localhost:3100/api/v1/places?featured=true'
 curl 'http://localhost:3100/api/v1/places?q=Oshawa'
 curl 'http://localhost:3100/api/v1/places?q=Mississauga'
+curl 'http://localhost:3100/api/v1/places?q=Montr%C3%A9al'
 
 # place-filtered sources are authoritative; counts expose total + authoritative
 curl 'http://localhost:3100/api/v1/sources?place=clarington-on'
@@ -129,11 +135,11 @@ expensive profile, aggregation, and export routes have dedicated rate limits.
 |---|---|
 | `scripts/catalog-sync.js` | full harvest: `package_list` → batched `package_show` (chunks of 50, concurrency 2), resumable via `sync_progress`; `--limit N`, `--dry-run` |
 | `scripts/incremental-sync.js` | upserts through a persisted, overlapping `metadata_modified` watermark with deterministic `id` tie ordering; page-cap runs are marked incomplete without advancing it |
-| `scripts/sync-places.js` | imports the EN/FR Statistics Canada SGC hierarchy with stable internal place ids |
+| `scripts/sync-places.js` | imports the Windows-1252 EN/FR Statistics Canada SGC hierarchy with stable internal ids and alias-safe canonical slug repair |
 | `scripts/sync-source.js` | validates or syncs one configured source adapter; `--source`, `--limit`, `--dry-run` |
 | `scripts/sync-municipal-sources.js` | refreshes every enabled non-federal source independently so one failure cannot suppress the others |
 | `scripts/ingest-worker.js` | exclusively owns the queue with a PostgreSQL advisory lock, heartbeats active-job leases, streams files into `store.r_*` via `COPY`, and recovers crash orphans immediately; `--once` for a single drain |
-| `scripts/map-worker.js` | exclusively owns the versioned map queue, streams official CKAN CSV dumps into PostGIS under row/vertex/file/disk budgets, and self-heals excluded map data after restore; `--once` or `--drain` |
+| `scripts/map-worker.js` | exclusively owns the versioned map queue, streams CKAN CSV dumps and direct GeoJSON files into PostGIS, reprojects named EPSG CRSs to WGS84 under row/vertex/file/disk budgets, and self-heals excluded map data after restore; `--once` or `--drain` |
 | `scripts/evict-store.js` | serializes with ingestion, rechecks pins/state under lock, and drops least-recently-accessed tables until under `STORE_BUDGET_GB` |
 | `scripts/seed-top100.js` | rebuilds the **Top 100** leaderboard: ranks the latest analytics snapshot, ingests + pins one latest-period resource per top dataset, upserts `top_downloads`; daily cron, `--dry-run` |
 
@@ -153,14 +159,17 @@ to TEXT per column when a later cast fails.
 
 Local maps have separate defaults: 1,000,000 rows and 10,000,000 vertices per
 resource, a 1 GB download cap, a 20 GB logical map-store budget, and a 30 GB
-filesystem free-space floor. `map_store.features` is a reproducible cache and may
+filesystem free-space floor. Direct GeoJSON supports absent/WGS84, CRS84, and
+named PostGIS EPSG definitions; unsupported or malformed CRS declarations fail
+closed for that resource. `map_store.features` is a reproducible cache and may
 be excluded from backups; the queue reindexes missing feature data after restore.
 
 ## Web UI
 
 The SPA (`client/`) starts with a search plus an optional remembered place
 (All Canada remains the default). Its grouped selector shows featured regions,
-their municipalities, and standalone featured cities such as Ottawa and Toronto;
+their municipalities, and standalone featured cities such as Montréal, Ottawa
+and Toronto;
 search on `/places` still reaches the complete Canadian SGC hierarchy. Place
 pages combine directly local datasets with records whose parent jurisdiction
 explicitly covers that place, and label regional-only coverage instead of
@@ -183,7 +192,8 @@ cd server && npm test && npm run lint
 cd client && npm test && npm run lint && npm run build
 ```
 
-Coverage includes source adapters, place hierarchy and APIs, bounded map
+Coverage includes source adapters, place hierarchy and APIs, streaming direct
+GeoJSON plus projected-CRS map conversion, bounded map
 queries, publisher-specific provenance, the four `/query` modes, filter-grammar injection attempts,
 SSRF/redirect/DNS-pinning checks, bounded caches, spreadsheet-safe streaming CSV
 exports, Excel archive caps, lease recovery, lossless incremental sync, strict

--- a/client/src/components/PlaceSelect.test.jsx
+++ b/client/src/components/PlaceSelect.test.jsx
@@ -13,12 +13,14 @@ describe('PlaceSelect', () => {
       { id: 'sgc-csd-3521005', slug: 'mississauga-on', kind: 'municipality', name: { en: 'Mississauga' }, parent: { id: 'sgc-cd-3521' }, dataset_count: 429 },
       { id: 'sgc-cd-3506', slug: 'ottawa-on', kind: 'municipality', name: { en: 'Ottawa' }, parent: { id: 'ca-on' }, dataset_count: 392 },
       { id: 'sgc-cd-3520', slug: 'toronto-on', kind: 'municipality', name: { en: 'Toronto' }, parent: { id: 'ca-on' }, dataset_count: 556 },
+      { id: 'sgc-csd-2466023', slug: 'montreal-qc', kind: 'municipality', name: { en: 'Montréal' }, parent: { id: 'sgc-cd-2466' }, dataset_count: 405 },
     ]} />);
     const select = screen.getByRole('combobox', { name: 'Choose a place' });
     expect(select).toHaveDisplayValue('All Canada');
     fireEvent.change(select, { target: { value: 'oshawa-on' } });
     expect(onChange).toHaveBeenCalledWith('oshawa-on');
     expect(screen.getByRole('option', { name: /Ottawa/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /Montréal/ })).toBeInTheDocument();
     expect([...container.querySelectorAll('optgroup')].map(group => group.label)).toEqual([
       'Featured regions', 'Municipalities in Durham', 'Municipalities in Peel', 'Featured cities', 'Other places'
     ]);

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -48,6 +48,12 @@ beforeEach(() => {
       name: { en: 'Ottawa' }, type: { en: 'City' },
       parent: { id: 'ca-on', name: { en: 'Ontario' } },
       dataset_count: 392, direct_dataset_count: 392, mappable_resource_count: 191
+    },
+    {
+      id: 'sgc-csd-2466023', slug: 'montreal-qc', kind: 'municipality',
+      name: { en: 'Montréal', fr: 'Montréal' }, type: { en: 'City', fr: 'Ville' },
+      parent: { id: 'sgc-cd-2466', name: { en: 'Montréal', fr: 'Montréal' } },
+      dataset_count: 405, direct_dataset_count: 390, mappable_resource_count: 304
     }
   ] });
 });
@@ -62,6 +68,7 @@ describe('PlacesPage', () => {
     expect(screen.getByRole('heading', { name: 'Featured cities' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Ottawa/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Toronto/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Montréal/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Clarington/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Caledon/ })).toBeInTheDocument();

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -137,7 +137,9 @@ Use `npm run sync:source -- --source=<source-id> --dry-run` before enabling a ne
 source. Adapters retain publisher-specific licences and only publish resources
 they can identify safely. Spatial ArcGIS leaf layers use bounded upstream
 viewports; configured CKAN GeoJSON DataStore resources are queued for a bounded
-local PostGIS index.
+local PostGIS index. Catalogued direct GeoJSON resources use the same queue and
+are streamed, CRS-validated, and reprojected to WGS84 without loading a whole
+file into memory.
 
 ## 6. Cron jobs
 
@@ -235,6 +237,7 @@ curl -s 'https://<your-domain>/api/v1/places?featured=true'
 curl -s 'https://<your-domain>/api/v1/places?q=Oshawa'
 curl -s 'https://<your-domain>/api/v1/places?q=Toronto'
 curl -s 'https://<your-domain>/api/v1/places?q=Ottawa'
+curl -s 'https://<your-domain>/api/v1/places?q=Montr%C3%A9al'
 curl -s 'https://<your-domain>/api/v1/places?q=Mississauga'
 curl -s 'https://<your-domain>/api/v1/places?q=Brampton'
 curl -s 'https://<your-domain>/api/v1/sources?place=clarington-on'

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -3,7 +3,7 @@ const { sources, getSource } = require('../config/catalogSources');
 describe('configured municipal catalogue sources', () => {
     test('syncs city portals before the authoritative portal in each regional cluster', () => {
         expect(sources.map(source => source.id)).toEqual([
-            'toronto-open-data', 'ottawa-hub',
+            'toronto-open-data', 'montreal-open-data', 'ottawa-hub',
             'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
             'mississauga-hub', 'brampton-hub', 'peel-hub'
         ]);
@@ -36,6 +36,27 @@ describe('configured municipal catalogue sources', () => {
             kind: 'ckan', placeId: 'sgc-cd-3520',
             defaultLicenseUrl: 'https://open.toronto.ca/open-data-licence/'
         }));
+    });
+
+    test('configures Montréal as a French-first, record-licensed CKAN source', () => {
+        const montreal = getSource('montreal-open-data');
+        expect(montreal).toEqual(expect.objectContaining({
+            kind: 'ckan', metadataLanguage: 'fr', licenseMode: 'record-explicit',
+            upstreamHost: 'donnees.montreal.ca', directGeoJsonMaps: true
+        }));
+        expect(montreal.licenseRules.map(rule => rule.license.url)).toEqual([
+            'https://creativecommons.org/licenses/by/4.0/',
+            'https://open.canada.ca/en/open-government-licence-canada'
+        ]);
+        expect(montreal.placeRules).toEqual([
+            expect.objectContaining({
+                placeId: 'sgc-csd-2466023', relationship: 'direct',
+                publisher: expect.any(RegExp)
+            }),
+            expect.objectContaining({
+                placeId: 'sgc-csd-2466023', relationship: 'coverage'
+            })
+        ]);
     });
 
     test('covers each direct feed without inventing a Clarington source', () => {

--- a/server/__tests__/ckanSourceAdapter.test.js
+++ b/server/__tests__/ckanSourceAdapter.test.js
@@ -2,6 +2,7 @@ const adapter = require('../services/ckanSourceAdapter');
 const { getSource } = require('../config/catalogSources');
 
 const source = getSource('toronto-open-data');
+const montreal = getSource('montreal-open-data');
 
 function packageRecord(overrides = {}) {
     return {
@@ -76,6 +77,7 @@ describe('generic CKAN source adapter', () => {
         expect(result.value.resources.find(resource => !resource.datastoreActive).url).toBe('https://example.test/wards.csv');
         expect(result.value.mapCandidates).toEqual([expect.objectContaining({
             resourceId: datastore.id, expectedRows: 20, expectedVertices: 80,
+            mode: 'ckan-datastore-csv',
             desiredVersion: expect.stringMatching(/^[a-f0-9]{64}$/)
         })]);
         expect(result.value.places[0]).toEqual(expect.objectContaining({ placeId: 'sgc-cd-3520', relationship: 'direct' }));
@@ -87,6 +89,82 @@ describe('generic CKAN source adapter', () => {
         expect(empty.value.resources).toEqual([]);
         await expect(adapter.enrichRecord(packageRecord({ id: '' }), source)).resolves.toEqual(expect.objectContaining({
             status: 'excluded', reason: 'invalid-package'
+        }));
+    });
+
+    test('does not expand Toronto into direct-file maps without source opt-in', async () => {
+        const result = await adapter.enrichRecord(packageRecord({
+            resources: [{
+                id: 'direct-geojson', name: 'Direct map', format: 'GeoJSON',
+                url: 'https://example.test/direct.geojson'
+            }]
+        }), source);
+        expect(result.value.resources).toHaveLength(1);
+        expect(result.value.mapCandidates).toEqual([]);
+    });
+
+    test('normalizes Montréal as French-first with record-level licences and direct GeoJSON maps', async () => {
+        const record = packageRecord({
+            name: 'arbres-publics',
+            title: 'Arbres publics',
+            notes: 'Inventaire des arbres.',
+            license_id: 'cc-by',
+            license_title: 'Creative Commons Attribution 4.0',
+            license_url: 'http://creativecommons.org/licenses/by/4.0/',
+            organization: {
+                id: 'ville-de-montreal', name: 'ville-de-montreal', title: 'Ville de Montréal'
+            },
+            tags: [{ name: 'environnement' }],
+            resources: [{
+                id: 'geojson-file', name: 'Arbres GeoJSON', format: 'GeoJSON',
+                url: 'https://donnees.montreal.ca/download/arbres.geojson',
+                size: 12345, hash: 'abc123', last_modified: '2026-08-23T12:00:00Z'
+            }]
+        });
+        const result = await adapter.enrichRecord(record, montreal);
+        expect(result.status).toBe('included');
+        expect(result.value.dataset).toEqual(expect.objectContaining({
+            titleEn: null, titleFr: 'Arbres publics', notesEn: null,
+            notesFr: 'Inventaire des arbres.', keywordsEn: [],
+            keywordsFr: ['Transportation', 'environnement']
+        }));
+        expect(result.value.organization).toEqual(expect.objectContaining({
+            titleEn: null, titleFr: 'Ville de Montréal', placeId: 'sgc-csd-2466023'
+        }));
+        expect(result.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseUrl: 'https://creativecommons.org/licenses/by/4.0/'
+        }));
+        expect(result.value.resources[0]).toEqual(expect.objectContaining({
+            nameEn: null, nameFr: 'Arbres GeoJSON', language: 'fr', sizeBytes: 12345
+        }));
+        expect(result.value.places).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-2466023', relationship: 'direct', includesDescendants: false
+        })]);
+        expect(result.value.mapCandidates).toEqual([expect.objectContaining({
+            mode: 'geojson-file', sourceUrl: record.resources[0].url,
+            expectedBytes: 12345, desiredVersion: expect.stringMatching(/^[a-f0-9]{64}$/)
+        })]);
+    });
+
+    test('keeps explicitly licensed third-party Montréal records as non-authoritative coverage', async () => {
+        const record = packageRecord({
+            license_id: 'OGL-Canada-2.0',
+            organization: { id: 'stm', name: 'stm', title: 'Société de transport de Montréal' }
+        });
+        const result = await adapter.enrichRecord(record, montreal);
+        expect(result.status).toBe('included');
+        expect(result.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: false,
+            licenseUrl: 'https://open.canada.ca/en/open-government-licence-canada'
+        }));
+        expect(result.value.places[0]).toEqual(expect.objectContaining({ relationship: 'coverage' }));
+
+        await expect(adapter.enrichRecord(packageRecord({
+            license_id: 'unknown-license',
+            organization: { id: 'third-party', title: 'Third Party' }
+        }), montreal)).resolves.toEqual(expect.objectContaining({
+            status: 'excluded', reason: 'unlicensed'
         }));
     });
 });

--- a/server/__tests__/mapIndexPipeline.test.js
+++ b/server/__tests__/mapIndexPipeline.test.js
@@ -1,12 +1,21 @@
 const { once } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
 const { parse } = require('csv-parse');
 const { csvParseOptions } = require('../services/csvLoad');
 const {
     MapSkipError,
     geometryVertexCount,
     selectPropertyFields,
+    selectGeoJsonPropertyFields,
     stagingTransform,
-    validateCandidate
+    geoJsonStagingTransform,
+    validateCandidate,
+    candidateMode,
+    sourceSridFromCrs,
+    inspectGeoJsonFile,
+    validWgs84Extent
 } = require('../services/mapIndexPipeline');
 
 describe('bounded local-map conversion', () => {
@@ -49,6 +58,87 @@ describe('bounded local-map conversion', () => {
 
         expect(() => validateCandidate({ expectedRows: 11 }, { maxRows: 10, maxVertices: 100 }))
             .toThrow(MapSkipError);
+        expect(() => validateCandidate({ expectedBytes: 101 }, {
+            maxRows: 10, maxVertices: 100, maxFileBytes: 100
+        })).toThrow(MapSkipError);
+    });
+
+    test('keeps legacy candidate mode while validating explicit modes', () => {
+        expect(candidateMode({})).toBe('ckan-datastore-csv');
+        expect(candidateMode({ mode: 'geojson-file' })).toBe('geojson-file');
+        expect(() => candidateMode({ mode: 'remote-url' })).toThrow(MapSkipError);
+    });
+
+    test('recognizes supported named CRSs and rejects unsupported declarations', () => {
+        expect(sourceSridFromCrs({ present: false })).toBe(4326);
+        expect(sourceSridFromCrs({ present: true, isNull: true })).toBe(4326);
+        expect(sourceSridFromCrs({
+            present: true, type: 'name', name: 'urn:ogc:def:crs:OGC:1.3:CRS84'
+        })).toBe(4326);
+        expect(sourceSridFromCrs({
+            present: true, type: 'name', name: 'urn:ogc:def:crs:EPSG::32188'
+        })).toBe(32188);
+        expect(() => sourceSridFromCrs({ present: true, type: 'link', name: 'EPSG:2950' }))
+            .toThrow(MapSkipError);
+    });
+
+    test('inspects a FeatureCollection without assembling its features', async () => {
+        const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'canquery-map-test-'));
+        const projected = path.join(dir, 'projected.geojson');
+        const defaultCrs = path.join(dir, 'default.geojson');
+        try {
+            await fs.promises.writeFile(projected, JSON.stringify({
+                type: 'FeatureCollection',
+                crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2950' } },
+                features: []
+            }));
+            await fs.promises.writeFile(defaultCrs, JSON.stringify({
+                type: 'FeatureCollection', features: []
+            }));
+            await expect(inspectGeoJsonFile(projected)).resolves.toEqual({
+                sourceSrid: 2950, crsName: 'urn:ogc:def:crs:EPSG::2950'
+            });
+            await expect(inspectGeoJsonFile(defaultCrs)).resolves.toEqual({
+                sourceSrid: 4326, crsName: null
+            });
+        } finally {
+            await fs.promises.rm(dir, { recursive: true, force: true });
+        }
+    });
+
+    test('streams Feature objects and keeps only bounded scalar popup fields', async () => {
+        let metadata;
+        const transform = geoJsonStagingTransform({
+            caps: { maxRows: 10, maxVertices: 10 },
+            onMetadata: value => { metadata = value; }
+        });
+        const chunks = [];
+        transform.on('data', chunk => chunks.push(chunk.toString()));
+        transform.write({ key: 0, value: { type: 'Feature', geometry: null, properties: {} } });
+        transform.write({
+            key: 1,
+            value: {
+                type: 'Feature', geometry: { type: 'Point', coordinates: [-73.5, 45.5] },
+                properties: { Name: 'Station', nested: { secret: true }, values: [1, 2], year: 2026 }
+            }
+        });
+        transform.end();
+        await once(transform, 'end');
+        expect(transform.result()).toEqual(expect.objectContaining({
+            rowCount: 2, featureCount: 1, vertexCount: 1, invalidCount: 1,
+            geometryType: 'point'
+        }));
+        expect(metadata.fields.map(field => field.name)).toEqual(['Name', 'year']);
+        expect(chunks.join('')).toContain('Station');
+        expect(chunks.join('')).not.toContain('secret');
+        expect(selectGeoJsonPropertyFields({ payload: {}, Address: 'Main' }).map(field => field.name))
+            .toEqual(['Address']);
+    });
+
+    test('validates transformed WGS84 extents', () => {
+        expect(validWgs84Extent([-74, 45, -73, 46])).toBe(true);
+        expect(validWgs84Extent([277000, 5040000, 300000, 5060000])).toBe(false);
+        expect(validWgs84Extent(null)).toBe(false);
     });
 
     test('accepts CKAN exports that mix CRLF headers with LF records', async () => {

--- a/server/__tests__/mapIndexQueries.test.js
+++ b/server/__tests__/mapIndexQueries.test.js
@@ -34,6 +34,8 @@ describe('versioned map-index queue', () => {
             resource_id: 'r1', claimed_version: 'v1'
         }));
         expect(db.query.mock.calls[1][0]).toContain('FOR UPDATE SKIP LOCKED');
+        expect(db.query.mock.calls[1][0]).toContain("candidate->>'expectedBytes'");
+        expect(db.query.mock.calls[1][0]).toContain('NULLS LAST');
     });
 
     test('terminal and retry transitions are lease and version guarded', async () => {

--- a/server/__tests__/mapWorker.test.js
+++ b/server/__tests__/mapWorker.test.js
@@ -22,7 +22,7 @@ jest.mock('../db/mapIndexQueries', () => ({
 const pool = require('../db/pool');
 const mapQueries = require('../db/mapIndexQueries');
 const { MapSkipError } = require('../services/mapIndexPipeline');
-const { processJob } = require('../scripts/map-worker');
+const { processJob, validateDirectGeoJson } = require('../scripts/map-worker');
 
 const resource = {
     id: 'r1', url: 'https://example.test/r1.csv',
@@ -56,9 +56,37 @@ describe('map worker transitions', () => {
             probeGeometry: async () => { throw new MapSkipError('too many vertices'); }
         });
         expect(mapQueries.finishJob).toHaveBeenCalledWith(
-            pool, job, expect.any(String), 'skipped', {}, 'too many vertices'
+            pool, job, expect.any(String), 'skipped', {}, 'MAP_CAP: too many vertices'
         );
         expect(mapQueries.requeueJob).not.toHaveBeenCalled();
+    });
+
+    test('indexes a catalogued direct GeoJSON without probing DataStore', async () => {
+        const directResource = {
+            id: 'r2', url: 'https://donnees.montreal.ca/r2.geojson', datastore_active: false,
+            raw: {
+                source_id: 'montreal-open-data', upstream_resource_id: 'upstream-r2',
+                original_format: 'GEOJSON'
+            }
+        };
+        const directJob = {
+            ...job, resource_id: 'r2',
+            candidate: { mode: 'geojson-file', sourceUrl: directResource.url }
+        };
+        const probe = jest.fn();
+        const index = jest.fn().mockResolvedValue({ queueStatus: 'ready', featureCount: 1, vertexCount: 1 });
+        await processJob(directJob, '00000000-0000-4000-8000-000000000001', {
+            getResourceById: async () => directResource,
+            probeGeometry: probe,
+            indexMapResource: index,
+            validateDirectGeoJson
+        });
+        expect(probe).not.toHaveBeenCalled();
+        expect(index).toHaveBeenCalled();
+
+        expect(() => validateDirectGeoJson(directResource, {
+            sourceUrl: 'https://attacker.example/map.geojson'
+        })).toThrow(MapSkipError);
     });
 
     test('retries transient failures and marks the third attempt failed', async () => {

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -1,19 +1,25 @@
-const { Client } = require('pg');
+const { Client, Pool } = require('pg');
 const { queryLocalMap } = require('../db/mapIndexQueries');
+const { indexMapResource } = require('../services/mapIndexPipeline');
 
 const databaseUrl = process.env.SPATIAL_TEST_DATABASE_URL;
 const spatialDescribe = databaseUrl ? describe : describe.skip;
 
 spatialDescribe('PostGIS viewport integration', () => {
     let client;
+    let mapPool;
     const suffix = process.pid + '-' + Date.now();
     const orgId = 'spatial-org-' + suffix;
     const datasetId = 'spatial-dataset-' + suffix;
     const resourceId = 'spatial-resource-' + suffix;
+    const projectedOrgId = 'projected-org-' + suffix;
+    const projectedDatasetId = 'projected-dataset-' + suffix;
+    const projectedResourceId = 'projected-resource-' + suffix;
 
     beforeAll(async () => {
         client = new Client({ connectionString: databaseUrl });
         await client.connect();
+        mapPool = new Pool({ connectionString: databaseUrl, max: 2 });
         await client.query("INSERT INTO organizations (id, name, title_en) VALUES ($1,$2,'Spatial test')", [orgId, orgId]);
         await client.query("INSERT INTO datasets (id, name, title_en, org_id) VALUES ($1,$2,'Spatial test',$3)", [datasetId, datasetId, orgId]);
         await client.query("INSERT INTO resources (id, dataset_id, format, url) VALUES ($1,$2,'CSV','https://example.test/map.csv')", [resourceId, datasetId]);
@@ -27,10 +33,14 @@ spatialDescribe('PostGIS viewport integration', () => {
 
     afterAll(async () => {
         if (!client) return;
+        await client.query('DELETE FROM resources WHERE id = $1', [projectedResourceId]);
+        await client.query('DELETE FROM datasets WHERE id = $1', [projectedDatasetId]);
+        await client.query('DELETE FROM organizations WHERE id = $1', [projectedOrgId]);
         await client.query('DELETE FROM resources WHERE id = $1', [resourceId]);
         await client.query('DELETE FROM datasets WHERE id = $1', [datasetId]);
         await client.query('DELETE FROM organizations WHERE id = $1', [orgId]);
         await client.end();
+        if (mapPool) await mapPool.end();
     });
 
     test('uses a bounded bbox query and clips geometry to the viewport', async () => {
@@ -45,6 +55,76 @@ spatialDescribe('PostGIS viewport integration', () => {
         const coordinates = rows[0].geometry.coordinates.flat(Infinity).filter(Number.isFinite);
         expect(Math.min(...coordinates.filter(value => value < 0))).toBeGreaterThanOrEqual(-79.800001);
         expect(Math.max(...coordinates.filter(value => value < 0))).toBeLessThanOrEqual(-79.199999);
+    });
+
+    test('streams and transforms a projected direct GeoJSON candidate into WGS84', async () => {
+        const workerId = '00000000-0000-4000-8000-000000000020';
+        const candidate = {
+            mode: 'geojson-file', sourceUrl: 'https://example.test/projected.geojson',
+            expectedBytes: 512
+        };
+        await client.query(
+            "INSERT INTO organizations (id, name, title_en) VALUES ($1,$2,'Projected test')",
+            [projectedOrgId, projectedOrgId]
+        );
+        await client.query(
+            "INSERT INTO datasets (id, name, title_en, org_id) VALUES ($1,$2,'Projected test',$3)",
+            [projectedDatasetId, projectedDatasetId, projectedOrgId]
+        );
+        await client.query(`
+            INSERT INTO resources (id, dataset_id, name_fr, format, url, datastore_active, raw)
+            VALUES ($1,$2,'Projection','GEOJSON',$3,false,$4)
+        `, [
+            projectedResourceId, projectedDatasetId, candidate.sourceUrl,
+            JSON.stringify({
+                source_id: 'montreal-open-data', upstream_resource_id: 'projection-test',
+                original_format: 'GEOJSON'
+            })
+        ]);
+        await client.query(`
+            INSERT INTO map_index_jobs (
+                resource_id, desired_version, status, candidate, attempts,
+                worker_id, claimed_at, heartbeat_at
+            ) VALUES ($1,'projected-v1','running',$2,1,$3,now(),now())
+        `, [projectedResourceId, JSON.stringify(candidate), workerId]);
+        const body = JSON.stringify({
+            type: 'FeatureCollection',
+            crs: { type: 'name', properties: { name: 'urn:ogc:def:crs:EPSG::2950' } },
+            features: [{
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [301656.0625, 5058619.8492] },
+                properties: { Nom_gare: 'Canary', nested: { ignored: true } }
+            }]
+        });
+        const result = await indexMapResource({
+            id: projectedResourceId, url: candidate.sourceUrl
+        }, {
+            resource_id: projectedResourceId,
+            claimed_version: 'projected-v1',
+            candidate
+        }, workerId, {
+            maxRows: 10,
+            maxVertices: 100,
+            maxFileBytes: 1024 * 1024,
+            storeBudgetBytes: 1024 * 1024 * 1024,
+            minFreeBytes: 1,
+            fetchImpl: async () => new Response(body, {
+                status: 200,
+                headers: { 'content-type': 'application/geo+json', 'content-length': String(Buffer.byteLength(body)) }
+            })
+        }, { metadataPool: mapPool, indexPool: mapPool });
+        expect(result).toEqual(expect.objectContaining({
+            featureCount: 1, vertexCount: 1, queueStatus: 'ready'
+        }));
+        const feature = await client.query(`
+            SELECT ST_X(geom) AS longitude, ST_Y(geom) AS latitude, properties
+            FROM map_store.features WHERE resource_id = $1
+        `, [projectedResourceId]);
+        expect(feature.rows[0].longitude).toBeGreaterThan(-74);
+        expect(feature.rows[0].longitude).toBeLessThan(-73);
+        expect(feature.rows[0].latitude).toBeGreaterThan(45);
+        expect(feature.rows[0].latitude).toBeLessThan(46);
+        expect(feature.rows[0].properties).toEqual({ Nom_gare: 'Canary' });
     });
 
     test('migrations expose one canonical Ottawa city with durable aliases', async () => {
@@ -78,5 +158,35 @@ spatialDescribe('PostGIS viewport integration', () => {
         ]);
         const duplicate = await client.query("SELECT 1 FROM places WHERE id = 'sgc-csd-3506008'");
         expect(duplicate.rowCount).toBe(0);
+    });
+
+    test('migrations expose distinct Montréal region and featured city identities', async () => {
+        const places = await client.query(`
+            SELECT id, slug, kind, parent_id, type_en, type_fr, featured,
+                   latitude, longitude, default_zoom
+            FROM places WHERE id IN ('sgc-cd-2466', 'sgc-csd-2466023')
+            ORDER BY id
+        `);
+        expect(places.rows).toEqual([
+            expect.objectContaining({
+                id: 'sgc-cd-2466', slug: 'montreal-region-qc', kind: 'region',
+                parent_id: 'sgc-pr-24', featured: false
+            }),
+            expect.objectContaining({
+                id: 'sgc-csd-2466023', slug: 'montreal-qc', kind: 'municipality',
+                parent_id: 'sgc-cd-2466', type_en: 'City', type_fr: 'Ville',
+                featured: true, latitude: 45.5019, longitude: -73.5674, default_zoom: 10
+            })
+        ]);
+        const aliases = await client.query(`
+            SELECT slug, place_id FROM place_aliases
+            WHERE slug IN ('montr-al-qc', 'montr-al-qc-2466023', 'montreal-qc-2466023')
+            ORDER BY slug
+        `);
+        expect(aliases.rows).toEqual([
+            { slug: 'montr-al-qc', place_id: 'sgc-cd-2466' },
+            { slug: 'montr-al-qc-2466023', place_id: 'sgc-csd-2466023' },
+            { slug: 'montreal-qc-2466023', place_id: 'sgc-csd-2466023' }
+        ]);
     });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -1,4 +1,4 @@
-const { normalize, slugify, rowsFrom } = require('../scripts/sync-places');
+const { normalize, slugify, rowsFrom, preflightPlaceChanges } = require('../scripts/sync-places');
 
 describe('Statistics Canada SGC place normalization', () => {
     test('builds stable province, region and municipality ancestry', () => {
@@ -94,6 +94,52 @@ describe('Statistics Canada SGC place normalization', () => {
         const parsed = rowsFrom(Buffer.from('Level,Code,Class title\n2,35,Ontario\n'), 'utf-8');
         expect(parsed[0].Code).toBe('35');
         expect(slugify('Montréal')).toBe('montreal');
+        const accented = rowsFrom(Buffer.from(
+            'Level,Code,Class title\n3,2466,Montr\xe9al\n', 'latin1'
+        ), 'windows-1252');
+        expect(accented[0]['Class title']).toBe('Montréal');
+    });
+
+    test('keeps Montréal region and city distinct and features only the city', () => {
+        const en = [
+            { Level: '2', Code: '24', 'Class title': 'Quebec' },
+            { Level: '3', Code: '2466', 'Class title': 'Montréal' },
+            { Level: '4', Code: '2466023', 'Class title': 'Montréal' }
+        ];
+        const fr = [
+            { Code: '24', 'Titres de classes': 'Québec' },
+            { Code: '2466', 'Titres de classes': 'Montréal' },
+            { Code: '2466023', 'Titres de classes': 'Montréal' }
+        ];
+        const result = normalize(en, fr);
+        expect(result.places.find(place => place.id === 'sgc-pr-24')).toEqual(expect.objectContaining({
+            nameEn: 'Quebec', nameFr: 'Québec', slug: 'quebec'
+        }));
+        expect(result.places.find(place => place.id === 'sgc-cd-2466')).toEqual(expect.objectContaining({
+            slug: 'montreal-region-qc', kind: 'region', parentId: 'sgc-pr-24', featured: false
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-2466023')).toEqual(expect.objectContaining({
+            slug: 'montreal-qc', kind: 'municipality', parentId: 'sgc-cd-2466',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 45.5019, longitude: -73.5674, defaultZoom: 10
+        }));
+    });
+
+    test('plans former-slug aliases and fails closed on ownership conflicts', async () => {
+        const desired = [{ id: 'p1', slug: 'montreal-qc', nameEn: 'Montréal' }];
+        const db = { query: jest.fn()
+            .mockResolvedValueOnce({ rows: [{ id: 'p1', slug: 'montr-al-qc', name_en: 'Montr�al' }] })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] }) };
+        await expect(preflightPlaceChanges(db, desired)).resolves.toEqual({
+            aliases: [{ slug: 'montr-al-qc', placeId: 'p1' }],
+            nameChanges: 1, slugChanges: 1, aliasConflicts: 0
+        });
+
+        const conflict = { query: jest.fn()
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ id: 'p2', slug: 'montreal-qc' }] }) };
+        await expect(preflightPlaceChanges(conflict, desired)).rejects.toThrow(/canonical for another place/);
     });
 
     test('merges Ottawa census-division and subdivision identities into one city', () => {

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -94,6 +94,14 @@ const CC_BY_4_LICENSE = {
     attributionFr: 'Sous licence Creative Commons Attribution 4.0 International.'
 };
 
+const OGL_CANADA_LICENSE = {
+    titleEn: 'Open Government Licence – Canada',
+    titleFr: 'Licence du gouvernement ouvert – Canada',
+    url: 'https://open.canada.ca/en/open-government-licence-canada',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Canada.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Canada.'
+};
+
 const STATCAN_LICENSE = {
     titleEn: 'Statistics Canada Open Licence',
     titleFr: 'Licence ouverte de Statistique Canada',
@@ -143,11 +151,51 @@ const sources = [{
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
     placeId: 'sgc-cd-3520',
+    metadataLanguage: 'en',
+    defaultOrganizationId: 'city-of-toronto',
+    defaultOrganizationName: 'city-of-toronto',
+    defaultOrganizationTitleEn: 'City of Toronto',
+    defaultOrganizationTitleFr: 'Ville de Toronto',
     defaultLicenseTitleEn: TORONTO_LICENSE.titleEn,
     defaultLicenseTitleFr: TORONTO_LICENSE.titleFr,
     defaultLicenseUrl: TORONTO_LICENSE.url,
     defaultAttributionEn: TORONTO_LICENSE.attributionEn,
     defaultAttributionFr: TORONTO_LICENSE.attributionFr
+}, {
+    id: 'montreal-open-data',
+    kind: 'ckan',
+    nameEn: 'Montréal Open Data',
+    nameFr: 'Données ouvertes de la Ville de Montréal',
+    homepageUrl: 'https://donnees.montreal.ca/',
+    catalogUrl: 'https://donnees.montreal.ca/api/3/action',
+    upstreamHost: 'donnees.montreal.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-montreal',
+    defaultOrganizationName: 'ville-de-montreal',
+    defaultOrganizationTitleFr: 'Ville de Montréal',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de montréal$/i }],
+    licenseRules: [
+        { licenseId: /^cc-by$/i, license: CC_BY_4_LICENSE },
+        { licenseId: /^ogl-canada-2\.0$/i, license: OGL_CANADA_LICENSE }
+    ],
+    placeRules: [
+        {
+            publisher: /^ville de montréal$/i,
+            placeId: 'sgc-csd-2466023',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            placeId: 'sgc-csd-2466023',
+            relationship: 'coverage',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'ottawa-hub',
     kind: 'arcgis-hub',
@@ -431,6 +479,7 @@ module.exports = {
     OTTAWA_POLICE_LICENSE,
     MISSISSAUGA_LICENSE,
     CC_BY_4_LICENSE,
+    OGL_CANADA_LICENSE,
     STATCAN_LICENSE,
     PEEL_LICENSE
 };

--- a/server/db/mapIndexQueries.js
+++ b/server/db/mapIndexQueries.js
@@ -137,7 +137,13 @@ async function claimJob(db, workerId) {
         WHERE resource_id = (
             SELECT resource_id FROM map_index_jobs
             WHERE status = 'pending'
-            ORDER BY updated_at, resource_id
+            ORDER BY
+                CASE
+                    WHEN candidate->>'expectedBytes' ~ '^[0-9]+$'
+                        THEN (candidate->>'expectedBytes')::numeric
+                    ELSE NULL
+                END NULLS LAST,
+                updated_at, resource_id
             LIMIT 1 FOR UPDATE SKIP LOCKED
         )
         RETURNING resource_id, desired_version AS claimed_version,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
                 "helmet": "^8.0.0",
                 "pg": "^8.13.0",
                 "pg-copy-streams": "^7.0.0",
+                "stream-json": "2.1.0",
                 "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
             },
             "devDependencies": {
@@ -6094,6 +6095,25 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/stream-chain": {
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-3.6.3.tgz",
+            "integrity": "sha512-JZuELdHUuiZL4Olcr4EllGUvj9VKEaDkGHA6QAP5SruD0bgrr8TwtNXwRfH+fCncysEII7HhWll1+aOwvHYyRw==",
+            "funding": {
+                "url": "https://github.com/sponsors/uhop"
+            }
+        },
+        "node_modules/stream-json": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-2.1.0.tgz",
+            "integrity": "sha512-9gV/ywtebMn3DdKnNKYCb9iESvgR1dHbucNV+bRGvdvy+jV4c9FFgYKmENhpKv58jSwvs90Wk80RhfKk1KxHPg==",
+            "dependencies": {
+                "stream-chain": "^3.6.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/uhop"
             }
         },
         "node_modules/string_decoder": {

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
         "helmet": "^8.0.0",
         "pg": "^8.13.0",
         "pg-copy-streams": "^7.0.0",
+        "stream-json": "2.1.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
     },
     "devDependencies": {

--- a/server/scripts/map-worker.js
+++ b/server/scripts/map-worker.js
@@ -10,7 +10,8 @@ const {
     MapSkipError,
     indexMapResource,
     validateMapFilesystems,
-    mapCaps
+    mapCaps,
+    candidateMode
 } = require('../services/mapIndexPipeline');
 const {
     acquireWorkerLock,
@@ -62,7 +63,19 @@ function ckanTarget(resource) {
     if (!source || source.kind !== 'ckan' || !raw.upstream_resource_id) {
         throw new MapSkipError('map candidate does not belong to a configured CKAN source', 'MAP_SOURCE');
     }
-    return { resourceId: raw.upstream_resource_id, baseUrl: source.catalogUrl };
+    return { resourceId: raw.upstream_resource_id, baseUrl: source.catalogUrl, source };
+}
+
+function validateDirectGeoJson(resource, candidate) {
+    ckanTarget(resource);
+    const raw = resource && resource.raw && typeof resource.raw === 'object' ? resource.raw : {};
+    if (resource.datastore_active === true || String(raw.original_format || '').toUpperCase() !== 'GEOJSON') {
+        throw new MapSkipError('direct map candidate is not a catalogued GeoJSON file', 'MAP_SOURCE');
+    }
+    if (!resource.url || (candidate.sourceUrl && candidate.sourceUrl !== resource.url)) {
+        throw new MapSkipError('direct map candidate URL differs from the catalogued resource', 'MAP_SOURCE');
+    }
+    return true;
 }
 
 async function probeGeometry(resource) {
@@ -102,24 +115,33 @@ async function processJob(job, workerId, options = {}) {
             console.log('[map ' + job.resource_id + '] reconciled existing index');
             return { reconciled: true };
         }
-        const probe = await (options.probeGeometry || probeGeometry)(resource);
-        if (probe.total > mapCaps(options.caps).maxRows) {
-            throw new MapSkipError('DataStore row count exceeds map cap', 'MAP_ROWS');
+        const mode = candidateMode(job.candidate || {});
+        let expectedRows = null;
+        if (mode === 'ckan-datastore-csv') {
+            const probe = await (options.probeGeometry || probeGeometry)(resource);
+            expectedRows = probe.total;
+            if (probe.total > mapCaps(options.caps).maxRows) {
+                throw new MapSkipError('DataStore row count exceeds map cap', 'MAP_ROWS');
+            }
+        } else {
+            (options.validateDirectGeoJson || validateDirectGeoJson)(resource, job.candidate || {});
         }
-        console.log('[map ' + job.resource_id + '] indexing attempt ' + job.attempts + ' (' + probe.total + ' rows)');
+        console.log('[map ' + job.resource_id + '] indexing attempt ' + job.attempts +
+            ' (' + mode + (expectedRows == null ? '' : ', ' + expectedRows + ' rows') + ')');
         const result = await (options.indexMapResource || indexMapResource)(resource, job, workerId, options.caps);
         console.log('[map ' + job.resource_id + '] ' + result.queueStatus + ': ' + result.featureCount +
             ' features, ' + result.vertexCount + ' vertices');
         return result;
     } catch (error) {
         const skipped = error instanceof MapSkipError || ['CAP_FILE'].includes(error && error.code);
-        console.error('[map ' + job.resource_id + '] ' + (skipped ? 'skipped' : 'failed') + ': ' + error.message);
+        const detail = error && error.code ? error.code + ': ' + error.message : error.message;
+        console.error('[map ' + job.resource_id + '] ' + (skipped ? 'skipped' : 'failed') + ': ' + detail);
         if (skipped) {
-            await finishJob(pool, job, workerId, 'skipped', {}, error.message);
+            await finishJob(pool, job, workerId, 'skipped', {}, detail);
         } else if (job.attempts >= MAX_ATTEMPTS) {
-            await finishJob(pool, job, workerId, 'failed', {}, error.message);
+            await finishJob(pool, job, workerId, 'failed', {}, detail);
         } else {
-            await requeueJob(pool, job, workerId, error.message);
+            await requeueJob(pool, job, workerId, detail);
         }
         return { error, skipped };
     } finally {
@@ -185,4 +207,7 @@ if (require.main === module) {
     });
 }
 
-module.exports = { main, processJob, probeGeometry, ckanTarget, requestStop, waitForPoll };
+module.exports = {
+    main, processJob, probeGeometry, ckanTarget, validateDirectGeoJson,
+    requestStop, waitForPoll
+};

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -25,9 +25,11 @@ const FEATURED_PLACE_IDS = new Set([
     'sgc-cd-3521',
     'sgc-csd-3521005',
     'sgc-csd-3521010',
-    'sgc-csd-3521024'
+    'sgc-csd-3521024',
+    'sgc-csd-2466023'
 ]);
 const MUNICIPAL_TYPES = {
+    '2466023': ['City', 'Ville'],
     '3518005': ['Town', 'Ville'],
     '3518039': ['Township', 'Canton'],
     '3518017': ['Municipality', 'Municipalité'],
@@ -41,6 +43,7 @@ const MUNICIPAL_TYPES = {
     '3521024': ['Town', 'Ville']
 };
 const PLACE_VIEWPORTS = {
+    '2466023': [45.5019, -73.5674, 10],
     '3506': [45.4215, -75.6972, 9],
     '3518': [44.0569, -78.8570, 9],
     '3518013': [43.8971, -78.8658, 11],
@@ -119,6 +122,8 @@ function normalize(enRows, frRows) {
         if (code === '35') baseSlug = 'ontario';
         let slug = baseSlug;
         if (code === '3518') slug = 'durham-on';
+        if (code === '2466') slug = 'montreal-region-qc';
+        if (code === '2466023') slug = 'montreal-qc';
         if (code === '3506') slug = 'ottawa-on';
         if (code === '3520') slug = 'toronto-on';
         if (code === '3518013') slug = 'oshawa-on';
@@ -146,13 +151,87 @@ function normalize(enRows, frRows) {
     return { places, identifiers };
 }
 
-async function upsert({ places, identifiers }, dryRun) {
-    if (dryRun) return;
+async function preflightPlaceChanges(client, places) {
+    const desiredById = new Map();
+    const desiredBySlug = new Map();
+    for (const place of places) {
+        if (desiredById.has(place.id)) throw new Error('duplicate desired place id: ' + place.id);
+        if (desiredBySlug.has(place.slug)) {
+            throw new Error('duplicate desired place slug: ' + place.slug);
+        }
+        desiredById.set(place.id, place);
+        desiredBySlug.set(place.slug, place.id);
+    }
+    const ids = Array.from(desiredById.keys());
+    const slugs = Array.from(desiredBySlug.keys());
+    const existingResult = await client.query(`
+        SELECT id, slug, name_en FROM places WHERE id = ANY($1::text[])
+    `, [ids]);
+    const canonicalResult = await client.query(`
+        SELECT id, slug FROM places WHERE slug = ANY($1::text[])
+    `, [slugs]);
+    for (const row of canonicalResult.rows) {
+        const desiredOwner = desiredBySlug.get(row.slug);
+        if (desiredOwner !== row.id) {
+            throw new Error('desired place slug is already canonical for another place: ' + row.slug);
+        }
+    }
+    const aliases = [];
+    let nameChanges = 0;
+    let slugChanges = 0;
+    for (const row of existingResult.rows) {
+        const desired = desiredById.get(row.id);
+        if (row.name_en !== desired.nameEn) nameChanges += 1;
+        if (row.slug === desired.slug) continue;
+        if (desiredBySlug.has(row.slug) && desiredBySlug.get(row.slug) !== row.id) {
+            throw new Error('former place slug is becoming canonical for another place: ' + row.slug);
+        }
+        slugChanges += 1;
+        aliases.push({ slug: row.slug, placeId: row.id });
+    }
+    if (aliases.length) {
+        const aliasResult = await client.query(`
+            SELECT slug, place_id FROM place_aliases WHERE slug = ANY($1::text[])
+        `, [aliases.map(item => item.slug)]);
+        const wanted = new Map(aliases.map(item => [item.slug, item.placeId]));
+        for (const row of aliasResult.rows) {
+            if (wanted.get(row.slug) !== row.place_id) {
+                throw new Error('former place slug is already an alias for another place: ' + row.slug);
+            }
+        }
+    }
+    return { aliases, nameChanges, slugChanges, aliasConflicts: 0 };
+}
+
+async function upsert({ places, identifiers }, dryRun, dbPool = pool) {
     const kindOrder = { country: 0, province: 1, territory: 1, region: 2, municipality: 3 };
     const orderedPlaces = [...places].sort((a, b) => kindOrder[a.kind] - kindOrder[b.kind]);
-    const client = await pool.connect();
+    const client = await dbPool.connect();
     try {
         await client.query('BEGIN');
+        const changes = await preflightPlaceChanges(client, orderedPlaces);
+        if (dryRun) {
+            await client.query('ROLLBACK');
+            return changes;
+        }
+        for (let index = 0; index < changes.aliases.length; index += 500) {
+            const chunk = changes.aliases.slice(index, index + 500);
+            const values = [];
+            const tuples = chunk.map((alias, i) => {
+                const p = i * 2 + 1;
+                values.push(alias.slug, alias.placeId);
+                return `($${p},$${p + 1})`;
+            });
+            const inserted = await client.query(`
+                INSERT INTO place_aliases (slug, place_id)
+                VALUES ${tuples.join(',')}
+                ON CONFLICT (slug) DO UPDATE SET place_id = EXCLUDED.place_id
+                WHERE place_aliases.place_id = EXCLUDED.place_id
+            `, values);
+            if (inserted.rowCount !== chunk.length) {
+                throw new Error('place alias ownership changed during refresh');
+            }
+        }
         for (let index = 0; index < orderedPlaces.length; index += 250) {
             const chunk = orderedPlaces.slice(index, index + 250);
             const values = [];
@@ -201,6 +280,7 @@ async function upsert({ places, identifiers }, dryRun) {
             `, values);
         }
         await client.query('COMMIT');
+        return changes;
     } catch (error) {
         try { await client.query('ROLLBACK'); } catch {}
         throw error;
@@ -214,9 +294,16 @@ async function main() {
         fetchPublicBuffer(EN_URL, { maxBytes: 2 * 1024 * 1024 }),
         fetchPublicBuffer(FR_URL, { maxBytes: 2 * 1024 * 1024 })
     ]);
-    const normalized = normalize(rowsFrom(en, 'utf-8'), rowsFrom(fr, 'windows-1252'));
-    await upsert(normalized, process.argv.includes('--dry-run'));
-    console.log(JSON.stringify({ places: normalized.places.length, identifiers: normalized.identifiers.length }));
+    const normalized = normalize(rowsFrom(en, 'windows-1252'), rowsFrom(fr, 'windows-1252'));
+    const changes = await upsert(normalized, process.argv.includes('--dry-run'));
+    console.log(JSON.stringify({
+        places: normalized.places.length,
+        identifiers: normalized.identifiers.length,
+        name_changes: changes.nameChanges,
+        slug_changes: changes.slugChanges,
+        aliases_to_add: changes.aliases.length,
+        alias_conflicts: changes.aliasConflicts
+    }));
 }
 
 if (require.main === module) {
@@ -230,4 +317,4 @@ if (require.main === module) {
         });
 }
 
-module.exports = { normalize, slugify, rowsFrom, upsert, main };
+module.exports = { normalize, slugify, rowsFrom, preflightPlaceChanges, upsert, main };

--- a/server/services/ckanSourceAdapter.js
+++ b/server/services/ckanSourceAdapter.js
@@ -2,6 +2,7 @@ const crypto = require('node:crypto');
 const { fetchPublicJson } = require('./publicJson');
 
 const PAGE_SIZE = 100;
+const DIRECT_GEOJSON_VERSION = 'geojson-v1';
 const FORMAT_PRIORITY = new Map([
     ['CSV-4326', 0], ['CSV-WGS84', 0], ['CSV', 1], ['XLSX', 2], ['XLS', 3],
     ['GEOJSON', 4], ['JSON', 5], ['GPKG', 6], ['SHP', 7], ['ZIP', 8], ['PDF', 9]
@@ -75,6 +76,84 @@ function mapVersion(resource) {
     return crypto.createHash('sha256').update(JSON.stringify(identity)).digest('hex');
 }
 
+function directMapVersion(resource) {
+    const identity = [
+        DIRECT_GEOJSON_VERSION,
+        resource.metadata_modified || null,
+        resource.last_modified || null,
+        resource.hash || null,
+        Number(resource.size) > 0 ? Number(resource.size) : null,
+        resource.url || null
+    ];
+    return crypto.createHash('sha256').update(JSON.stringify(identity)).digest('hex');
+}
+
+function patternMatches(pattern, value) {
+    if (!pattern) return true;
+    if (pattern instanceof RegExp) {
+        pattern.lastIndex = 0;
+        return pattern.test(clean(value));
+    }
+    return clean(pattern).toLowerCase() === clean(value).toLowerCase();
+}
+
+function publisherName(record, source) {
+    const organization = record.organization || {};
+    return clean(organization.title) ||
+        clean(source.defaultOrganizationTitleEn || source.defaultOrganizationTitleFr) ||
+        clean(source.nameEn || source.nameFr) || 'Publisher';
+}
+
+function authoritativePublisher(source, publisher) {
+    if (!Array.isArray(source.authoritativePublishers)) return true;
+    return source.authoritativePublishers.some(rule => patternMatches(rule.publisher, publisher));
+}
+
+function placeRuleFor(source, publisher) {
+    const configured = Array.isArray(source.placeRules) ? source.placeRules : [];
+    const match = configured.find(rule => patternMatches(rule.publisher, publisher));
+    if (match) return match;
+    if (!source.placeId) return null;
+    return {
+        placeId: source.placeId,
+        relationship: 'direct',
+        includesDescendants: false
+    };
+}
+
+function configuredLicense(source) {
+    if (!source.defaultLicenseUrl) return null;
+    return {
+        titleEn: source.defaultLicenseTitleEn || null,
+        titleFr: source.defaultLicenseTitleFr || null,
+        url: source.defaultLicenseUrl,
+        attributionEn: source.defaultAttributionEn || null,
+        attributionFr: source.defaultAttributionFr || null
+    };
+}
+
+function licenseFor(record, source) {
+    const rules = Array.isArray(source.licenseRules) ? source.licenseRules : [];
+    if (rules.length) {
+        const id = clean(record.license_id);
+        const title = clean(record.license_title);
+        const url = clean(record.license_url);
+        const rule = rules.find(item =>
+            patternMatches(item.licenseId, id) &&
+            patternMatches(item.licenseTitle, title) &&
+            patternMatches(item.licenseUrl, url)
+        );
+        return rule ? rule.license : null;
+    }
+    return configuredLicense(source);
+}
+
+function translated(value, language) {
+    const result = { en: null, fr: null };
+    result[language === 'fr' ? 'fr' : 'en'] = clean(value) || null;
+    return result;
+}
+
 function resourceUrl(resource, actionBase) {
     if (resource.datastore_active === true) {
         return actionBase.replace(/\/api\/3\/action\/?$/, '') + '/datastore/dump/' + encodeURIComponent(resource.id);
@@ -85,22 +164,25 @@ function resourceUrl(resource, actionBase) {
 function normalizeResource(resource, datasetId, source) {
     const upstreamId = clean(resource.id);
     const originalFormat = formatOf(resource);
+    const language = source.metadataLanguage === 'fr' ? 'fr' : 'en';
+    const name = translated(clean(resource.name) || originalFormat, language);
     return {
         id: namespace(source.id, 'resource', upstreamId),
         datasetId,
-        nameEn: clean(resource.name) || originalFormat,
-        nameFr: null,
+        nameEn: name.en,
+        nameFr: name.fr,
         format: resource.datastore_active === true ? 'CSV' : originalFormat,
         url: resourceUrl(resource, source.catalogUrl),
-        sizeBytes: Number.isFinite(Number(resource.size)) ? Number(resource.size) : null,
+        sizeBytes: Number.isFinite(Number(resource.size)) && Number(resource.size) > 0 ? Number(resource.size) : null,
         datastoreActive: resource.datastore_active === true,
-        language: 'en',
+        language,
         lastModified: timestamp(resource.last_modified || resource.metadata_modified),
         raw: {
             provider: 'ckan',
             source_id: source.id,
             upstream_resource_id: upstreamId,
             original_format: originalFormat,
+            source_hash: clean(resource.hash) || null,
             record_count: Number.isFinite(Number(resource.record_count)) ? Number(resource.record_count) : null,
             vertex_count: Number.isFinite(Number(resource.vertex_count)) ? Number(resource.vertex_count) : null
         }
@@ -145,19 +227,38 @@ async function enrichRecord(record, source) {
     }
     const datasetId = namespace(source.id, 'dataset', externalId);
     const organization = record.organization || {};
-    const upstreamOrgId = clean(organization.id || record.owner_org || 'city-of-toronto');
+    const upstreamOrgId = clean(organization.id || record.owner_org || source.defaultOrganizationId || 'publisher');
     const orgId = namespace(source.id, 'org', upstreamOrgId);
+    const publisher = publisherName(record, source);
+    const placeRule = placeRuleFor(source, publisher);
+    const licence = licenseFor(record, source);
+    if (!licence || !licence.url) {
+        return { status: 'excluded', reason: 'unlicensed', externalId: canonicalKey(externalId) };
+    }
+    const language = source.metadataLanguage === 'fr' ? 'fr' : 'en';
+    const organizationTitle = translated(publisher, language);
+    if (source.defaultOrganizationTitleEn && !organizationTitle.en) {
+        organizationTitle.en = source.defaultOrganizationTitleEn;
+    }
+    if (source.defaultOrganizationTitleFr && !organizationTitle.fr) {
+        organizationTitle.fr = source.defaultOrganizationTitleFr;
+    }
     const selectedResources = chooseResources(Array.isArray(record.resources) ? record.resources : []);
     const resources = selectedResources.map(resource => normalizeResource(resource, datasetId, source));
     const resourceByUpstream = new Map(resources.map(resource => [resource.raw.upstream_resource_id, resource]));
     const mapCandidates = selectedResources
-        .filter(resource => resource.datastore_active === true && formatOf(resource) === 'GEOJSON')
+        .filter(resource => formatOf(resource) === 'GEOJSON' &&
+            (resource.datastore_active === true ||
+                (source.directGeoJsonMaps === true && clean(resource.url) !== '')))
         .map(resource => ({
             resourceId: resourceByUpstream.get(clean(resource.id)).id,
-            desiredVersion: mapVersion(resource),
+            desiredVersion: resource.datastore_active === true ? mapVersion(resource) : directMapVersion(resource),
+            mode: resource.datastore_active === true ? 'ckan-datastore-csv' : 'geojson-file',
             sourceUrl: resourceUrl(resource, source.catalogUrl),
             expectedRows: Number.isFinite(Number(resource.record_count)) ? Number(resource.record_count) : null,
             expectedVertices: Number.isFinite(Number(resource.vertex_count)) ? Number(resource.vertex_count) : null,
+            expectedBytes: Number.isFinite(Number(resource.size)) && Number(resource.size) > 0
+                ? Number(resource.size) : null,
             raw: { upstream_resource_id: clean(resource.id) }
         }));
     const keywords = Array.from(new Set([
@@ -165,51 +266,63 @@ async function enrichRecord(record, source) {
         ...(Array.isArray(record.tags) ? record.tags.map(tag => tag && (tag.display_name || tag.name)) : [])
     ].map(clean).filter(Boolean)));
     const modified = timestamp(record.metadata_modified || record.last_refreshed);
+    const datasetTitle = translated(record.title, language);
+    const datasetNotes = translated(record.notes || record.excerpt, language);
     return {
         status: 'included',
         value: {
             externalId: canonicalKey(externalId),
             organization: {
                 id: orgId,
-                name: source.id + '-' + (clean(organization.name) || 'city-of-toronto'),
-                titleEn: clean(organization.title) || 'City of Toronto',
-                titleFr: 'Ville de Toronto',
-                placeId: source.placeId
+                name: source.id + '-' + (clean(organization.name) || source.defaultOrganizationName || 'publisher'),
+                titleEn: organizationTitle.en,
+                titleFr: organizationTitle.fr,
+                placeId: placeRule ? placeRule.placeId : null
             },
             dataset: {
                 id: datasetId,
                 name: source.id + '-' + clean(record.name),
-                titleEn: clean(record.title),
-                titleFr: null,
-                notesEn: clean(record.notes || record.excerpt) || null,
-                notesFr: null,
+                titleEn: datasetTitle.en,
+                titleFr: datasetTitle.fr,
+                notesEn: datasetNotes.en,
+                notesFr: datasetNotes.fr,
                 orgId,
-                keywordsEn: keywords,
-                keywordsFr: [],
+                keywordsEn: language === 'en' ? keywords : [],
+                keywordsFr: language === 'fr' ? keywords : [],
                 metadataModified: modified,
-                raw: { provider: 'ckan', source_id: source.id, upstream_dataset_id: externalId, retired: record.is_retired === true }
+                raw: {
+                    provider: 'ckan', source_id: source.id, upstream_dataset_id: externalId,
+                    metadata_language: language, retired: record.is_retired === true
+                }
             },
             source: {
                 sourceId: source.id,
                 externalId: canonicalKey(externalId),
                 datasetId,
                 landingUrl: source.homepageUrl.replace(/\/+$/, '') + '/dataset/' + encodeURIComponent(record.name) + '/',
-                licenseTitleEn: source.defaultLicenseTitleEn,
-                licenseTitleFr: source.defaultLicenseTitleFr,
-                licenseUrl: source.defaultLicenseUrl,
-                attributionEn: source.defaultAttributionEn,
-                attributionFr: source.defaultAttributionFr,
-                isAuthoritative: true,
-                raw: { upstream_dataset_id: externalId, retired: record.is_retired === true }
+                licenseTitleEn: licence.titleEn || null,
+                licenseTitleFr: licence.titleFr || null,
+                licenseUrl: licence.url,
+                attributionEn: licence.attributionEn || null,
+                attributionFr: licence.attributionFr || null,
+                isAuthoritative: authoritativePublisher(source, publisher),
+                raw: {
+                    upstream_dataset_id: externalId,
+                    publisher,
+                    license_id: clean(record.license_id) || null,
+                    license_title: clean(record.license_title) || null,
+                    license_url: clean(record.license_url) || null,
+                    retired: record.is_retired === true
+                }
             },
             resources,
-            places: [{
+            places: placeRule ? [{
                 datasetId,
-                placeId: source.placeId,
-                relationship: 'direct',
-                includesDescendants: false,
+                placeId: placeRule.placeId,
+                relationship: placeRule.relationship,
+                includesDescendants: placeRule.includesDescendants === true,
                 assignmentMethod: 'source'
-            }],
+            }] : [],
             maps: [],
             manageMaps: false,
             manageMapCandidates: true,
@@ -227,5 +340,9 @@ module.exports = {
     logicalKey,
     priority,
     mapVersion,
+    directMapVersion,
+    licenseFor,
+    authoritativePublisher,
+    placeRuleFor,
     namespace
 };

--- a/server/services/mapIndexPipeline.js
+++ b/server/services/mapIndexPipeline.js
@@ -1,9 +1,12 @@
 const fs = require('node:fs');
 const os = require('node:os');
-const { Transform } = require('node:stream');
+const { Transform, Writable } = require('node:stream');
 const { pipeline } = require('node:stream/promises');
 const { parse } = require('csv-parse');
 const { from: copyFrom } = require('pg-copy-streams');
+const streamJson = require('stream-json');
+const streamPick = require('stream-json/filters/pick.js');
+const streamArray = require('stream-json/streamers/stream-array.js');
 const metadataPool = require('../db/pool');
 const indexPool = require('../db/longRunningPool');
 const { downloadToTempFile, sniffCsvMeta } = require('./csvDownload');
@@ -49,6 +52,17 @@ function validateCandidate(candidate, caps) {
     if (candidate.expectedVertices != null && Number(candidate.expectedVertices) > caps.maxVertices) {
         throw new MapSkipError('source vertex count exceeds map cap ' + caps.maxVertices, 'MAP_VERTICES');
     }
+    if (candidate.expectedBytes != null && Number(candidate.expectedBytes) > caps.maxFileBytes) {
+        throw new MapSkipError('source file size exceeds map cap ' + caps.maxFileBytes, 'CAP_FILE');
+    }
+}
+
+function candidateMode(candidate = {}) {
+    const mode = candidate.mode || 'ckan-datastore-csv';
+    if (!['ckan-datastore-csv', 'geojson-file'].includes(mode)) {
+        throw new MapSkipError('unsupported map candidate mode', 'MAP_SOURCE');
+    }
+    return mode;
 }
 
 function geometryVertexCount(geometry) {
@@ -91,6 +105,11 @@ function scalarValue(value) {
     return text.slice(0, 256);
 }
 
+function scalarPropertyValue(value) {
+    if (value != null && typeof value === 'object') return null;
+    return scalarValue(value);
+}
+
 function selectPropertyFields(headers, sample, geometryColumn) {
     const candidates = headers.filter(name => {
         if (name === geometryColumn || name.toLowerCase() === '_id') return false;
@@ -106,6 +125,104 @@ function selectPropertyFields(headers, sample, geometryColumn) {
         return aPriority - bPriority || headers.indexOf(a) - headers.indexOf(b);
     });
     return candidates.slice(0, 6).map(name => ({ name, alias: name, type: 'text' }));
+}
+
+function selectGeoJsonPropertyFields(properties) {
+    const sample = properties && typeof properties === 'object' && !Array.isArray(properties)
+        ? properties : {};
+    const headers = Object.keys(sample).filter(name => scalarPropertyValue(sample[name]) != null);
+    return selectPropertyFields(headers, sample, null);
+}
+
+function sourceSridFromCrs({ present, type, name, isNull }) {
+    if (!present || isNull) return 4326;
+    if (String(type || '').toLowerCase() !== 'name' || typeof name !== 'string') {
+        throw new MapSkipError('GeoJSON uses an unsupported CRS declaration', 'MAP_CRS');
+    }
+    const normalized = name.trim();
+    if (/CRS84$/i.test(normalized)) return 4326;
+    if (!/EPSG/i.test(normalized)) {
+        throw new MapSkipError('GeoJSON CRS is not an EPSG or CRS84 name', 'MAP_CRS');
+    }
+    const match = normalized.match(/(\d+)\s*$/);
+    const srid = match ? Number(match[1]) : NaN;
+    if (!Number.isInteger(srid) || srid < 1 || srid > 998999) {
+        throw new MapSkipError('GeoJSON CRS has an invalid EPSG identifier', 'MAP_CRS');
+    }
+    return srid;
+}
+
+async function inspectGeoJsonFile(filePath) {
+    let depth = 0;
+    let rootKind = null;
+    let rootType = null;
+    let rootKey = null;
+    let featuresArray = false;
+    let crsPresent = false;
+    let crsObject = false;
+    let crsNull = false;
+    let crsType = null;
+    let crsName = null;
+    let expectedCrsValue = null;
+    const sink = new Writable({
+        objectMode: true,
+        write(token, encoding, callback) {
+            try {
+                if (token.name === 'startObject' || token.name === 'startArray') {
+                    if (depth === 0) rootKind = token.name;
+                    if (depth === 1 && rootKey === 'features') {
+                        featuresArray = token.name === 'startArray';
+                    }
+                    if (depth === 1 && rootKey === 'crs') {
+                        crsPresent = true;
+                        crsObject = token.name === 'startObject';
+                    }
+                    depth += 1;
+                } else if (token.name === 'endObject' || token.name === 'endArray') {
+                    depth -= 1;
+                } else if (token.name === 'keyValue') {
+                    if (depth === 1) {
+                        rootKey = token.value;
+                    } else if (rootKey === 'crs' && token.value === 'type') {
+                        expectedCrsValue = 'type';
+                    } else if (rootKey === 'crs' && token.value === 'name') {
+                        expectedCrsValue = 'name';
+                    } else {
+                        expectedCrsValue = null;
+                    }
+                } else if (token.name === 'stringValue') {
+                    if (depth === 1 && rootKey === 'type') rootType = token.value;
+                    if (rootKey === 'crs' && expectedCrsValue === 'type') crsType = token.value;
+                    if (rootKey === 'crs' && expectedCrsValue === 'name') crsName = token.value;
+                    expectedCrsValue = null;
+                } else if (depth === 1 && rootKey === 'crs' && token.name === 'nullValue') {
+                    crsPresent = true;
+                    crsNull = true;
+                }
+                callback();
+            } catch (error) {
+                callback(error);
+            }
+        }
+    });
+    try {
+        await pipeline(fs.createReadStream(filePath), streamJson.parser.asStream(), sink);
+    } catch (error) {
+        if (error instanceof MapSkipError) throw error;
+        throw new MapSkipError('source is not valid JSON: ' + error.message, 'MAP_GEOMETRY');
+    }
+    if (rootKind !== 'startObject' || rootType !== 'FeatureCollection' || !featuresArray) {
+        throw new MapSkipError('source is not a GeoJSON FeatureCollection', 'MAP_GEOMETRY');
+    }
+    if (crsPresent && !crsNull && !crsObject) {
+        throw new MapSkipError('GeoJSON uses an unsupported CRS declaration', 'MAP_CRS');
+    }
+    return {
+        sourceSrid: sourceSridFromCrs({
+            present: crsPresent, type: crsType, name: crsName, isNull: crsNull
+        }),
+        crsName: crsName || null
+    };
 }
 
 function stagingTransform({ caps, onMetadata }) {
@@ -181,6 +298,66 @@ function stagingTransform({ caps, onMetadata }) {
     return transform;
 }
 
+function geoJsonStagingTransform({ caps, onMetadata }) {
+    let rowCount = 0;
+    let featureCount = 0;
+    let vertexCount = 0;
+    let invalidCount = 0;
+    let fields = null;
+    const geometryTypes = new Set();
+    const transform = new Transform({
+        writableObjectMode: true,
+        transform(entry, encoding, callback) {
+            try {
+                rowCount += 1;
+                if (rowCount > caps.maxRows) {
+                    throw new MapSkipError('row count exceeds map cap ' + caps.maxRows, 'MAP_ROWS');
+                }
+                const feature = entry && entry.value;
+                const geometry = feature && feature.type === 'Feature' ? feature.geometry : null;
+                if (!geometry || typeof geometry.type !== 'string') {
+                    invalidCount += 1;
+                    callback();
+                    return;
+                }
+                const vertices = geometryVertexCount(geometry);
+                if (vertices === 0) {
+                    invalidCount += 1;
+                    callback();
+                    return;
+                }
+                vertexCount += vertices;
+                if (vertexCount > caps.maxVertices) {
+                    throw new MapSkipError('vertex count exceeds map cap ' + caps.maxVertices, 'MAP_VERTICES');
+                }
+                const properties = feature.properties && typeof feature.properties === 'object' &&
+                    !Array.isArray(feature.properties) ? feature.properties : {};
+                if (!fields) {
+                    fields = selectGeoJsonPropertyFields(properties);
+                    onMetadata({ geometryColumn: 'geometry', fields });
+                }
+                const selected = {};
+                for (const field of fields) selected[field.name] = scalarPropertyValue(properties[field.name]);
+                geometryTypes.add(normalizedGeometryType(geometry.type));
+                featureCount += 1;
+                callback(null, [
+                    escapeCsvValue(rowCount),
+                    escapeCsvValue(JSON.stringify(geometry)),
+                    escapeCsvValue(JSON.stringify(selected))
+                ].join(',') + '\n');
+            } catch (error) {
+                callback(error);
+            }
+        }
+    });
+    transform.result = () => ({
+        rowCount, featureCount, vertexCount, invalidCount,
+        fields: fields || [],
+        geometryType: geometryTypes.size === 1 ? Array.from(geometryTypes)[0] : 'mixed'
+    });
+    return transform;
+}
+
 async function currentMapBytes(db, excludeResourceId) {
     const result = await db.query(`
         SELECT coalesce(sum(byte_size), 0)::bigint AS bytes
@@ -200,9 +377,57 @@ async function validateMapFilesystems(capsRaw = {}) {
     return caps;
 }
 
+function validWgs84Extent(extent) {
+    if (!Array.isArray(extent) || extent.length !== 4) return false;
+    const values = extent.map(Number);
+    return values.every(Number.isFinite) &&
+        values[0] >= -180 && values[0] <= 180 &&
+        values[2] >= -180 && values[2] <= 180 &&
+        values[1] >= -90 && values[1] <= 90 &&
+        values[3] >= -90 && values[3] <= 90 &&
+        values[0] <= values[2] && values[1] <= values[3];
+}
+
+async function assertKnownSrid(client, srid) {
+    const result = await client.query('SELECT 1 FROM spatial_ref_sys WHERE srid = $1', [srid]);
+    if (result.rowCount !== 1) {
+        throw new MapSkipError('PostGIS does not recognize source EPSG:' + srid, 'MAP_CRS');
+    }
+}
+
+async function copyCandidateToStage({ mode, filePath, csvMeta, caps, client }) {
+    let metadata = null;
+    let transform;
+    if (mode === 'geojson-file') {
+        transform = geoJsonStagingTransform({ caps, onMetadata: value => { metadata = value; } });
+        await pipeline(
+            fs.createReadStream(filePath),
+            streamJson.parser.asStream(),
+            streamPick.asStream({ filter: 'features' }),
+            streamArray.asStream(),
+            transform,
+            client.query(copyFrom('COPY map_stage (feature_id, geom_json, properties) FROM STDIN WITH (FORMAT csv)'))
+        );
+    } else {
+        transform = stagingTransform({ caps, onMetadata: value => { metadata = value; } });
+        await pipeline(
+            fs.createReadStream(filePath, { encoding: csvMeta.encoding }),
+            parse(csvParseOptions({ columns: true, delimiter: csvMeta.delimiter })),
+            transform,
+            client.query(copyFrom('COPY map_stage (feature_id, geom_json, properties) FROM STDIN WITH (FORMAT csv)'))
+        );
+    }
+    const result = transform.result();
+    if (!metadata || result.featureCount === 0) {
+        throw new MapSkipError('source contains no valid GeoJSON geometry', 'MAP_GEOMETRY');
+    }
+    return { metadata, result };
+}
+
 async function indexMapResource(resource, job, workerId, capsRaw = {}, options = {}) {
     const caps = mapCaps(capsRaw);
     const candidate = { ...(job.candidate || {}) };
+    const mode = candidateMode(candidate);
     validateCandidate(candidate, caps);
     await validateMapFilesystems(caps);
     const retainedBytes = await currentMapBytes(options.metadataPool || metadataPool, resource.id);
@@ -218,52 +443,86 @@ async function indexMapResource(resource, job, workerId, capsRaw = {}, options =
         requestImpl: caps.requestImpl
     });
     try {
-        const { delimiter, encoding } = await sniffCsvMeta(filePath);
+        const geoJsonMeta = mode === 'geojson-file' ? await inspectGeoJsonFile(filePath) : null;
+        const csvMeta = mode === 'ckan-datastore-csv' ? await sniffCsvMeta(filePath) : null;
+        const sourceSrid = geoJsonMeta ? geoJsonMeta.sourceSrid : 4326;
         const db = options.indexPool || indexPool;
         const client = await db.connect();
         try {
             await client.query('BEGIN');
+            await assertKnownSrid(client, sourceSrid);
             await client.query(`
                 CREATE TEMP TABLE map_stage (
                     feature_id bigint NOT NULL,
                     geom_json text NOT NULL,
-                    properties jsonb NOT NULL
+                    properties jsonb NOT NULL,
+                    geom geometry
                 ) ON COMMIT DROP
             `);
-            let metadata = null;
-            const transform = stagingTransform({ caps, onMetadata: value => { metadata = value; } });
-            await pipeline(
-                fs.createReadStream(filePath, { encoding }),
-                parse(csvParseOptions({ columns: true, delimiter })),
-                transform,
-                client.query(copyFrom('COPY map_stage (feature_id, geom_json, properties) FROM STDIN WITH (FORMAT csv)'))
-            );
-            const result = transform.result();
-            if (!metadata || result.featureCount === 0) {
-                throw new MapSkipError('source contains no valid GeoJSON geometry', 'MAP_GEOMETRY');
+            const { metadata, result } = await copyCandidateToStage({
+                mode, filePath, csvMeta, caps, client
+            });
+
+            await client.query(`
+                CREATE OR REPLACE FUNCTION pg_temp.canquery_safe_map_geometry(
+                    input text, input_srid integer
+                ) RETURNS geometry LANGUAGE plpgsql AS $function$
+                DECLARE parsed geometry;
+                BEGIN
+                    parsed := ST_GeomFromGeoJSON(input);
+                    IF parsed IS NULL THEN RETURN NULL; END IF;
+                    parsed := ST_SetSRID(parsed, input_srid);
+                    IF NOT ST_IsValid(parsed) THEN parsed := ST_MakeValid(parsed); END IF;
+                    IF input_srid <> 4326 THEN parsed := ST_Transform(parsed, 4326); END IF;
+                    parsed := ST_Force2D(parsed);
+                    IF ST_IsEmpty(parsed) THEN RETURN NULL; END IF;
+                    RETURN parsed;
+                EXCEPTION WHEN OTHERS THEN
+                    RETURN NULL;
+                END
+                $function$
+            `);
+            await client.query(`
+                UPDATE map_stage
+                SET geom = pg_temp.canquery_safe_map_geometry(geom_json, $1)
+            `, [sourceSrid]);
+            const converted = await client.query(`
+                SELECT count(*) FILTER (WHERE geom IS NOT NULL)::int AS valid,
+                       count(*) FILTER (WHERE geom IS NULL)::int AS invalid
+                FROM map_stage
+            `);
+            const validFeatures = Number(converted.rows[0].valid) || 0;
+            result.invalidCount += Number(converted.rows[0].invalid) || 0;
+            result.featureCount = validFeatures;
+            if (validFeatures === 0) {
+                throw new MapSkipError('source contains no transformable GeoJSON geometry', 'MAP_GEOMETRY');
             }
 
             await client.query('DELETE FROM map_store.features WHERE resource_id = $1', [resource.id]);
             await client.query(`
                 INSERT INTO map_store.features (resource_id, feature_id, geom, properties)
-                SELECT $1, feature_id,
-                       ST_Force2D(ST_MakeValid(ST_SetSRID(ST_GeomFromGeoJSON(geom_json), 4326))),
-                       properties
-                FROM map_stage
+                SELECT $1, feature_id, geom, properties
+                FROM map_stage WHERE geom IS NOT NULL
             `, [resource.id]);
             const spatial = await client.query(`
                 WITH bounds AS (
                     SELECT ST_Extent(geom) AS extent,
-                           coalesce(sum(pg_column_size(f)), 0)::bigint AS data_bytes
+                           coalesce(sum(pg_column_size(f)), 0)::bigint AS data_bytes,
+                           count(*)::int AS feature_count
                     FROM map_store.features f WHERE resource_id = $1
                 )
                 SELECT CASE WHEN extent IS NULL THEN NULL ELSE jsonb_build_array(
                            ST_XMin(extent::box3d), ST_YMin(extent::box3d),
                            ST_XMax(extent::box3d), ST_YMax(extent::box3d)
                        ) END AS extent,
-                       data_bytes
+                       data_bytes, feature_count
                 FROM bounds
             `, [resource.id]);
+            const extent = spatial.rows[0].extent;
+            if (!validWgs84Extent(extent)) {
+                throw new MapSkipError('transformed GeoJSON extent is outside WGS84 bounds', 'MAP_CRS');
+            }
+            result.featureCount = Number(spatial.rows[0].feature_count) || 0;
             const logicalBytes = Math.ceil((Number(spatial.rows[0].data_bytes) || 0) * 2);
             if (retainedBytes + logicalBytes > caps.storeBudgetBytes) {
                 throw new MapSkipError('local map store budget would be exceeded', 'MAP_BUDGET');
@@ -291,7 +550,7 @@ async function indexMapResource(resource, job, workerId, capsRaw = {}, options =
                     updated_at = now()
             `, [
                 resource.id, candidate.sourceUrl || resource.url, result.geometryType,
-                JSON.stringify(spatial.rows[0].extent), metadata.geometryColumn,
+                JSON.stringify(extent), metadata.geometryColumn,
                 result.fields[0] ? result.fields[0].name : null,
                 JSON.stringify(result.fields), result.featureCount, logicalBytes,
                 indexedAt, job.claimed_version
@@ -330,10 +589,18 @@ module.exports = {
     MapSkipError,
     mapCaps,
     validateCandidate,
+    candidateMode,
     geometryVertexCount,
     normalizedGeometryType,
     selectPropertyFields,
+    selectGeoJsonPropertyFields,
     stagingTransform,
+    geoJsonStagingTransform,
+    sourceSridFromCrs,
+    inspectGeoJsonFile,
+    validWgs84Extent,
+    assertKnownSrid,
+    copyCandidateToStage,
     currentMapBytes,
     validateMapFilesystems,
     indexMapResource

--- a/server/services/municipalSyncService.js
+++ b/server/services/municipalSyncService.js
@@ -77,7 +77,7 @@ async function syncMunicipalSource(source, {
             log.warn(source.id + ' record failed: ' + (results[index].error && results[index].error.message));
         }
         const keepExternalIds = Array.from(new Set(included.map(row => row.externalId).concat(failedExternalIds)));
-        if (included.length === 0) throw new Error('ArcGIS Hub produced no eligible records');
+        if (included.length === 0) throw new Error('catalogue source produced no eligible records');
 
         summary = {
             source_id: source.id,
@@ -89,6 +89,21 @@ async function syncMunicipalSource(source, {
             mappable: included.reduce((count, item) => count +
                 (item.maps || (item.map ? [item.map] : [])).length +
                 (item.mapCandidates || []).length, 0),
+            authoritative: included.filter(item => item.source && item.source.isAuthoritative === true).length,
+            licenses: included.reduce((counts, item) => {
+                const key = item.source && item.source.licenseUrl || 'none';
+                counts[key] = (counts[key] || 0) + 1;
+                return counts;
+            }, {}),
+            relationships: included.flatMap(item => item.places || []).reduce((counts, item) => {
+                counts[item.relationship] = (counts[item.relationship] || 0) + 1;
+                return counts;
+            }, {}),
+            map_modes: included.flatMap(item => item.mapCandidates || []).reduce((counts, item) => {
+                const key = item.mode || 'ckan-datastore-csv';
+                counts[key] = (counts[key] || 0) + 1;
+                return counts;
+            }, {}),
             formats: included.reduce((counts, item) => {
                 const resources = item.resources || (item.resource ? [item.resource] : []);
                 for (const resource of resources) {

--- a/server/sql/migrations/013_montreal_place.sql
+++ b/server/sql/migrations/013_montreal_place.sql
@@ -1,0 +1,76 @@
+-- Montréal is a lower-tier census subdivision inside the distinct Montréal
+-- census division. Keep both official places while exposing the city as the
+-- featured standalone destination. Former mojibake and generic subdivision
+-- slugs remain durable aliases.
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-pr-24', 'quebec', 'province', 'Quebec', 'Québec',
+    'Province', 'Province', 'ca', NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-2466', 'montreal-region-qc', 'region', 'Montréal', 'Montréal',
+    'Census division', 'Division de recensement', 'sgc-pr-24',
+    NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-csd-2466023', 'montreal-qc', 'municipality', 'Montréal', 'Montréal',
+    'City', 'Ville', 'sgc-cd-2466', 45.5019, -73.5674, 10, true, true
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+VALUES
+    ('sgc-pr-24', 'sgc-pr', '2021', '24'),
+    ('sgc-cd-2466', 'sgc-cd', '2021', '2466'),
+    ('sgc-csd-2466023', 'sgc-csd', '2021', '2466023')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;
+
+INSERT INTO place_aliases (slug, place_id)
+VALUES
+    ('montr-al-qc', 'sgc-cd-2466'),
+    ('montr-al-qc-2466023', 'sgc-csd-2466023'),
+    ('montreal-qc-2466023', 'sgc-csd-2466023')
+ON CONFLICT (slug) DO UPDATE SET place_id = EXCLUDED.place_id;


### PR DESCRIPTION
## What & why

Add the Ville de Montréal CKAN catalogue as a fail-closed source and make direct GeoJSON resources usable through CanQuery's bounded local PostGIS map path.

This change:

- admits only explicit CC BY 4.0 or Open Government Licence - Canada records
- keeps Montréal municipal publishers authoritative while retaining honest non-authoritative coverage
- adds source-scoped direct GeoJSON map candidates without changing Toronto's existing DataStore map set
- streams FeatureCollections and normalizes supported CRS values, including EPSG:32188 and EPSG:2950, into WGS84
- keeps row, vertex, file, map-store, output, and free-space bounds in force
- repairs Windows-1252 SGC names and separates the Montréal region and city with collision-safe aliases
- adds migration `013_montreal_place.sql`

Official-source dry-run baseline on August 23, 2026: 405 datasets included, 0 excluded, 0 failed, 304 mappable resources, 390 authoritative records, 403 CC BY records, and 2 OGL-Canada records. Toronto remains at its existing 187 DataStore map candidates.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

- Server validation: 361 default-run tests plus 4 isolated PostGIS tests, 365 total.
- Client validation: 106 tests across 25 files.
- Clean installs, both linters, the production Vite build, and the production dependency audit passed.
- The PostGIS integration suite indexes a projected EPSG:2950 direct GeoJSON resource end to end.
- Production rollout should stop the map worker before source synchronization, deploy and migrate first, then restart the new worker so legacy code cannot claim direct-file jobs.