### PR TITLE
Skip stale Socrata map candidates

### DIFF
--- a/server/__tests__/mapWorker.test.js
+++ b/server/__tests__/mapWorker.test.js
@@ -236,4 +236,22 @@ describe('map worker transitions', () => {
         expect(build).toHaveBeenCalledWith(pmtilesResource, pmtilesJob, expect.any(String), undefined, {});
         expect(index).not.toHaveBeenCalled();
     });
+
+    test('skips stale Socrata PMTiles work without retrying the unchanged candidate', async () => {
+        const staleJob = {
+            ...job,
+            candidate: { mode: 'socrata-geojson-pmtiles' }
+        };
+        await processJob(staleJob, '00000000-0000-4000-8000-000000000001', {
+            getResourceById: async () => resource,
+            buildPmtilesResource: async () => {
+                throw new MapSkipError('source changed', 'MAP_SOURCE_CHANGED');
+            }
+        });
+        expect(mapQueries.finishJob).toHaveBeenCalledWith(
+            pool, staleJob, expect.any(String), 'skipped', {},
+            'MAP_SOURCE_CHANGED: source changed'
+        );
+        expect(mapQueries.requeueJob).not.toHaveBeenCalled();
+    });
 });

--- a/server/__tests__/pmtilesMapPipeline.test.js
+++ b/server/__tests__/pmtilesMapPipeline.test.js
@@ -10,7 +10,8 @@ const {
     validateSocrataCandidate,
     downloadSocrataFeatures,
     runTippecanoe,
-    commitPmtilesMap
+    commitPmtilesMap,
+    buildPmtilesResource
 } = require('../services/pmtilesMapPipeline');
 
 const source = getSource('calgary-open-data');
@@ -110,6 +111,26 @@ describe('PMTiles map pipeline', () => {
             '--drop-densest-as-needed', '--maximum-tile-bytes=500000'
         ]));
         expect(invocation.args).not.toContain('--extend-zooms-if-still-dropping');
+    });
+
+    test('fail-closes a source version that changed before indexing without retrying stale work', async () => {
+        const metadataPool = {
+            query: jest.fn().mockResolvedValue({ rows: [{ bytes: '0' }] })
+        };
+        const view = {
+            id: 'abcd-1234', viewLastModified: 1, rowsUpdatedAt: 2,
+            columns: [{ fieldName: 'point', dataTypeName: 'point' }]
+        };
+        await expect(buildPmtilesResource(
+            resource,
+            { resource_id: resource.id, claimed_version: 'a'.repeat(64), candidate },
+            '00000000-0000-4000-8000-000000000001',
+            {
+                minFreeBytes: 1, maxFileBytes: 1, archiveMaxBytes: 1,
+                fetchJson: jest.fn().mockResolvedValue(view)
+            },
+            { metadataPool, storageConfig: { budgetBytes: 100 } }
+        )).rejects.toMatchObject({ code: 'MAP_SOURCE_CHANGED' });
     });
 
     test('commits object metadata and queue readiness in one transaction', async () => {

--- a/server/services/pmtilesMapPipeline.js
+++ b/server/services/pmtilesMapPipeline.js
@@ -374,7 +374,10 @@ async function buildPmtilesResource(resource, job, workerId, capsRaw = {}, optio
     });
     const startVersion = directMapVersion(firstView, source, expectedRows);
     if (startVersion !== job.claimed_version) {
-        throw new Error('Socrata source changed before PMTiles indexing began');
+        throw new MapSkipError(
+            'Socrata source changed before PMTiles indexing began',
+            'MAP_SOURCE_CHANGED'
+        );
     }
 
     const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'canquery-pmtiles-'));
@@ -398,7 +401,10 @@ async function buildPmtilesResource(resource, job, workerId, capsRaw = {}, optio
             userAgent: caps.userAgent
         });
         if (directMapVersion(finalView, source, expectedRows) !== startVersion) {
-            throw new Error('Socrata source changed while the PMTiles archive was being built');
+            throw new MapSkipError(
+                'Socrata source changed while the PMTiles archive was being built',
+                'MAP_SOURCE_CHANGED'
+            );
         }
         const key = objectKeyFor(resource.id, job.claimed_version);
         const sha256 = await sha256File(outputPath);


### PR DESCRIPTION
## What & why

Treat Socrata source-version drift detected before or during a PMTiles build as an expected fail-closed map skip. Retrying the unchanged queued candidate cannot succeed and previously exhausted all three attempts, degrading `/ops`. A later source sync can safely enqueue the new source version.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: unchanged from the CI-passed v22 release
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any - not applicable
- [x] No secrets, credentials, or production-specific details added

## Notes

Production canaries exposed one Calgary dataset whose Socrata version changed immediately after the source sync. The map worker is stopped while this hotfix passes CI.