### PR TITLE
Skip Socrata row-count drift

### DIFF
--- a/server/__tests__/pmtilesMapPipeline.test.js
+++ b/server/__tests__/pmtilesMapPipeline.test.js
@@ -92,6 +92,25 @@ describe('PMTiles map pipeline', () => {
         }
     });
 
+    test('fail-closes a Socrata row-count change instead of retrying a stale page plan', async () => {
+        const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pmtiles-row-drift-test-'));
+        const inputPath = path.join(dir, 'features.geojsonseq');
+        try {
+            await expect(downloadSocrataFeatures({
+                resource, candidate, inputPath,
+                caps: {
+                    pageSize: 2, maxRows: 10, maxVertices: 10, maxFeatureVertices: 10,
+                    maxFileBytes: 1024 * 1024,
+                    fetchJson: async () => ({ type: 'FeatureCollection', features: [] }),
+                    userAgent: 'test'
+                },
+                view: { columns: [] }, source, datasetId: 'abcd-1234'
+            })).rejects.toMatchObject({ code: 'MAP_SOURCE_CHANGED' });
+        } finally {
+            await fs.promises.rm(dir, { recursive: true, force: true });
+        }
+    });
+
     test('invokes Tippecanoe with fixed zoom, layer, drop, and tile-byte bounds', async () => {
         let invocation;
         const spawnImpl = (command, args) => {

--- a/server/services/pmtilesMapPipeline.js
+++ b/server/services/pmtilesMapPipeline.js
@@ -153,7 +153,10 @@ async function downloadSocrataFeatures({ candidate, inputPath, caps, view, sourc
                 throw new MapSkipError('GeoJSON download exceeds map cap ' + caps.maxFileBytes, 'CAP_FILE');
             }
             if (payload.features.length !== limit) {
-                throw new Error('Socrata row count changed while the map archive was being built');
+                throw new MapSkipError(
+                    'Socrata row count changed while the map archive was being built',
+                    'MAP_SOURCE_CHANGED'
+                );
             }
             for (const upstream of payload.features) {
                 rows += 1;
@@ -190,7 +193,12 @@ async function downloadSocrataFeatures({ candidate, inputPath, caps, view, sourc
                 features += 1;
             }
         }
-        if (rows !== expectedRows) throw new Error('Socrata row count changed while the map archive was being built');
+        if (rows !== expectedRows) {
+            throw new MapSkipError(
+                'Socrata row count changed while the map archive was being built',
+                'MAP_SOURCE_CHANGED'
+            );
+        }
         if (!features || !validWgs84Extent(bounds)) {
             throw new MapSkipError('Socrata source contains no valid WGS84 geometry', 'MAP_GEOMETRY');
         }


### PR DESCRIPTION
## What & why

Classify Socrata row-count drift detected while following a fixed pagination plan as `MAP_SOURCE_CHANGED`. Retrying the same stale expected row count cannot succeed; fail-closing as a skip keeps `/ops` healthy and lets the next source sync enqueue the new version.

## Checklist

- [x] `server`: `npm run lint && npm test` pass (412 default-run tests)
- [x] `client`: unchanged from the CI-passed v22 release
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any - not applicable
- [x] No secrets, credentials, or production-specific details added

## Notes

Production exposed this second guard on the same continuously changing Calgary dataset. The worker is stopped while CI runs.