### PR TITLE
Bound individual map feature complexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ for the production worker).
 Type inference (1,000-row sample → INTEGER/NUMERIC/DATE/TIMESTAMPTZ/TEXT) falls back
 to TEXT per column when a later cast fails.
 
-Local maps have separate defaults: 1,000,000 rows and 10,000,000 vertices per
-resource, a 1 GB download cap, a 20 GB logical map-store budget, and a 30 GB
+Local maps have separate defaults: 1,000,000 rows, 1,000,000 vertices per feature,
+and 10,000,000 vertices per resource, plus a 1 GB download cap, a 20 GB logical
+map-store budget, and a 30 GB
 filesystem free-space floor. Direct GeoJSON supports absent/WGS84, CRS84, and
 named PostGIS EPSG definitions; unsupported or malformed CRS declarations fail
 closed for that resource. `map_store.features` is a reproducible cache and may

--- a/server/.env.example
+++ b/server/.env.example
@@ -107,6 +107,7 @@ INGEST_STALL_TIMEOUT_MS=
 # metadata should be backed up; map_store.features data may be excluded.
 MAP_MAX_ROWS=1000000
 MAP_MAX_VERTICES=10000000
+MAP_MAX_FEATURE_VERTICES=1000000
 MAP_MAX_FILE_MB=1024
 MAP_STORE_BUDGET_GB=20
 # Fail closed unless this much space remains on TMPDIR and PostgreSQL's

--- a/server/__tests__/mapIndexPipeline.test.js
+++ b/server/__tests__/mapIndexPipeline.test.js
@@ -135,6 +135,26 @@ describe('bounded local-map conversion', () => {
             .toEqual(['Address']);
     });
 
+    test('rejects one oversized feature before PostGIS conversion', async () => {
+        const transform = geoJsonStagingTransform({
+            caps: { maxRows: 10, maxVertices: 10, maxFeatureVertices: 2 },
+            onMetadata: () => {}
+        });
+        const failed = once(transform, 'error');
+        transform.end({
+            key: 0,
+            value: {
+                type: 'Feature',
+                geometry: { type: 'LineString', coordinates: [[0, 0], [1, 1], [2, 2]] },
+                properties: {}
+            }
+        });
+        const [error] = await failed;
+        expect(error).toBeInstanceOf(MapSkipError);
+        expect(error).toMatchObject({ code: 'MAP_VERTICES' });
+        expect(error.message).toContain('feature vertex count exceeds map cap 2');
+    });
+
     test('validates transformed WGS84 extents', () => {
         expect(validWgs84Extent([-74, 45, -73, 46])).toBe(true);
         expect(validWgs84Extent([277000, 5040000, 300000, 5060000])).toBe(false);

--- a/server/services/mapIndexPipeline.js
+++ b/server/services/mapIndexPipeline.js
@@ -30,9 +30,13 @@ function finiteCap(value, fallback) {
 }
 
 function mapCaps(overrides = {}) {
+    const maxVertices = finiteCap(overrides.maxVertices,
+        finiteCap(process.env.MAP_MAX_VERTICES, 10_000_000));
     return {
         maxRows: finiteCap(overrides.maxRows, finiteCap(process.env.MAP_MAX_ROWS, 1_000_000)),
-        maxVertices: finiteCap(overrides.maxVertices, finiteCap(process.env.MAP_MAX_VERTICES, 10_000_000)),
+        maxVertices,
+        maxFeatureVertices: Math.min(maxVertices, finiteCap(overrides.maxFeatureVertices,
+            finiteCap(process.env.MAP_MAX_FEATURE_VERTICES, 1_000_000))),
         maxFileBytes: finiteCap(overrides.maxFileBytes, finiteCap(process.env.MAP_MAX_FILE_MB, 1024) * 1024 * 1024),
         storeBudgetBytes: finiteCap(overrides.storeBudgetBytes, finiteCap(process.env.MAP_STORE_BUDGET_GB, 20) * GB),
         minFreeBytes: finiteCap(overrides.minFreeBytes, finiteCap(process.env.MAP_MIN_FREE_GB, 30) * GB),
@@ -82,6 +86,16 @@ function geometryVertexCount(geometry) {
     };
     walk(geometry.coordinates);
     return count;
+}
+
+function assertFeatureVertexCount(vertices, caps) {
+    const maxFeatureVertices = finiteCap(caps.maxFeatureVertices, caps.maxVertices);
+    if (vertices > maxFeatureVertices) {
+        throw new MapSkipError(
+            'feature vertex count exceeds map cap ' + maxFeatureVertices,
+            'MAP_VERTICES'
+        );
+    }
 }
 
 function normalizedGeometryType(type) {
@@ -268,6 +282,7 @@ function stagingTransform({ caps, onMetadata }) {
                     callback();
                     return;
                 }
+                assertFeatureVertexCount(vertices, caps);
                 vertexCount += vertices;
                 if (vertexCount > caps.maxVertices) {
                     throw new MapSkipError('vertex count exceeds map cap ' + caps.maxVertices, 'MAP_VERTICES');
@@ -326,6 +341,7 @@ function geoJsonStagingTransform({ caps, onMetadata }) {
                     callback();
                     return;
                 }
+                assertFeatureVertexCount(vertices, caps);
                 vertexCount += vertices;
                 if (vertexCount > caps.maxVertices) {
                     throw new MapSkipError('vertex count exceeds map cap ' + caps.maxVertices, 'MAP_VERTICES');


### PR DESCRIPTION
## What & why

The map pipeline already caps each resource at 10 million vertices, but a source can place several million vertices in one MultiPolygon. PostgreSQL then enters one long GEOS validity/transform call; cancellation is not observed until that C call returns, so the statement timeout alone is not a sufficient per-feature bound.

- Add `MAP_MAX_FEATURE_VERTICES`, defaulting to 1,000,000 and never exceeding the existing resource-wide cap.
- Enforce it for both CKAN DataStore geometry rows and direct GeoJSON Features before PostGIS conversion.
- Keep the existing 10-million-vertex resource allowance for normal multi-feature maps.
- Document and regression-test the new fail-closed bound.

## Checklist

- [x] `server`: `npm run lint && npm test` pass (51 suites, 363 tests; spatial integration remains separately exercised by CI)
- [ ] `client`: no client files changed; full client validation is delegated to CI
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any - N/A
- [x] No secrets, credentials, or production-specific details added

## Notes

This complements PR #9's worker heap and orphan-attempt hardening. Resource-wide row, vertex, file, store, free-space, and response caps are unchanged.