### PR TITLE
Add Vancouver open data coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ live maps served through bounded upstream viewports. Montréal's official CKAN
 catalogue is included as a French-first standalone city: record-level CC BY 4.0
 and Open Government Licence - Canada terms are preserved, while selected direct
 GeoJSON files are streamed and reprojected into the local PostGIS index. The
-featured local directory
+City of Vancouver's official Opendatasoft catalogue is included as an English-first
+standalone city. Its record-explicit Open Government Licence - Vancouver metadata
+is preserved, CSV exports remain loadable only within the shared row cap, and all
+eligible spatial datasets use separately validated GeoJSON exports in the local
+PostGIS index. The featured local directory
 also covers Durham Region and all eight lower-tier municipalities, with direct
 feeds from Durham, Ajax,
 Oshawa, Pickering and the explicitly open-licensed subset of Whitby.
@@ -65,6 +69,7 @@ node scripts/catalog-sync.js --limit 200   # small real harvest (~2 min, polite)
 npm run sync:places                       # Statistics Canada SGC hierarchy
 npm run sync:source -- --source=montreal-open-data --dry-run
 npm run sync:source -- --source=ottawa-hub --dry-run
+npm run sync:source -- --source=vancouver-open-data --dry-run
 npm run sync:source -- --source=durham-hub --dry-run
 npm run sync:source -- --source=peel-hub --dry-run
 npm run sync:municipal                    # sync every enabled local source
@@ -92,10 +97,12 @@ curl 'http://localhost:3100/api/v1/places?featured=true'
 curl 'http://localhost:3100/api/v1/places?q=Oshawa'
 curl 'http://localhost:3100/api/v1/places?q=Mississauga'
 curl 'http://localhost:3100/api/v1/places?q=Montr%C3%A9al'
+curl 'http://localhost:3100/api/v1/places?q=Vancouver'
 
 # place-filtered sources are authoritative; counts expose total + authoritative
 curl 'http://localhost:3100/api/v1/sources?place=clarington-on'
 curl 'http://localhost:3100/api/v1/sources?place=mississauga-on'
+curl 'http://localhost:3100/api/v1/sources?place=vancouver-bc'
 
 # dataset detail - resources tagged datastore | ingested | ingestable | file-only
 curl 'http://localhost:3100/api/v1/datasets/<idOrName>'
@@ -104,7 +111,7 @@ curl 'http://localhost:3100/api/v1/datasets/<idOrName>'
 curl 'http://localhost:3100/api/v1/resources/<id>/query?limit=10'
 curl 'http://localhost:3100/api/v1/resources/<id>/query?filters={"year":{"op":"gte","value":2020}}&sort=year%20desc'
 
-# bounded GeoJSON for an upstream ArcGIS or locally indexed CKAN resource
+# bounded GeoJSON for an upstream ArcGIS or locally indexed CKAN/Opendatasoft resource
 curl 'http://localhost:3100/api/v1/resources/<id>/map?bbox=-79,43.8,-78.7,44&zoom=11&limit=1000'
 
 # load a tabular file (idempotent; 5/hour/IP), then poll a newly-enqueued job.
@@ -139,7 +146,7 @@ expensive profile, aggregation, and export routes have dedicated rate limits.
 | `scripts/sync-source.js` | validates or syncs one configured source adapter; `--source`, `--limit`, `--dry-run` |
 | `scripts/sync-municipal-sources.js` | refreshes every enabled non-federal source independently so one failure cannot suppress the others |
 | `scripts/ingest-worker.js` | exclusively owns the queue with a PostgreSQL advisory lock, heartbeats active-job leases, streams files into `store.r_*` via `COPY`, and recovers crash orphans immediately; `--once` for a single drain |
-| `scripts/map-worker.js` | exclusively owns the versioned map queue, streams CKAN CSV dumps and direct GeoJSON files into PostGIS, reprojects named EPSG CRSs to WGS84 under row/vertex/file/disk budgets, and self-heals excluded map data after restore; `--once` or `--drain` |
+| `scripts/map-worker.js` | exclusively owns the versioned map queue, streams CKAN CSV dumps and validated CKAN/Opendatasoft GeoJSON exports into PostGIS, reprojects named EPSG CRSs to WGS84 under row/vertex/file/disk budgets, and self-heals excluded map data after restore; `--once` or `--drain` |
 | `scripts/evict-store.js` | serializes with ingestion, rechecks pins/state under lock, and drops least-recently-accessed tables until under `STORE_BUDGET_GB` |
 | `scripts/seed-top100.js` | rebuilds the **Top 100** leaderboard: ranks the latest analytics snapshot, ingests + pins one latest-period resource per top dataset, upserts `top_downloads`; daily cron, `--dry-run` |
 
@@ -162,15 +169,17 @@ and 10,000,000 vertices per resource, plus a 1 GB download cap, a 20 GB logical
 map-store budget, and a 30 GB
 filesystem free-space floor. Direct GeoJSON supports absent/WGS84, CRS84, and
 named PostGIS EPSG definitions; unsupported or malformed CRS declarations fail
-closed for that resource. `map_store.features` is a reproducible cache and may
+closed for that resource. Known upstream record counts above `MAX_ROWS` keep a
+CSV discoverable as `file-only` without enqueueing an ingest that cannot finish.
+`map_store.features` is a reproducible cache and may
 be excluded from backups; the queue reindexes missing feature data after restore.
 
 ## Web UI
 
 The SPA (`client/`) starts with a search plus an optional remembered place
 (All Canada remains the default). Its grouped selector shows featured regions,
-their municipalities, and standalone featured cities such as Montréal, Ottawa
-and Toronto;
+their municipalities, and standalone featured cities such as Montréal, Ottawa,
+Toronto and Vancouver;
 search on `/places` still reaches the complete Canadian SGC hierarchy. Place
 pages combine directly local datasets with records whose parent jurisdiction
 explicitly covers that place, and label regional-only coverage instead of
