### PR TITLE
Skip permanently missing map downloads

### DIFF
--- a/server/__tests__/ingestCaps.test.js
+++ b/server/__tests__/ingestCaps.test.js
@@ -69,6 +69,21 @@ describe('ingestion caps', () => {
         fs.unlinkSync(filePath);
     });
 
+    it('preserves the HTTP status on a failed download', async () => {
+        const missingFetch = async () => ({
+            status: 404,
+            body: new ReadableStream({ start(controller) { controller.close(); } })
+        });
+        await expect(downloadToTempFile('https://example.org/missing.csv', {
+            maxFileBytes: 1024,
+            fetchImpl: missingFetch
+        })).rejects.toMatchObject({
+            code: 'DOWNLOAD_HTTP',
+            httpStatus: 404,
+            message: 'download failed: HTTP 404'
+        });
+    });
+
     it('a stalled download is aborted instead of hanging the worker', async () => {
         // Sends one chunk then never closes - mirrors an upstream that accepts
         // the socket and then goes silent. Without the stall guard this read

--- a/server/__tests__/mapWorker.test.js
+++ b/server/__tests__/mapWorker.test.js
@@ -103,4 +103,20 @@ describe('map worker transitions', () => {
             pool, finalJob, expect.any(String), 'failed', {}, 'temporary upstream failure'
         );
     });
+
+    test('skips a permanently missing catalogued download without retrying', async () => {
+        const error = Object.assign(new Error('download failed: HTTP 404'), {
+            code: 'DOWNLOAD_HTTP', httpStatus: 404
+        });
+        await processJob(job, '00000000-0000-4000-8000-000000000001', {
+            getResourceById: async () => resource,
+            probeGeometry: async () => ({ total: 1, fields: [{ id: 'geometry' }] }),
+            indexMapResource: async () => { throw error; }
+        });
+        expect(mapQueries.finishJob).toHaveBeenCalledWith(
+            pool, job, expect.any(String), 'skipped', {},
+            'DOWNLOAD_HTTP: download failed: HTTP 404'
+        );
+        expect(mapQueries.requeueJob).not.toHaveBeenCalled();
+    });
 });

--- a/server/scripts/map-worker.js
+++ b/server/scripts/map-worker.js
@@ -41,6 +41,10 @@ function requestStop(signal) {
     if (wakePoll) wakePoll();
 }
 
+function isPermanentMissingDownload(error) {
+    return error && error.code === 'DOWNLOAD_HTTP' && [404, 410].includes(Number(error.httpStatus));
+}
+
 function waitForPoll() {
     if (stopRequested) return Promise.resolve();
     return new Promise(resolve => {
@@ -133,7 +137,8 @@ async function processJob(job, workerId, options = {}) {
             ' features, ' + result.vertexCount + ' vertices');
         return result;
     } catch (error) {
-        const skipped = error instanceof MapSkipError || ['CAP_FILE'].includes(error && error.code);
+        const skipped = error instanceof MapSkipError || ['CAP_FILE'].includes(error && error.code)
+            || isPermanentMissingDownload(error);
         const detail = error && error.code ? error.code + ': ' + error.message : error.message;
         console.error('[map ' + job.resource_id + '] ' + (skipped ? 'skipped' : 'failed') + ': ' + detail);
         if (skipped) {

--- a/server/services/csvDownload.js
+++ b/server/services/csvDownload.js
@@ -367,7 +367,9 @@ async function downloadToTempFile(url, {
     if (status < 200 || status >= 300 || !responseBody) {
         disarm();
         destroyResponse(res);
-        throw new Error('download failed: HTTP ' + status);
+        const err = downloadError('download failed: HTTP ' + status, 'DOWNLOAD_HTTP');
+        err.httpStatus = status;
+        throw err;
     }
     const contentLength = Number(responseHeader(res, 'content-length'));
     if (Number.isFinite(contentLength) && contentLength > maxFileBytes) {


### PR DESCRIPTION
## What & why

A catalogued GeoJSON URL can remain in upstream CKAN metadata after the file itself starts returning HTTP 404. The map worker previously retried that permanent condition three times, marked the job failed, and degraded `/ops`.

This change:

- preserves non-success download status as structured `DOWNLOAD_HTTP` metadata;
- classifies only HTTP 404 and 410 map downloads as permanent fail-closed skips;
- keeps 403, 429, 5xx, stalls, and network errors on the existing retry/failure path;
- adds downloader and worker-transition regressions.

## Checklist

- [x] `server`: `npm run lint && npm test` pass (51 suites, 365 tests)
- [ ] `client`: unchanged; CI will run lint, tests, and build
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (not applicable)
- [x] No secrets, credentials, or production-specific details added

## Notes

No migration or client change. The map worker must be restarted after deployment.