### PR TITLE
Stabilize Socrata catalogue snapshots

### DIFF
--- a/server/__tests__/socrataAdapter.test.js
+++ b/server/__tests__/socrataAdapter.test.js
@@ -41,22 +41,25 @@ function view(overrides = {}) {
 }
 
 describe('Socrata catalogue adapter', () => {
-    test('discovers every advertised dataset and rejects drift or duplicates', async () => {
+    test('discovers one bounded catalogue snapshot and rejects truncation or duplicates', async () => {
         const records = Array.from({ length: 201 }, (_, index) => catalogRecord('id-' + index));
         const fetchJson = jest.fn(async value => {
             const url = new URL(value);
-            const offset = Number(url.searchParams.get('offset'));
             expect(url.searchParams.get('only')).toBe('datasets');
             expect(url.searchParams.get('search_context')).toBe('data.calgary.ca');
-            return { resultSetSize: records.length, results: records.slice(offset, offset + 100) };
+            expect(url.searchParams.get('limit')).toBe('5000');
+            expect(url.searchParams.get('offset')).toBe('0');
+            return { resultSetSize: records.length, results: records };
         });
         await expect(discover(source, { fetchJson })).resolves.toEqual(records);
-        expect(fetchJson).toHaveBeenCalledTimes(3);
+        expect(fetchJson).toHaveBeenCalledTimes(1);
 
-        await expect(discover(source, { fetchJson: jest.fn()
-            .mockResolvedValueOnce({ resultSetSize: 101, results: records.slice(0, 100) })
-            .mockResolvedValueOnce({ resultSetSize: 102, results: records.slice(100, 102) })
-        })).rejects.toThrow(/count changed/);
+        await expect(discover(source, { fetchJson: async () => ({
+            resultSetSize: 5001, results: records
+        }) })).rejects.toThrow(/safe snapshot limit/);
+        await expect(discover(source, { fetchJson: async () => ({
+            resultSetSize: 202, results: records
+        }) })).rejects.toThrow(/advertised count/);
         await expect(discover(source, { fetchJson: async () => ({
             resultSetSize: 2, results: [catalogRecord('same'), catalogRecord('same')]
         }) })).rejects.toThrow(/duplicate dataset id/);

--- a/server/services/socrataAdapter.js
+++ b/server/services/socrataAdapter.js
@@ -1,7 +1,11 @@
 const crypto = require('node:crypto');
 const { fetchPublicJson } = require('./publicJson');
 
-const PAGE_SIZE = 100;
+// The Discovery API is relevance-ranked and does not expose a stable catalogue
+// sort key. Fetch each configured city in one bounded response so an item cannot
+// move across offset pages during a sync. Larger future portals fail closed
+// instead of risking an incomplete source sweep.
+const PAGE_SIZE = 5000;
 const MAP_VERSION = 'socrata-pmtiles-v1';
 const GEOMETRY_TYPES = new Set([
     'point', 'multipoint', 'line', 'multiline', 'polygon', 'multipolygon',
@@ -262,40 +266,33 @@ function directMapVersion(view, source, recordCount) {
 async function discover(source, options = {}) {
     validateSource(source);
     const fetchJson = options.fetchJson || fetchPublicJson;
-    const records = [];
-    const identities = new Set();
-    let expectedTotal = null;
+    const url = new URL(source.catalogUrl);
+    url.searchParams.set('only', 'datasets');
+    url.searchParams.set('search_context', source.upstreamHost);
+    url.searchParams.set('limit', String(PAGE_SIZE));
+    url.searchParams.set('offset', '0');
+    const body = await fetchJson(url.href, options.http);
+    const expectedTotal = Number(body && body.resultSetSize);
+    const records = body && body.results;
+    if (!Number.isInteger(expectedTotal) || expectedTotal < 0 || !Array.isArray(records)) {
+        throw new Error('Socrata source returned an invalid catalogue response');
+    }
+    if (expectedTotal > PAGE_SIZE) {
+        throw new Error('Socrata source catalogue exceeds the safe snapshot limit');
+    }
+    if (records.length !== expectedTotal) {
+        throw new Error('Socrata source catalogue ended before its advertised count');
+    }
 
-    for (let offset = 0; expectedTotal == null || offset < expectedTotal; offset += PAGE_SIZE) {
-        const url = new URL(source.catalogUrl);
-        url.searchParams.set('only', 'datasets');
-        url.searchParams.set('search_context', source.upstreamHost);
-        url.searchParams.set('limit', String(PAGE_SIZE));
-        url.searchParams.set('offset', String(offset));
-        const body = await fetchJson(url.href, options.http);
-        const total = Number(body && body.resultSetSize);
-        const page = body && body.results;
-        if (!Number.isInteger(total) || total < 0 || !Array.isArray(page)) {
-            throw new Error('Socrata source returned an invalid catalogue response');
+    const identities = new Set();
+    for (const record of records) {
+        const identity = identityFor(record);
+        if (!identity) throw new Error('Socrata source returned a record without a dataset id');
+        const key = canonicalKey(identity);
+        if (identities.has(key)) {
+            throw new Error('Socrata source returned a duplicate dataset id: ' + identity);
         }
-        if (expectedTotal == null) expectedTotal = total;
-        if (expectedTotal !== total) {
-            throw new Error('Socrata source catalogue count changed during pagination');
-        }
-        const expectedPage = Math.min(PAGE_SIZE, expectedTotal - offset);
-        if (page.length !== expectedPage) {
-            throw new Error('Socrata source catalogue ended before its advertised count');
-        }
-        for (const record of page) {
-            const identity = identityFor(record);
-            if (!identity) throw new Error('Socrata source returned a record without a dataset id');
-            const key = canonicalKey(identity);
-            if (identities.has(key)) {
-                throw new Error('Socrata source returned a duplicate dataset id: ' + identity);
-            }
-            identities.add(key);
-            records.push(record);
-        }
+        identities.add(key);
     }
 
     if (!expectedTotal || records.length !== expectedTotal) {


### PR DESCRIPTION
## Summary
- fetch each configured Socrata city catalogue in one bounded Discovery API snapshot
- fail closed when a future catalogue exceeds the safe snapshot limit or is truncated
- cover the snapshot limit, truncation, and duplicate guards

## Production finding
Edmonton returned a transient duplicate ID across 100-row offset pages after its successful dry-run. The complete 1,428-record response is 14.6 MB and remains below the existing 25 MB upstream JSON cap.

## Validation
- 57 default server suites: 418 passing tests, 7 expected spatial skips
- server lint
- live Edmonton dry-run: 1,428 discovered, 975 admitted, 453 excluded, 0 failed, 125 mappable