@@ -193,7 +202,7 @@ cd server && npm test && npm run lint
 cd client && npm test && npm run lint && npm run build
 ```
 
-Coverage includes source adapters, place hierarchy and APIs, streaming direct
+Coverage includes CKAN, ArcGIS Hub and Opendatasoft source adapters, place hierarchy and APIs, streaming direct
 GeoJSON plus projected-CRS map conversion, bounded map
 queries, publisher-specific provenance, the four `/query` modes, filter-grammar injection attempts,
 SSRF/redirect/DNS-pinning checks, bounded caches, spreadsheet-safe streaming CSV

--- a/client/src/components/PlaceSelect.test.jsx
+++ b/client/src/components/PlaceSelect.test.jsx
@@ -14,6 +14,7 @@ describe('PlaceSelect', () => {
       { id: 'sgc-cd-3506', slug: 'ottawa-on', kind: 'municipality', name: { en: 'Ottawa' }, parent: { id: 'ca-on' }, dataset_count: 392 },
       { id: 'sgc-cd-3520', slug: 'toronto-on', kind: 'municipality', name: { en: 'Toronto' }, parent: { id: 'ca-on' }, dataset_count: 556 },
       { id: 'sgc-csd-2466023', slug: 'montreal-qc', kind: 'municipality', name: { en: 'Montréal' }, parent: { id: 'sgc-cd-2466' }, dataset_count: 405 },
+      { id: 'sgc-csd-5915022', slug: 'vancouver-bc', kind: 'municipality', name: { en: 'Vancouver' }, parent: { id: 'sgc-cd-5915' }, dataset_count: 178 },
     ]} />);
     const select = screen.getByRole('combobox', { name: 'Choose a place' });
     expect(select).toHaveDisplayValue('All Canada');
@@ -21,6 +22,7 @@ describe('PlaceSelect', () => {
     expect(onChange).toHaveBeenCalledWith('oshawa-on');
     expect(screen.getByRole('option', { name: /Ottawa/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Montréal/ })).toBeInTheDocument();
+    expect(screen.getAllByRole('option', { name: /Vancouver/ })).toHaveLength(1);
     expect([...container.querySelectorAll('optgroup')].map(group => group.label)).toEqual([
       'Featured regions', 'Municipalities in Durham', 'Municipalities in Peel', 'Featured cities', 'Other places'
     ]);

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -54,6 +54,12 @@ beforeEach(() => {
       name: { en: 'Montréal', fr: 'Montréal' }, type: { en: 'City', fr: 'Ville' },
       parent: { id: 'sgc-cd-2466', name: { en: 'Montréal', fr: 'Montréal' } },
       dataset_count: 405, direct_dataset_count: 390, mappable_resource_count: 304
+    },
+    {
+      id: 'sgc-csd-5915022', slug: 'vancouver-bc', kind: 'municipality',
+      name: { en: 'Vancouver', fr: 'Vancouver' }, type: { en: 'City', fr: 'Ville' },
+      parent: { id: 'sgc-cd-5915', name: { en: 'Greater Vancouver', fr: 'Greater Vancouver' } },
+      dataset_count: 178, direct_dataset_count: 178, mappable_resource_count: 133
     }
   ] });
 });
@@ -69,6 +75,7 @@ describe('PlacesPage', () => {
     expect(screen.getByRole('link', { name: /Ottawa/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Toronto/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Montréal/ })).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /Vancouver/ })).toHaveLength(1);
     expect(screen.getByRole('link', { name: /Clarington/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Caledon/ })).toBeInTheDocument();

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -139,7 +139,9 @@ they can identify safely. Spatial ArcGIS leaf layers use bounded upstream
 viewports; configured CKAN GeoJSON DataStore resources are queued for a bounded
 local PostGIS index. Catalogued direct GeoJSON resources use the same queue and
 are streamed, CRS-validated, and reprojected to WGS84 without loading a whole
-file into memory.
+file into memory. Opendatasoft sources reconstruct and validate their separate
+CSV and GeoJSON export URLs from the configured catalogue identity; queued URLs
+are never treated as arbitrary download targets.
 
 ## 6. Cron jobs
 
@@ -238,11 +240,13 @@ curl -s 'https://<your-domain>/api/v1/places?q=Oshawa'
 curl -s 'https://<your-domain>/api/v1/places?q=Toronto'
 curl -s 'https://<your-domain>/api/v1/places?q=Ottawa'
 curl -s 'https://<your-domain>/api/v1/places?q=Montr%C3%A9al'
+curl -s 'https://<your-domain>/api/v1/places?q=Vancouver'
 curl -s 'https://<your-domain>/api/v1/places?q=Mississauga'
 curl -s 'https://<your-domain>/api/v1/places?q=Brampton'
 curl -s 'https://<your-domain>/api/v1/sources?place=clarington-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=caledon-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=ottawa-on'
+curl -s 'https://<your-domain>/api/v1/sources?place=vancouver-bc'
 # UI: search by place, open a mapped dataset, pan/zoom the live Map tab, then load its table snapshot
 ```
 

--- a/server/__tests__/catalogApi.test.js
+++ b/server/__tests__/catalogApi.test.js
@@ -117,12 +117,13 @@ describe('Catalog API', () => {
             { id: 'r4', dataset_id: 'd1', name_en: 'd', name_fr: null, format: 'PDF', url: 'u', size_bytes: null, datastore_active: false, language: null, last_modified: null, ingest_status: null },
             { id: 'r5', dataset_id: 'd1', name_en: 'e', name_fr: null, format: 'XLSX', url: 'u', size_bytes: '1048576', datastore_active: false, language: null, last_modified: null, ingest_status: null },
             { id: 'r6', dataset_id: 'd1', name_en: 'f', name_fr: null, format: 'XLSX', url: 'u', size_bytes: String(25 * 1024 * 1024), datastore_active: false, language: null, last_modified: null, ingest_status: null },
-            { id: 'r7', dataset_id: 'd1', name_en: 'g', name_fr: null, format: 'XLS', url: 'u', size_bytes: null, datastore_active: false, language: null, last_modified: null, ingest_status: null }
+            { id: 'r7', dataset_id: 'd1', name_en: 'g', name_fr: null, format: 'XLS', url: 'u', size_bytes: null, datastore_active: false, language: null, last_modified: null, ingest_status: null },
+            { id: 'r8', dataset_id: 'd1', name_en: 'h', name_fr: null, format: 'CSV', url: 'u', size_bytes: null, raw: { record_count: 1000001 }, datastore_active: false, language: null, last_modified: null, ingest_status: null }
         ]);
         const res = await request(app).get('/api/v1/datasets/d1');
         expect(res.status).toBe(200);
         const modes = res.body.data.resources.map(r => r.query_mode);
