### PR TITLE
Harden map worker for large GeoJSON features

### DIFF
--- a/deploy/canquery-map-worker.service
+++ b/deploy/canquery-map-worker.service
@@ -14,6 +14,9 @@ Group=canquery
 WorkingDirectory=/home/canquery/canquery/server
 ExecStart=/usr/bin/node scripts/map-worker.js
 Environment=NODE_ENV=production
+# Direct GeoJSON files can contain a few very large Feature objects. stream-json
+# bounds the collection, but each feature still needs enough heap to be assembled.
+Environment=NODE_OPTIONS=--max-old-space-size=1024
 Restart=on-failure
 RestartSec=10
 KillSignal=SIGTERM

--- a/server/__tests__/mapIndexQueries.test.js
+++ b/server/__tests__/mapIndexQueries.test.js
@@ -27,12 +27,27 @@ describe('versioned map-index queue', () => {
 
     test('recovers leases and claims one pending version with SKIP LOCKED', async () => {
         const db = { query: jest.fn()
-            .mockResolvedValueOnce({ rowCount: 2 })
+            .mockResolvedValueOnce({
+                rowCount: 2,
+                rows: [
+                    { resource_id: 'r1', status: 'pending' },
+                    { resource_id: 'r2', status: 'failed' }
+                ]
+            })
             .mockResolvedValueOnce({ rows: [{ resource_id: 'r1', claimed_version: 'v1', candidate: {}, attempts: 1 }] }) };
-        await expect(recoverOrphanedJobs(db)).resolves.toMatchObject({ rowCount: 2 });
+        await expect(recoverOrphanedJobs(db, 3)).resolves.toMatchObject({
+            rowCount: 2,
+            rows: expect.arrayContaining([
+                expect.objectContaining({ status: 'pending' }),
+                expect.objectContaining({ status: 'failed' })
+            ])
+        });
         await expect(claimJob(db, '00000000-0000-4000-8000-000000000001')).resolves.toEqual(expect.objectContaining({
             resource_id: 'r1', claimed_version: 'v1'
         }));
+        expect(db.query.mock.calls[0][0]).toContain("attempts >= $1 THEN 'failed'");
+        expect(db.query.mock.calls[0][0]).toContain('RETURNING resource_id, status');
+        expect(db.query.mock.calls[0][1]).toEqual([3]);
         expect(db.query.mock.calls[1][0]).toContain('FOR UPDATE SKIP LOCKED');
         expect(db.query.mock.calls[1][0]).toContain("candidate->>'expectedBytes'");
         expect(db.query.mock.calls[1][0]).toContain('NULLS LAST');

--- a/server/db/mapIndexQueries.js
+++ b/server/db/mapIndexQueries.js
@@ -85,14 +85,21 @@ async function releaseWorkerLock(db) {
     return result.rows[0].released === true;
 }
 
-async function recoverOrphanedJobs(db) {
+async function recoverOrphanedJobs(db, maxAttempts = 3) {
     return db.query(`
         UPDATE map_index_jobs
-        SET status = 'pending', worker_id = NULL, claimed_at = NULL,
-            heartbeat_at = NULL, finished_at = NULL,
-            error = 'requeued after map worker restart', updated_at = now()
+        SET status = CASE WHEN attempts >= $1 THEN 'failed' ELSE 'pending' END,
+            worker_id = NULL, claimed_at = NULL, heartbeat_at = NULL,
+            finished_at = CASE WHEN attempts >= $1 THEN now() ELSE NULL END,
+            error = CASE
+                WHEN attempts >= $1
+                    THEN 'map worker terminated during indexing after ' || attempts || ' attempts'
+                ELSE 'requeued after map worker restart'
+            END,
+            updated_at = now()
         WHERE status = 'running'
-    `);
+        RETURNING resource_id, status
+    `, [maxAttempts]);
 }
 
 async function reconcileMissingFeatures(db) {

--- a/server/scripts/map-worker.js
+++ b/server/scripts/map-worker.js
@@ -170,8 +170,12 @@ async function main() {
             throw new Error(message);
         }
         console.log('map-worker started as ' + workerId + (drainMode ? ' (drain mode)' : onceMode ? ' (once mode)' : ''));
-        const recovered = await recoverOrphanedJobs(pool);
-        if (recovered.rowCount) console.log('requeued ' + recovered.rowCount + ' interrupted map job(s)');
+        const recovered = await recoverOrphanedJobs(pool, MAX_ATTEMPTS);
+        const recoveredRows = recovered.rows || [];
+        const requeuedCount = recoveredRows.filter(row => row.status === 'pending').length;
+        const failedCount = recoveredRows.filter(row => row.status === 'failed').length;
+        if (requeuedCount) console.log('requeued ' + requeuedCount + ' interrupted map job(s)');
+        if (failedCount) console.error('failed ' + failedCount + ' interrupted map job(s) at the attempt limit');
         const missing = await reconcileMissingFeatures(pool);
         if (missing.length) console.log('queued ' + missing.length + ' map index(es) absent after restore');
 


### PR DESCRIPTION
## What & why

A direct GeoJSON can stay within the configured file and vertex caps while containing only a few extremely large Feature objects. `stream-json` bounds the collection, but its array streamer must still assemble one Feature at a time. With Node's cgroup-adjusted default heap, that shape could terminate the process before the worker recorded a normal attempt failure.

- Give the dedicated map worker a 1 GB V8 heap while retaining its 1.5 GB systemd memory ceiling.
- Make startup recovery respect the three-attempt limit, terminally failing an interrupted job at the limit instead of requeueing it forever.
- Report requeued and terminally failed interrupted jobs separately.

## Checklist

- [x] `server`: `npm run lint && npm test` pass (51 suites, 362 tests; spatial integration remains separately exercised by CI)
- [ ] `client`: no client files changed; full client validation is delegated to CI
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any - N/A
- [x] No secrets, credentials, or production-specific details added

## Notes

The exact 205 MB, four-feature workload that exposed the issue completed locally in 66.6 seconds with 5,117,412 vertices under `--max-old-space-size=1024`; the same workload reproduces the OOM at 512 MB.