-        expect(modes).toEqual(['datastore', 'ingested', 'file-only', 'file-only', 'ingestable', 'file-only', 'ingestable']);
+        expect(modes).toEqual(['datastore', 'ingested', 'file-only', 'file-only', 'ingestable', 'file-only', 'ingestable', 'file-only']);
         // Relative catalogue URLs are resolved to absolute so the client's links work.
         expect(res.body.data.resources[0].url).toBe('https://open.canada.ca/u');
     });

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -3,10 +3,31 @@ const { sources, getSource } = require('../config/catalogSources');
 describe('configured municipal catalogue sources', () => {
     test('syncs city portals before the authoritative portal in each regional cluster', () => {
         expect(sources.map(source => source.id)).toEqual([
-            'toronto-open-data', 'montreal-open-data', 'ottawa-hub',
+            'toronto-open-data', 'montreal-open-data', 'ottawa-hub', 'vancouver-open-data',
             'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
             'mississauga-hub', 'brampton-hub', 'peel-hub'
         ]);
+    });
+
+    test('configures Vancouver as a record-licensed Opendatasoft city source', () => {
+        const vancouver = getSource('vancouver-open-data');
+        expect(vancouver).toEqual(expect.objectContaining({
+            kind: 'opendatasoft', metadataLanguage: 'en',
+            licenseMode: 'record-explicit', timezone: 'America/Vancouver',
+            upstreamHost: 'opendata.vancouver.ca'
+        }));
+        expect(vancouver.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            licenseTitle: expect.any(RegExp),
+            licenseUrl: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://opendata.vancouver.ca/pages/licence/'
+            })
+        })]);
+        expect(vancouver.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-5915022', relationship: 'direct',
+            includesDescendants: false
+        })]);
     });
 
     test('configures Ottawa as a canonical city with Police licence precedence', () => {

--- a/server/__tests__/ingestApi.test.js
+++ b/server/__tests__/ingestApi.test.js
@@ -120,6 +120,19 @@ describe('ingest API', () => {
         expect(res.body.download_url).toBe('https://example.org/y.pdf');
     });
 
+    it('keeps a CSV with a known upstream row count over the cap download-only', async () => {
+        queries.getResourceById.mockResolvedValue(makeRow({
+            id: 'large-csv',
+            raw: { provider: 'opendatasoft', record_count: 1_000_001 }
+        }));
+
+        const res = await request(app).post('/api/v1/resources/large-csv/ingest');
+
+        expect(res.status).toBe(422);
+        expect(res.body.download_url).toBe('https://example.org/file.csv');
+        expect(ingestQueries.enqueueJob).not.toHaveBeenCalled();
+    });
+
     it('job polling returns the job', async () => {
         ingestQueries.getJobById.mockResolvedValue({ id: 7, resource_id: 'csv-1', status: 'done', attempts: 1, error: null, claimed_at: '2026-01-01', finished_at: '2026-01-01', created_at: '2026-01-01' });
         const res = await request(app).get('/api/v1/jobs/7');

--- a/server/__tests__/mapIndexQueries.test.js
+++ b/server/__tests__/mapIndexQueries.test.js
@@ -50,6 +50,7 @@ describe('versioned map-index queue', () => {
         expect(db.query.mock.calls[0][1]).toEqual([3]);
         expect(db.query.mock.calls[1][0]).toContain('FOR UPDATE SKIP LOCKED');
         expect(db.query.mock.calls[1][0]).toContain("candidate->>'expectedBytes'");
+        expect(db.query.mock.calls[1][0]).toContain("candidate->>'expectedRows'");
         expect(db.query.mock.calls[1][0]).toContain('NULLS LAST');
     });
 

--- a/server/__tests__/mapWorker.test.js
+++ b/server/__tests__/mapWorker.test.js
@@ -22,6 +22,8 @@ jest.mock('../db/mapIndexQueries', () => ({
 const pool = require('../db/pool');
 const mapQueries = require('../db/mapIndexQueries');
 const { MapSkipError } = require('../services/mapIndexPipeline');
+const { getSource } = require('../config/catalogSources');
+const { exportUrl } = require('../services/opendatasoftAdapter');
 const { processJob, validateDirectGeoJson } = require('../scripts/map-worker');
 
 const resource = {
@@ -87,6 +89,85 @@ describe('map worker transitions', () => {
         expect(() => validateDirectGeoJson(directResource, {
             sourceUrl: 'https://attacker.example/map.geojson'
         })).toThrow(MapSkipError);
+    });
+
+    test('reconstructs the Opendatasoft GeoJSON export instead of trusting the candidate URL', async () => {
+        const source = getSource('vancouver-open-data');
+        const upstreamId = 'public-trees';
+        const csvUrl = exportUrl(source, upstreamId, 'csv');
+        const geoJsonUrl = exportUrl(source, upstreamId, 'geojson');
+        const directResource = {
+            id: 'r-vancouver', url: csvUrl, format: 'CSV', datastore_active: false,
+            raw: {
+                provider: 'opendatasoft', source_id: source.id,
+                upstream_dataset_id: upstreamId, dataset_uid: 'da_trees',
+                original_format: 'CSV'
+            }
+        };
+        const candidate = {
+            mode: 'geojson-file', sourceUrl: geoJsonUrl, expectedRows: 42,
+            raw: {
+                provider: 'opendatasoft', source_id: source.id,
+                upstream_dataset_id: upstreamId, dataset_uid: 'da_trees'
+            }
+        };
+        const directJob = { ...job, resource_id: directResource.id, candidate };
+        const probe = jest.fn();
+        const index = jest.fn().mockResolvedValue({ queueStatus: 'ready', featureCount: 1, vertexCount: 1 });
+
+        await processJob(directJob, '00000000-0000-4000-8000-000000000001', {
+            getResourceById: async () => directResource,
+            probeGeometry: probe,
+            indexMapResource: index,
+            validateDirectGeoJson
+        });
+
+        expect(probe).not.toHaveBeenCalled();
+        expect(index).toHaveBeenCalledWith(
+            expect.objectContaining({ id: directResource.id, url: geoJsonUrl }),
+            directJob,
+            '00000000-0000-4000-8000-000000000001',
+            undefined
+        );
+        expect(csvUrl).not.toBe(geoJsonUrl);
+    });
+
+    test('skips a mismatched Opendatasoft map URL before invoking the downloader', async () => {
+        const source = getSource('vancouver-open-data');
+        const upstreamId = 'public-trees';
+        const directResource = {
+            id: 'r-vancouver-bad', url: exportUrl(source, upstreamId, 'csv'),
+            format: 'CSV', datastore_active: false,
+            raw: {
+                provider: 'opendatasoft', source_id: source.id,
+                upstream_dataset_id: upstreamId, original_format: 'CSV'
+            }
+        };
+        const directJob = {
+            ...job,
+            resource_id: directResource.id,
+            candidate: {
+                mode: 'geojson-file', sourceUrl: 'https://attacker.example/map.geojson',
+                raw: {
+                    provider: 'opendatasoft', source_id: source.id,
+                    upstream_dataset_id: upstreamId
+                }
+            }
+        };
+        const index = jest.fn();
+
+        await processJob(directJob, '00000000-0000-4000-8000-000000000001', {
+            getResourceById: async () => directResource,
+            indexMapResource: index,
+            validateDirectGeoJson
+        });
+
+        expect(index).not.toHaveBeenCalled();
+        expect(mapQueries.finishJob).toHaveBeenCalledWith(
+            pool, directJob, expect.any(String), 'skipped', {},
+            expect.stringContaining('MAP_SOURCE')
+        );
+        expect(mapQueries.requeueJob).not.toHaveBeenCalled();
     });
 
     test('retries transient failures and marks the third attempt failed', async () => {

--- a/server/__tests__/opendatasoftAdapter.test.js
+++ b/server/__tests__/opendatasoftAdapter.test.js
@@ -1,0 +1,173 @@
+const {
+    discover,
+    enrichRecord,
+    exportUrl,
+    directMapVersion
+} = require('../services/opendatasoftAdapter');
+const { getSource } = require('../config/catalogSources');
+
+const source = getSource('vancouver-open-data');
+
+function makeRecord(overrides = {}) {
+    const defaults = {
+        title: 'Public trees',
+        description: '<p>Tree locations<br>updated daily.</p>',
+        theme: ['Geographic data'],
+        keyword: ['trees', 'parks'],
+        license: 'Open Government Licence - Vancouver',
+        license_url: 'https://opendata.vancouver.ca/pages/licence/',
+        publisher: 'City of Vancouver',
+        modified: '2026-08-20T12:00:00+00:00',
+        data_processed: '2026-08-25T14:07:12+00:00',
+        geometry_types: ['Point'],
+        records_count: 42
+    };
+    const record = {
+        visibility: 'domain',
+        fields: [
+            { name: 'tree_id', label: 'Tree ID', type: 'int' },
+            { name: 'geom', label: 'Geometry', type: 'geo_point_2d' }
+        ],
+        dataset_id: 'public-trees',
+        dataset_uid: 'da_trees',
+        has_records: true,
+        features: ['analyze', 'geo'],
+        data_visible: true,
+        metas: { default: defaults }
+    };
+    const merged = { ...record, ...overrides };
+    merged.metas = {
+        ...record.metas,
+        ...(overrides.metas || {}),
+        default: { ...defaults, ...(overrides.metas && overrides.metas.default || {}) }
+    };
+    return merged;
+}
+
+describe('Opendatasoft catalogue adapter', () => {
+    test('discovers every advertised record in stable id order', async () => {
+        const all = Array.from({ length: 201 }, (_, index) => ({
+            dataset_id: 'dataset-' + String(index).padStart(3, '0')
+        }));
+        const fetchJson = jest.fn(async value => {
+            const url = new URL(value);
+            const offset = Number(url.searchParams.get('offset'));
+            expect(url.pathname).toBe('/api/explore/v2.1/catalog/datasets');
+            expect(url.searchParams.get('limit')).toBe('100');
+            expect(url.searchParams.get('order_by')).toBe('dataset_id');
+            return { total_count: all.length, results: all.slice(offset, offset + 100) };
+        });
+
+        await expect(discover(source, { fetchJson })).resolves.toEqual(all);
+        expect(fetchJson).toHaveBeenCalledTimes(3);
+    });
+
+    test('fails closed on count drift, truncation, duplicate ids, and empty catalogues', async () => {
+        const page = Array.from({ length: 100 }, (_, index) => ({ dataset_id: 'd-' + index }));
+        await expect(discover(source, { fetchJson: jest.fn()
+            .mockResolvedValueOnce({ total_count: 101, results: page })
+            .mockResolvedValueOnce({ total_count: 102, results: [{ dataset_id: 'last' }] })
+        })).rejects.toThrow(/count changed/);
+
+        await expect(discover(source, { fetchJson: async () => ({
+            total_count: 2, results: [{ dataset_id: 'only-one' }]
+        }) })).rejects.toThrow(/ended before/);
+
+        await expect(discover(source, { fetchJson: async () => ({
+            total_count: 2, results: [{ dataset_id: 'same' }, { dataset_id: 'same' }]
+        }) })).rejects.toThrow(/duplicate dataset id/);
+
+        await expect(discover(source, { fetchJson: async () => ({
+            total_count: 0, results: []
+        }) })).rejects.toThrow(/empty catalogue/);
+    });
+
+    test('normalizes a licensed city record into one loadable CSV and one bounded map candidate', async () => {
+        const record = makeRecord();
+        const result = await enrichRecord(record, source);
+
+        expect(result.status).toBe('included');
+        expect(result.value).toEqual(expect.objectContaining({
+            externalId: 'public-trees',
+            organization: expect.objectContaining({
+                id: 'opendatasoft-vancouver-open-data-org-city-of-vancouver',
+                titleEn: 'City of Vancouver',
+                titleFr: 'Ville de Vancouver',
+                placeId: 'sgc-csd-5915022'
+            }),
+            dataset: expect.objectContaining({
+                id: 'opendatasoft-vancouver-open-data-dataset-public-trees',
+                titleEn: 'Public trees',
+                notesEn: 'Tree locations\nupdated daily.',
+                keywordsEn: ['Geographic data', 'trees', 'parks']
+            }),
+            source: expect.objectContaining({
+                isAuthoritative: true,
+                licenseUrl: 'https://opendata.vancouver.ca/pages/licence/',
+                landingUrl: 'https://opendata.vancouver.ca/explore/dataset/public-trees/information/'
+            }),
+            places: [expect.objectContaining({
+                placeId: 'sgc-csd-5915022', relationship: 'direct', includesDescendants: false
+            })],
+            manageMaps: false,
+            manageMapCandidates: true
+        }));
+        expect(result.value.resources).toEqual([expect.objectContaining({
+            id: 'opendatasoft-vancouver-open-data-resource-public-trees',
+            format: 'CSV', datastoreActive: false, sizeBytes: null,
+            url: 'https://opendata.vancouver.ca/api/explore/v2.1/catalog/datasets/public-trees/exports/csv' +
+                '?lang=en&timezone=America%2FVancouver&use_labels=false&delimiter=%2C',
+            raw: expect.objectContaining({
+                provider: 'opendatasoft', record_count: 42, field_count: 2
+            })
+        })]);
+        expect(result.value.mapCandidates).toEqual([expect.objectContaining({
+            resourceId: 'opendatasoft-vancouver-open-data-resource-public-trees',
+            mode: 'geojson-file', expectedRows: 42,
+            sourceUrl: 'https://opendata.vancouver.ca/api/explore/v2.1/catalog/datasets/public-trees/exports/geojson' +
+                '?lang=en&timezone=America%2FVancouver',
+            desiredVersion: expect.stringMatching(/^[0-9a-f]{64}$/)
+        })]);
+        expect(result.value.resources[0].url).not.toBe(result.value.mapCandidates[0].sourceUrl);
+    });
+
+    test('uses the configured City publisher only when record metadata omits it', async () => {
+        const record = makeRecord({ metas: { default: { publisher: null } } });
+        const result = await enrichRecord(record, source);
+        expect(result.status).toBe('included');
+        expect(result.value.source.raw).toEqual(expect.objectContaining({
+            publisher: 'City of Vancouver', supplied_publisher: null
+        }));
+    });
+
+    test.each([
+        [{ has_records: false }, 'not-loadable'],
+        [{ data_visible: false }, 'not-public'],
+        [{ metas: { default: { license: null } } }, 'unlicensed'],
+        [{ metas: { default: { license_url: 'https://example.test/terms' } } }, 'unlicensed'],
+        [{ metas: { default: { publisher: 'External Publisher' } } }, 'publisher-not-admitted']
+    ])('excludes ineligible records with a stable reason', async (overrides, reason) => {
+        await expect(enrichRecord(makeRecord(overrides), source)).resolves.toEqual(expect.objectContaining({
+            status: 'excluded', reason
+        }));
+    });
+
+    test('requires both geo capability and a declared geometry type for map admission', async () => {
+        const result = await enrichRecord(makeRecord({
+            metas: { default: { geometry_types: null } }
+        }), source);
+        expect(result.value.mapCandidates).toEqual([]);
+    });
+
+    test('export URLs and map versions are deterministic and source-bound', () => {
+        const record = makeRecord();
+        expect(exportUrl(source, 'public trees', 'geojson')).toBe(
+            'https://opendata.vancouver.ca/api/explore/v2.1/catalog/datasets/public%20trees/exports/geojson' +
+            '?lang=en&timezone=America%2FVancouver'
+        );
+        expect(directMapVersion(record, source)).toBe(directMapVersion(record, source));
+        expect(directMapVersion(record, source)).not.toBe(directMapVersion(makeRecord({
+            metas: { default: { records_count: 43 } }
+        }), source));
+    });
+});

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -189,4 +189,45 @@ spatialDescribe('PostGIS viewport integration', () => {
             { slug: 'montreal-qc-2466023', place_id: 'sgc-csd-2466023' }
         ]);
     });
+
+    test('migrations seed the canonical featured Vancouver ancestry', async () => {
+        const places = await client.query(`
+            SELECT id, slug, kind, parent_id, type_en, type_fr, featured,
+                   latitude, longitude, default_zoom
+            FROM places
+            WHERE id IN ('sgc-pr-59', 'sgc-cd-5915', 'sgc-csd-5915022')
+            ORDER BY CASE id
+                WHEN 'sgc-pr-59' THEN 1
+                WHEN 'sgc-cd-5915' THEN 2
+                ELSE 3
+            END
+        `);
+        expect(places.rows).toEqual([
+            expect.objectContaining({
+                id: 'sgc-pr-59', slug: 'british-columbia', kind: 'province',
+                parent_id: 'ca', featured: false
+            }),
+            expect.objectContaining({
+                id: 'sgc-cd-5915', slug: 'greater-vancouver-bc', kind: 'region',
+                parent_id: 'sgc-pr-59', featured: false
+            }),
+            expect.objectContaining({
+                id: 'sgc-csd-5915022', slug: 'vancouver-bc', kind: 'municipality',
+                parent_id: 'sgc-cd-5915', type_en: 'City', type_fr: 'Ville',
+                featured: true, latitude: 49.2827, longitude: -123.1207,
+                default_zoom: 10
+            })
+        ]);
+
+        const identifiers = await client.query(`
+            SELECT place_id, scheme, value FROM place_identifiers
+            WHERE place_id IN ('sgc-pr-59', 'sgc-cd-5915', 'sgc-csd-5915022')
+            ORDER BY place_id
+        `);
+        expect(identifiers.rows).toEqual([
+            { place_id: 'sgc-cd-5915', scheme: 'sgc-cd', value: '5915' },
+            { place_id: 'sgc-csd-5915022', scheme: 'sgc-csd', value: '5915022' },
+            { place_id: 'sgc-pr-59', scheme: 'sgc-pr', value: '59' }
+        ]);
+    });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -125,6 +125,32 @@ describe('Statistics Canada SGC place normalization', () => {
         }));
     });
 
+    test('features Vancouver as a canonical city beneath Greater Vancouver', () => {
+        const en = [
+            { Level: '2', Code: '59', 'Class title': 'British Columbia' },
+            { Level: '3', Code: '5915', 'Class title': 'Greater Vancouver' },
+            { Level: '4', Code: '5915022', 'Class title': 'Vancouver' }
+        ];
+        const fr = [
+            { Code: '59', 'Titres de classes': 'Colombie-Britannique' },
+            { Code: '5915', 'Titres de classes': 'Greater Vancouver' },
+            { Code: '5915022', 'Titres de classes': 'Vancouver' }
+        ];
+        const result = normalize(en, fr);
+
+        expect(result.places.find(place => place.id === 'sgc-pr-59')).toEqual(expect.objectContaining({
+            slug: 'british-columbia', parentId: 'ca', featured: false
+        }));
+        expect(result.places.find(place => place.id === 'sgc-cd-5915')).toEqual(expect.objectContaining({
+            slug: 'greater-vancouver-bc', kind: 'region', parentId: 'sgc-pr-59', featured: false
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-5915022')).toEqual(expect.objectContaining({
+            slug: 'vancouver-bc', kind: 'municipality', parentId: 'sgc-cd-5915',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 49.2827, longitude: -123.1207, defaultZoom: 10
+        }));
+    });
+
     test('plans former-slug aliases and fails closed on ownership conflicts', async () => {
         const desired = [{ id: 'p1', slug: 'montreal-qc', nameEn: 'Montréal' }];
         const db = { query: jest.fn()

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -78,6 +78,14 @@ const OTTAWA_POLICE_LICENSE = {
     attributionFr: 'Contient de l’information visée par la Licence du gouvernement ouvert – Service de police d’Ottawa.'
 };
 
+const VANCOUVER_LICENSE = {
+    titleEn: 'Open Government Licence – Vancouver',
+    titleFr: 'Licence du gouvernement ouvert – Vancouver',
+    url: 'https://opendata.vancouver.ca/pages/licence/',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Vancouver.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Vancouver.'
+};
+
 const MISSISSAUGA_LICENSE = {
     titleEn: 'City of Mississauga Open Data Terms of Use',
     titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Mississauga',
@@ -223,6 +231,42 @@ const sources = [{
     placeRules: [{
         publisher: /^city of ottawa$/i,
         placeId: 'sgc-cd-3506',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'vancouver-open-data',
+    kind: 'opendatasoft',
+    nameEn: 'City of Vancouver Open Data',
+    nameFr: 'Données ouvertes de la Ville de Vancouver',
+    homepageUrl: 'https://opendata.vancouver.ca/',
+    catalogUrl: 'https://opendata.vancouver.ca/api/explore/v2.1',
+    upstreamHost: 'opendata.vancouver.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'en',
+    timezone: 'America/Vancouver',
+    defaultOrganizationId: 'city-of-vancouver',
+    defaultOrganizationName: 'city-of-vancouver',
+    defaultOrganizationTitleEn: 'City of Vancouver',
+    defaultOrganizationTitleFr: 'Ville de Vancouver',
+    defaultLicenseTitleEn: VANCOUVER_LICENSE.titleEn,
+    defaultLicenseTitleFr: VANCOUVER_LICENSE.titleFr,
+    defaultLicenseUrl: VANCOUVER_LICENSE.url,
+    defaultAttributionEn: VANCOUVER_LICENSE.attributionEn,
+    defaultAttributionFr: VANCOUVER_LICENSE.attributionFr,
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^city of vancouver$/i }],
+    licenseRules: [{
+        publisher: /^city of vancouver$/i,
+        licenseTitle: /^open government licence\s*[-–]\s*vancouver$/i,
+        licenseUrl: /^https:\/\/opendata\.vancouver\.ca\/pages\/licence\/?$/i,
+        license: VANCOUVER_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^city of vancouver$/i,
+        placeId: 'sgc-csd-5915022',
         relationship: 'direct',
         includesDescendants: false
     }]
@@ -477,6 +521,7 @@ module.exports = {
     TORONTO_LICENSE,
     OTTAWA_LICENSE,
     OTTAWA_POLICE_LICENSE,
+    VANCOUVER_LICENSE,
     MISSISSAUGA_LICENSE,
     CC_BY_4_LICENSE,
     OGL_CANADA_LICENSE,

--- a/server/db/mapIndexQueries.js
+++ b/server/db/mapIndexQueries.js
@@ -150,6 +150,11 @@ async function claimJob(db, workerId) {
                         THEN (candidate->>'expectedBytes')::numeric
                     ELSE NULL
                 END NULLS LAST,
+                CASE
+                    WHEN candidate->>'expectedRows' ~ '^[0-9]+$'
+                        THEN (candidate->>'expectedRows')::numeric
+                    ELSE NULL
+                END NULLS LAST,
                 updated_at, resource_id
             LIMIT 1 FOR UPDATE SKIP LOCKED
         )

--- a/server/scripts/map-worker.js
+++ b/server/scripts/map-worker.js
@@ -6,6 +6,7 @@ const longRunningPool = require('../db/longRunningPool');
 const { getResourceById } = require('../db/catalogReadQueries');
 const { datastoreSearch } = require('../services/ckanClient');
 const { getSource } = require('../config/catalogSources');
+const { exportUrl: opendatasoftExportUrl } = require('../services/opendatasoftAdapter');
 const {
     MapSkipError,
     indexMapResource,
@@ -71,15 +72,33 @@ function ckanTarget(resource) {
 }
 
 function validateDirectGeoJson(resource, candidate) {
-    ckanTarget(resource);
     const raw = resource && resource.raw && typeof resource.raw === 'object' ? resource.raw : {};
+    const source = getSource(raw.source_id);
+    if (source && source.kind === 'opendatasoft') {
+        const candidateRaw = candidate && candidate.raw && typeof candidate.raw === 'object'
+            ? candidate.raw : {};
+        if (raw.provider !== 'opendatasoft' || !raw.upstream_dataset_id ||
+            resource.datastore_active === true || String(resource.format || '').toUpperCase() !== 'CSV') {
+            throw new MapSkipError('direct map candidate is not a catalogued Opendatasoft export', 'MAP_SOURCE');
+        }
+        const expectedCsvUrl = opendatasoftExportUrl(source, raw.upstream_dataset_id, 'csv');
+        const expectedGeoJsonUrl = opendatasoftExportUrl(source, raw.upstream_dataset_id, 'geojson');
+        if (resource.url !== expectedCsvUrl || candidate.sourceUrl !== expectedGeoJsonUrl ||
+            candidateRaw.provider !== 'opendatasoft' || candidateRaw.source_id !== raw.source_id ||
+            candidateRaw.upstream_dataset_id !== raw.upstream_dataset_id) {
+            throw new MapSkipError('Opendatasoft map candidate differs from its catalogued exports', 'MAP_SOURCE');
+        }
+        return expectedGeoJsonUrl;
+    }
+
+    ckanTarget(resource);
     if (resource.datastore_active === true || String(raw.original_format || '').toUpperCase() !== 'GEOJSON') {
         throw new MapSkipError('direct map candidate is not a catalogued GeoJSON file', 'MAP_SOURCE');
     }
     if (!resource.url || (candidate.sourceUrl && candidate.sourceUrl !== resource.url)) {
         throw new MapSkipError('direct map candidate URL differs from the catalogued resource', 'MAP_SOURCE');
     }
-    return true;
+    return resource.url;
 }
 
 async function probeGeometry(resource) {
@@ -121,6 +140,7 @@ async function processJob(job, workerId, options = {}) {
         }
         const mode = candidateMode(job.candidate || {});
         let expectedRows = null;
+        let downloadUrl = resource.url;
         if (mode === 'ckan-datastore-csv') {
             const probe = await (options.probeGeometry || probeGeometry)(resource);
             expectedRows = probe.total;
@@ -128,11 +148,18 @@ async function processJob(job, workerId, options = {}) {
                 throw new MapSkipError('DataStore row count exceeds map cap', 'MAP_ROWS');
             }
         } else {
-            (options.validateDirectGeoJson || validateDirectGeoJson)(resource, job.candidate || {});
+            downloadUrl = (options.validateDirectGeoJson || validateDirectGeoJson)(
+                resource, job.candidate || {}
+            ) || resource.url;
         }
         console.log('[map ' + job.resource_id + '] indexing attempt ' + job.attempts +
             ' (' + mode + (expectedRows == null ? '' : ', ' + expectedRows + ' rows') + ')');
-        const result = await (options.indexMapResource || indexMapResource)(resource, job, workerId, options.caps);
+        const result = await (options.indexMapResource || indexMapResource)(
+            downloadUrl === resource.url ? resource : { ...resource, url: downloadUrl },
+            job,
+            workerId,
+            options.caps
+        );
         console.log('[map ' + job.resource_id + '] ' + result.queueStatus + ': ' + result.featureCount +
             ' features, ' + result.vertexCount + ' vertices');
         return result;

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -26,7 +26,8 @@ const FEATURED_PLACE_IDS = new Set([
     'sgc-csd-3521005',
     'sgc-csd-3521010',
     'sgc-csd-3521024',
-    'sgc-csd-2466023'
+    'sgc-csd-2466023',
+    'sgc-csd-5915022'
 ]);
 const MUNICIPAL_TYPES = {
     '2466023': ['City', 'Ville'],
@@ -40,7 +41,8 @@ const MUNICIPAL_TYPES = {
     '3518009': ['Town', 'Ville'],
     '3521005': ['City', 'Ville'],
     '3521010': ['City', 'Ville'],
-    '3521024': ['Town', 'Ville']
+    '3521024': ['Town', 'Ville'],
+    '5915022': ['City', 'Ville']
 };
 const PLACE_VIEWPORTS = {
     '2466023': [45.5019, -73.5674, 10],
@@ -51,7 +53,8 @@ const PLACE_VIEWPORTS = {
     '3521': [43.7500, -79.7800, 9],
     '3521005': [43.5890, -79.6440, 10],
     '3521010': [43.7315, -79.7624, 10],
-    '3521024': [43.8668, -79.8670, 9]
+    '3521024': [43.8668, -79.8670, 9],
+    '5915022': [49.2827, -123.1207, 10]
 };
 
 function slugify(value) {

--- a/server/services/catalogService.js
+++ b/server/services/catalogService.js
@@ -8,6 +8,7 @@ const { sources: configuredSources } = require('../config/catalogSources');
 
 const MAX_FILE_MB = Number(process.env.MAX_FILE_MB) || 50;
 const MAX_XLSX_MB = Number(process.env.MAX_XLSX_MB) || 20;
+const MAX_ROWS = Number(process.env.MAX_ROWS) > 0 ? Number(process.env.MAX_ROWS) : 1_000_000;
 
 const maxFileBytes = () => MAX_FILE_MB * 1024 * 1024;
 
@@ -15,9 +16,26 @@ const maxFileBytes = () => MAX_FILE_MB * 1024 * 1024;
 // but XLSX shared strings/styles and legacy XLS parsing still expand in memory
 // inside that child process.
 const ingestCapBytesFor = (format) => {
-    if (format === 'CSV') return maxFileBytes();
-    if (format === 'XLSX' || format === 'XLS') return MAX_XLSX_MB * 1024 * 1024;
+    const normalized = String(format || '').toUpperCase();
+    if (normalized === 'CSV') return maxFileBytes();
+    if (normalized === 'XLSX' || normalized === 'XLS') return MAX_XLSX_MB * 1024 * 1024;
     return null;
+};
+
+const knownRecordCount = (row) => {
+    const raw = row && row.raw && typeof row.raw === 'object' && !Array.isArray(row.raw)
+        ? row.raw : {};
+    if (raw.record_count == null || raw.record_count === '') return null;
+    const count = Number(raw.record_count);
+    return Number.isFinite(count) && count >= 0 ? count : null;
+};
+
+const isIngestableFile = (row) => {
+    const cap = ingestCapBytesFor(row && row.format);
+    const recordCount = knownRecordCount(row);
+    return cap !== null &&
+        (row.size_bytes == null || Number(row.size_bytes) <= cap) &&
+        (recordCount == null || recordCount <= MAX_ROWS);
 };
 
 const clampLimit = (limit, def, max) => {
@@ -95,8 +113,7 @@ const shapePlaceMatch = (row) => row.matched_place_id ? {
 const computeQueryMode = (row) => {
     if (row.ingest_status === 'ready') return 'ingested';
     if (row.datastore_active) return 'datastore';
-    const cap = ingestCapBytesFor(row.format);
-    if (cap !== null && (row.size_bytes == null || Number(row.size_bytes) <= cap)) return 'ingestable';
+    if (isIngestableFile(row)) return 'ingestable';
     return 'file-only';
 };
 
@@ -455,6 +472,8 @@ module.exports = {
     healthz,
     computeQueryMode,
     ingestCapBytesFor,
+    knownRecordCount,
+    isIngestableFile,
     recentlyUnlocked,
     popularResources,
     opsStatus,

--- a/server/services/ingestService.js
+++ b/server/services/ingestService.js
@@ -1,13 +1,8 @@
 const { getResourceById } = require('../db/catalogReadQueries');
-const { computeQueryMode, ingestCapBytesFor } = require('./catalogService');
+const { computeQueryMode, isIngestableFile } = require('./catalogService');
 const { enqueueJob, getJobById } = require('../db/ingestQueries');
 const AppError = require('../utils/AppError');
 const { toAbsoluteUrl } = require('../utils/resolveUrl');
-
-function isIngestableFile(row) {
-    const cap = ingestCapBytesFor(row.format);
-    return cap !== null && (row.size_bytes == null || Number(row.size_bytes) <= cap);
-}
 
 async function enqueueIngest(resourceId) {
     const row = await getResourceById(resourceId);
@@ -38,7 +33,7 @@ async function enqueueIngest(resourceId) {
     // can actually load (CSV/XLSX/XLS under the size cap); otherwise it is a
     // plain download, same as a file-only resource.
     if (mode === 'file-only' || (mode === 'datastore' && !isIngestableFile(row))) {
-        const err = new AppError('Only CSV, XLSX or XLS resources under the size cap can be ingested', 422);
+        const err = new AppError('Only CSV, XLSX or XLS resources under the configured size and row caps can be ingested', 422);
         err.download_url = toAbsoluteUrl(row.url);
         throw err;
     }

--- a/server/services/opendatasoftAdapter.js
+++ b/server/services/opendatasoftAdapter.js
@@ -1,0 +1,360 @@
+const crypto = require('node:crypto');
+const { fetchPublicJson } = require('./publicJson');
+
+const PAGE_SIZE = 100;
+const DIRECT_GEOJSON_VERSION = 'opendatasoft-geojson-v1';
+
+function clean(value) {
+    return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+}
+
+function array(value) {
+    if (Array.isArray(value)) return value;
+    return value == null ? [] : [value];
+}
+
+function timestamp(value) {
+    if (value == null || value === '') return null;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function decodeEntities(value) {
+    return value
+        .replace(/&#(\d+);/g, (_, number) => String.fromCodePoint(Number(number)))
+        .replace(/&#x([0-9a-f]+);/gi, (_, number) => String.fromCodePoint(parseInt(number, 16)))
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&amp;/gi, '&')
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;|&apos;/gi, "'");
+}
+
+function htmlToText(value) {
+    const text = String(value == null ? '' : value)
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+        .replace(/<br\s*\/?>|<\/p>|<\/div>|<\/li>/gi, '\n')
+        .replace(/<[^>]+>/g, ' ');
+    return decodeEntities(text).replace(/[ \t]+/g, ' ').replace(/\s*\n\s*/g, '\n').trim();
+}
+
+function patternMatches(pattern, value) {
+    if (!pattern) return true;
+    if (pattern instanceof RegExp) {
+        pattern.lastIndex = 0;
+        return pattern.test(clean(value));
+    }
+    return clean(pattern).toLowerCase() === clean(value).toLowerCase();
+}
+
+function finiteNonNegative(value) {
+    if (value == null || value === '') return null;
+    const number = Number(value);
+    return Number.isFinite(number) && number >= 0 ? number : null;
+}
+
+function namespace(sourceId, kind, upstreamId) {
+    return ['opendatasoft', sourceId, kind, clean(upstreamId).toLowerCase()].join('-');
+}
+
+function identityFor(record) {
+    return clean(record && record.dataset_id) || null;
+}
+
+function canonicalKey(identity) {
+    return clean(identity).toLowerCase();
+}
+
+function metadataFor(record) {
+    const metas = record && record.metas;
+    return metas && typeof metas.default === 'object' && metas.default ? metas.default : {};
+}
+
+function publisherName(record, source) {
+    const metadata = metadataFor(record);
+    return clean(metadata.publisher) || clean(source.defaultOrganizationTitleEn) ||
+        clean(source.nameEn) || 'Publisher';
+}
+
+function authoritativePublisher(source, publisher) {
+    if (!Array.isArray(source.authoritativePublishers)) return true;
+    return source.authoritativePublishers.some(rule => patternMatches(rule.publisher, publisher));
+}
+
+function placeRuleFor(source, publisher) {
+    const rules = Array.isArray(source.placeRules) ? source.placeRules : [];
+    const matched = rules.find(rule => patternMatches(rule.publisher, publisher));
+    if (matched) return matched;
+    if (!source.placeId) return null;
+    return {
+        placeId: source.placeId,
+        relationship: 'direct',
+        includesDescendants: false
+    };
+}
+
+function configuredLicense(source) {
+    if (!source.defaultLicenseUrl) return null;
+    return {
+        titleEn: source.defaultLicenseTitleEn || null,
+        titleFr: source.defaultLicenseTitleFr || null,
+        url: source.defaultLicenseUrl,
+        attributionEn: source.defaultAttributionEn || null,
+        attributionFr: source.defaultAttributionFr || null
+    };
+}
+
+function licenseFor(record, source, publisher = publisherName(record, source)) {
+    const metadata = metadataFor(record);
+    const rules = Array.isArray(source.licenseRules) ? source.licenseRules : [];
+    if (rules.length) {
+        const matched = rules.find(rule =>
+            patternMatches(rule.publisher, publisher) &&
+            patternMatches(rule.licenseTitle, metadata.license) &&
+            patternMatches(rule.licenseUrl, metadata.license_url)
+        );
+        return matched ? matched.license : null;
+    }
+    return source.licenseMode === 'record-explicit' ? null : configuredLicense(source);
+}
+
+function exportUrl(source, datasetId, format) {
+    const normalizedFormat = clean(format).toLowerCase();
+    if (!['csv', 'geojson'].includes(normalizedFormat)) {
+        throw new Error('unsupported Opendatasoft export format: ' + format);
+    }
+    const url = new URL(
+        source.catalogUrl.replace(/\/+$/, '') + '/catalog/datasets/' +
+        encodeURIComponent(clean(datasetId)) + '/exports/' + normalizedFormat
+    );
+    url.searchParams.set('lang', source.metadataLanguage === 'fr' ? 'fr' : 'en');
+    url.searchParams.set('timezone', source.timezone || 'UTC');
+    if (normalizedFormat === 'csv') {
+        url.searchParams.set('use_labels', 'false');
+        url.searchParams.set('delimiter', ',');
+    }
+    return url.href;
+}
+
+function directMapVersion(record, source) {
+    const metadata = metadataFor(record);
+    const fields = array(record && record.fields).map(field => ({
+        name: clean(field && field.name),
+        type: clean(field && field.type)
+    }));
+    const identity = [
+        DIRECT_GEOJSON_VERSION,
+        source.id,
+        identityFor(record),
+        clean(record && record.dataset_uid) || null,
+        timestamp(metadata.data_processed || metadata.modified),
+        finiteNonNegative(metadata.records_count),
+        fields,
+        array(metadata.geometry_types).map(clean),
+        exportUrl(source, identityFor(record), 'geojson')
+    ];
+    return crypto.createHash('sha256').update(JSON.stringify(identity)).digest('hex');
+}
+
+async function discover(source, options = {}) {
+    const fetchJson = options.fetchJson || fetchPublicJson;
+    const records = [];
+    const identities = new Set();
+    let expectedTotal = null;
+
+    for (let offset = 0; expectedTotal == null || offset < expectedTotal; offset += PAGE_SIZE) {
+        const url = new URL(source.catalogUrl.replace(/\/+$/, '') + '/catalog/datasets');
+        url.searchParams.set('limit', String(PAGE_SIZE));
+        url.searchParams.set('offset', String(offset));
+        url.searchParams.set('order_by', 'dataset_id');
+        const body = await fetchJson(url.href, options.http);
+        const total = Number(body && body.total_count);
+        const page = body && body.results;
+        if (!Number.isInteger(total) || total < 0 || !Array.isArray(page)) {
+            throw new Error('Opendatasoft source returned an invalid catalogue response');
+        }
+        if (expectedTotal == null) expectedTotal = total;
+        if (total !== expectedTotal) {
+            throw new Error('Opendatasoft source catalogue count changed during pagination');
+        }
+        const expectedPageSize = Math.min(PAGE_SIZE, expectedTotal - offset);
+        if (page.length !== expectedPageSize) {
+            throw new Error('Opendatasoft source catalogue ended before its advertised count');
+        }
+        for (const record of page) {
+            const identity = identityFor(record);
+            if (!identity) throw new Error('Opendatasoft source returned a record without a dataset id');
+            const key = canonicalKey(identity);
+            if (identities.has(key)) {
+                throw new Error('Opendatasoft source returned a duplicate dataset id: ' + identity);
+            }
+            identities.add(key);
+            records.push(record);
+        }
+    }
+
+    if (expectedTotal === 0 || records.length === 0) {
+        throw new Error('Opendatasoft source returned an empty catalogue');
+    }
+    if (records.length !== expectedTotal) {
+        throw new Error('Opendatasoft source catalogue count did not match its records');
+    }
+    return records;
+}
+
+async function enrichRecord(record, source) {
+    const externalId = identityFor(record);
+    const metadata = metadataFor(record);
+    const fields = array(record && record.fields).filter(field => clean(field && field.name));
+    if (!externalId || !clean(metadata.title)) {
+        return { status: 'excluded', reason: 'invalid-dataset', externalId };
+    }
+    if (record.visibility !== 'domain' || record.data_visible !== true) {
+        return { status: 'excluded', reason: 'not-public', externalId: canonicalKey(externalId) };
+    }
+    if (record.has_records !== true || fields.length === 0) {
+        return { status: 'excluded', reason: 'not-loadable', externalId: canonicalKey(externalId) };
+    }
+
+    const publisher = publisherName(record, source);
+    if (!authoritativePublisher(source, publisher)) {
+        return { status: 'excluded', reason: 'publisher-not-admitted', externalId: canonicalKey(externalId) };
+    }
+    const licence = licenseFor(record, source, publisher);
+    if (!licence || !licence.url) {
+        return { status: 'excluded', reason: 'unlicensed', externalId: canonicalKey(externalId) };
+    }
+
+    const datasetId = namespace(source.id, 'dataset', externalId);
+    const resourceId = namespace(source.id, 'resource', externalId);
+    const upstreamOrgId = source.defaultOrganizationId || 'publisher';
+    const orgId = namespace(source.id, 'org', upstreamOrgId);
+    const placeRule = placeRuleFor(source, publisher);
+    const keywords = Array.from(new Set(
+        array(metadata.theme).concat(array(metadata.keyword)).map(clean).filter(Boolean)
+    ));
+    const modified = timestamp(metadata.data_processed || metadata.modified);
+    const recordCount = finiteNonNegative(metadata.records_count);
+    const geometryTypes = array(metadata.geometry_types).map(clean).filter(Boolean);
+    const hasMap = array(record.features).map(clean).includes('geo') && geometryTypes.length > 0;
+    const csvUrl = exportUrl(source, externalId, 'csv');
+    const geoJsonUrl = hasMap ? exportUrl(source, externalId, 'geojson') : null;
+
+    return {
+        status: 'included',
+        value: {
+            externalId: canonicalKey(externalId),
+            organization: {
+                id: orgId,
+                name: source.id + '-' + (source.defaultOrganizationName || upstreamOrgId),
+                titleEn: source.defaultOrganizationTitleEn || publisher,
+                titleFr: source.defaultOrganizationTitleFr || null,
+                placeId: placeRule ? placeRule.placeId : null
+            },
+            dataset: {
+                id: datasetId,
+                name: source.id + '-' + canonicalKey(externalId),
+                titleEn: clean(metadata.title),
+                titleFr: null,
+                notesEn: htmlToText(metadata.description) || null,
+                notesFr: null,
+                orgId,
+                keywordsEn: keywords,
+                keywordsFr: [],
+                metadataModified: modified,
+                raw: {
+                    provider: 'opendatasoft',
+                    source_id: source.id,
+                    upstream_dataset_id: externalId,
+                    dataset_uid: clean(record.dataset_uid) || null,
+                    metadata_language: 'en'
+                }
+            },
+            source: {
+                sourceId: source.id,
+                externalId: canonicalKey(externalId),
+                datasetId,
+                landingUrl: source.homepageUrl.replace(/\/+$/, '') + '/explore/dataset/' +
+                    encodeURIComponent(externalId) + '/information/',
+                licenseTitleEn: licence.titleEn || null,
+                licenseTitleFr: licence.titleFr || null,
+                licenseUrl: licence.url,
+                attributionEn: licence.attributionEn || null,
+                attributionFr: licence.attributionFr || null,
+                isAuthoritative: true,
+                raw: {
+                    upstream_dataset_id: externalId,
+                    dataset_uid: clean(record.dataset_uid) || null,
+                    publisher,
+                    supplied_publisher: clean(metadata.publisher) || null,
+                    license_title: clean(metadata.license) || null,
+                    license_url: clean(metadata.license_url) || null
+                }
+            },
+            resources: [{
+                id: resourceId,
+                datasetId,
+                nameEn: clean(metadata.title),
+                nameFr: null,
+                format: 'CSV',
+                url: csvUrl,
+                sizeBytes: null,
+                datastoreActive: false,
+                language: 'en',
+                lastModified: modified,
+                raw: {
+                    provider: 'opendatasoft',
+                    source_id: source.id,
+                    upstream_dataset_id: externalId,
+                    dataset_uid: clean(record.dataset_uid) || null,
+                    original_format: 'CSV',
+                    record_count: recordCount,
+                    field_count: fields.length,
+                    data_processed: timestamp(metadata.data_processed)
+                }
+            }],
+            places: placeRule ? [{
+                datasetId,
+                placeId: placeRule.placeId,
+                relationship: placeRule.relationship,
+                includesDescendants: placeRule.includesDescendants === true,
+                assignmentMethod: 'source'
+            }] : [],
+            maps: [],
+            manageMaps: false,
+            manageMapCandidates: true,
+            mapCandidates: hasMap ? [{
+                resourceId,
+                desiredVersion: directMapVersion(record, source),
+                mode: 'geojson-file',
+                sourceUrl: geoJsonUrl,
+                expectedRows: recordCount,
+                expectedVertices: null,
+                expectedBytes: null,
+                raw: {
+                    provider: 'opendatasoft',
+                    source_id: source.id,
+                    upstream_dataset_id: externalId,
+                    dataset_uid: clean(record.dataset_uid) || null
+                }
+            }] : []
+        }
+    };
+}
+
+module.exports = {
+    PAGE_SIZE,
+    discover,
+    enrichRecord,
+    identityFor,
+    canonicalKey,
+    namespace,
+    exportUrl,
+    directMapVersion,
+    licenseFor,
+    authoritativePublisher,
+    placeRuleFor,
+    htmlToText
+};

--- a/server/services/sourceAdapters.js
+++ b/server/services/sourceAdapters.js
@@ -1,9 +1,11 @@
 const arcgisHub = require('./arcgisHubAdapter');
 const ckanSource = require('./ckanSourceAdapter');
+const opendatasoft = require('./opendatasoftAdapter');
 
 const adapters = new Map([
     ['arcgis-hub', arcgisHub],
-    ['ckan', ckanSource]
+    ['ckan', ckanSource],
+    ['opendatasoft', opendatasoft]
 ]);
 
 function getSourceAdapter(kind) {

--- a/server/sql/migrations/014_vancouver_place.sql
+++ b/server/sql/migrations/014_vancouver_place.sql
@@ -1,0 +1,72 @@
+-- Vancouver is a Statistics Canada census subdivision within the Greater
+-- Vancouver census division. Seed the complete ancestry so a clean migration
+-- stack can enable the source before the full SGC refresh runs.
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-pr-59', 'british-columbia', 'province',
+    'British Columbia', 'Colombie-Britannique',
+    'Province', 'Province', 'ca', NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-5915', 'greater-vancouver-bc', 'region',
+    'Greater Vancouver', 'Greater Vancouver',
+    'Census division', 'Division de recensement', 'sgc-pr-59',
+    NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-csd-5915022', 'vancouver-bc', 'municipality',
+    'Vancouver', 'Vancouver', 'City', 'Ville', 'sgc-cd-5915',
+    49.2827, -123.1207, 10, true, true
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+VALUES
+    ('sgc-pr-59', 'sgc-pr', '2021', '59'),
+    ('sgc-cd-5915', 'sgc-cd', '2021', '5915'),
+    ('sgc-csd-5915022', 'sgc-csd', '2021', '5915022')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;


### PR DESCRIPTION
## What & why

Add the City of Vancouver's official Opendatasoft catalogue as a first-class, featured city source. The adapter paginates deterministically, admits only record-explicit Open Government Licence - Vancouver datasets, exposes CSV exports through the unified ingest path, and queues all eligible GeoJSON exports for the bounded local PostGIS index.

Known upstream record counts now participate in the shared ingestability decision, so the seven Vancouver datasets above `MAX_ROWS` remain discoverable as honest download-only resources. Map-worker validation reconstructs Opendatasoft export URLs from configured source identity instead of trusting queued URLs. Migration 014 seeds Vancouver's canonical SGC ancestry and the SGC importer preserves its featured city metadata.

Live dry-run baseline: 197 discovered, 178 included, 19 excluded (15 without records and 4 without explicit licence), 135 map candidates, zero failures. Of the included CSVs, 171 are within the row cap and 7 are download-only; 2 map candidates are expected row-cap skips.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any (none required)
- [x] No secrets, credentials, or production-specific details added

## Notes

- 381 default-run server tests pass; the five isolated PostGIS migration/viewport tests also pass against PostGIS 3.5.
- 106 client tests pass and the production Vite build is unchanged in bundle size.
- Clean migrations apply through `014_vancouver_place.sql`.
- The remote feature commit is tree-identical to locally validated commit `76a084b`.