### PR TITLE
Add Halifax open data coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ records explicitly attributed to the City under its portal terms. Winnipeg
 requires its record-specific Open Government Licence - Winnipeg evidence, admits
 recognized City units, and permits missing attribution only alongside that exact
 licence evidence. Records attributed to external governments or agencies remain
-excluded. The featured local directory
-also covers Durham Region and all eight lower-tier municipalities, with direct
-feeds from Durham, Ajax,
-Oshawa, Pickering and the explicitly open-licensed subset of Whitby.
+excluded. Halifax Regional Municipality's official ArcGIS catalogue adds the
+first Atlantic standalone destination. The portal-wide Open Government Licence -
+Halifax applies only to exact Halifax Regional Municipality publisher evidence;
+placeholder, external, and explicitly restricted records remain excluded, while
+eligible spatial layers use the existing bounded ArcGIS viewport path. The
+featured local directory also covers Durham Region and all eight lower-tier
+municipalities, with direct feeds from Durham, Ajax, Oshawa, Pickering and the
+explicitly open-licensed subset of Whitby.
 Clarington is represented through Durham’s regional coverage only: its current
 public web-map terms are personal/non-commercial, so no direct adapter is enabled.
 Peel Region is included alongside direct Mississauga and Brampton feeds; Caledon
@@ -81,6 +85,7 @@ npm run sync:source -- --source=montreal-open-data --dry-run
 npm run sync:source -- --source=ottawa-hub --dry-run
 npm run sync:source -- --source=vancouver-open-data --dry-run
 npm run sync:source -- --source=calgary-open-data --dry-run
+npm run sync:source -- --source=halifax-hub --dry-run
 npm run sync:source -- --source=durham-hub --dry-run
 npm run sync:source -- --source=peel-hub --dry-run
 npm run sync:municipal                    # sync every enabled local source
@@ -112,6 +117,7 @@ curl 'http://localhost:3100/api/v1/places?q=Vancouver'
 curl 'http://localhost:3100/api/v1/places?q=Calgary'
 curl 'http://localhost:3100/api/v1/places?q=Edmonton'
 curl 'http://localhost:3100/api/v1/places?q=Winnipeg'
+curl 'http://localhost:3100/api/v1/places?q=Halifax'
 
 # place-filtered sources are authoritative; counts expose total + authoritative
 curl 'http://localhost:3100/api/v1/sources?place=clarington-on'
@@ -120,6 +126,7 @@ curl 'http://localhost:3100/api/v1/sources?place=vancouver-bc'
 curl 'http://localhost:3100/api/v1/sources?place=calgary-ab'
 curl 'http://localhost:3100/api/v1/sources?place=edmonton-ab'
 curl 'http://localhost:3100/api/v1/sources?place=winnipeg-mb'
+curl 'http://localhost:3100/api/v1/sources?place=halifax-ns'
 
 # dataset detail - resources tagged datastore | ingested | ingestable | file-only
 curl 'http://localhost:3100/api/v1/datasets/<idOrName>'
@@ -206,7 +213,7 @@ remain in PostGIS.
 The SPA (`client/`) starts with a search plus an optional remembered place
 (All Canada remains the default). Its grouped selector shows featured regions,
 their municipalities, and standalone featured cities such as Calgary, Montréal,
-Edmonton, Ottawa, Toronto, Vancouver and Winnipeg;
+Edmonton, Halifax, Ottawa, Toronto, Vancouver and Winnipeg;
 search on `/places` still reaches the complete Canadian SGC hierarchy. Place
 pages combine directly local datasets with records whose parent jurisdiction
 explicitly covers that place, and label regional-only coverage instead of

--- a/client/src/components/PlaceSelect.test.jsx
+++ b/client/src/components/PlaceSelect.test.jsx
@@ -18,6 +18,7 @@ describe('PlaceSelect', () => {
       { id: 'sgc-csd-4806016', slug: 'calgary-ab', kind: 'municipality', name: { en: 'Calgary' }, parent: { id: 'sgc-cd-4806' }, dataset_count: 570 },
       { id: 'sgc-csd-4811061', slug: 'edmonton-ab', kind: 'municipality', name: { en: 'Edmonton' }, parent: { id: 'sgc-cd-4811' }, dataset_count: 974 },
       { id: 'sgc-csd-4611040', slug: 'winnipeg-mb', kind: 'municipality', name: { en: 'Winnipeg' }, parent: { id: 'sgc-cd-4611' }, dataset_count: 229 },
+      { id: 'sgc-csd-1209034', slug: 'halifax-ns', kind: 'municipality', name: { en: 'Halifax' }, parent: { id: 'sgc-cd-1209' }, dataset_count: 327 },
     ]} />);
     const select = screen.getByRole('combobox', { name: 'Choose a place' });
     expect(select).toHaveDisplayValue('All Canada');
@@ -29,6 +30,7 @@ describe('PlaceSelect', () => {
     expect(screen.getAllByRole('option', { name: /Calgary/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Edmonton/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Winnipeg/ })).toHaveLength(1);
+    expect(screen.getAllByRole('option', { name: /Halifax/ })).toHaveLength(1);
     expect([...container.querySelectorAll('optgroup')].map(group => group.label)).toEqual([
       'Featured regions', 'Municipalities in Durham', 'Municipalities in Peel', 'Featured cities', 'Other places'
     ]);

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -78,6 +78,13 @@ beforeEach(() => {
       name: { en: 'Winnipeg', fr: 'Winnipeg' }, type: { en: 'City', fr: 'Ville' },
       parent: { id: 'sgc-cd-4611', name: { en: 'Division No. 11', fr: 'Division No. 11' } },
       dataset_count: 229, direct_dataset_count: 229, mappable_resource_count: 94
+    },
+    {
+      id: 'sgc-csd-1209034', slug: 'halifax-ns', kind: 'municipality',
+      name: { en: 'Halifax', fr: 'Halifax' },
+      type: { en: 'Regional municipality', fr: 'Municipalité régionale' },
+      parent: { id: 'sgc-cd-1209', name: { en: 'Halifax', fr: 'Halifax' } },
+      dataset_count: 327, direct_dataset_count: 327, mappable_resource_count: 196
     }
   ] });
 });
@@ -97,6 +104,7 @@ describe('PlacesPage', () => {
     expect(screen.getAllByRole('link', { name: /Calgary/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Edmonton/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Winnipeg/ })).toHaveLength(1);
+    expect(screen.getAllByRole('link', { name: /Halifax/ })).toHaveLength(1);
     expect(screen.getByRole('link', { name: /Clarington/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Caledon/ })).toBeInTheDocument();

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -279,12 +279,14 @@ curl -s 'https://<your-domain>/api/v1/places?q=Ottawa'
 curl -s 'https://<your-domain>/api/v1/places?q=Montr%C3%A9al'
 curl -s 'https://<your-domain>/api/v1/places?q=Vancouver'
 curl -s 'https://<your-domain>/api/v1/places?q=Calgary'
+curl -s 'https://<your-domain>/api/v1/places?q=Halifax'
 curl -s 'https://<your-domain>/api/v1/places?q=Mississauga'
 curl -s 'https://<your-domain>/api/v1/places?q=Brampton'
 curl -s 'https://<your-domain>/api/v1/sources?place=clarington-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=caledon-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=ottawa-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=vancouver-bc'
+curl -s 'https://<your-domain>/api/v1/sources?place=halifax-ns'
 # UI: search by place, open a mapped dataset, pan/zoom the live Map tab, then load its table snapshot
 ```
 

--- a/server/__tests__/arcgisHubAdapter.test.js
+++ b/server/__tests__/arcgisHubAdapter.test.js
@@ -207,6 +207,48 @@ describe('ArcGIS Hub adapter', () => {
         });
     });
 
+    test('applies Halifax portal terms only to exact HRM publisher evidence', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'opendata_HRM', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+        const source = getSource('halifax-hub');
+        const cityRecord = record({
+            landingPage: 'https://data-hrm.hub.arcgis.com/datasets/HRM::parks',
+            publisher: { name: 'Halifax Regional Municipality' },
+            license: null
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+
+        expect(city.status).toBe('included');
+        expect(city.value.organization.titleEn).toBe('Halifax Regional Municipality');
+        expect(city.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-1209034', relationship: 'direct', includesDescendants: false
+        }));
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'Open Government Licence – Halifax',
+            licenseUrl: 'https://data-hrm.hub.arcgis.com/pages/open-data-licence'
+        }));
+
+        const restricted = await adapter.enrichRecord({
+            ...cityRecord,
+            license: 'Reproduction is permitted for non-commercial use only.'
+        }, source, { fetchJson });
+        expect(restricted).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+
+        const externalFetch = jest.fn(async () => ({ owner: 'ExternalPublisher', type: 'Feature Service' }));
+        const placeholder = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: '{{source}}' }
+        }, source, { fetchJson: externalFetch });
+        expect(placeholder).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+        expect(externalFetch).toHaveBeenCalledTimes(1);
+    });
+
     test('admits only explicit Brampton CC BY or Statistics Canada records', async () => {
         const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
             ? { owner: 'Brampton', type: 'Feature Service' }

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -4,10 +4,31 @@ describe('configured municipal catalogue sources', () => {
     test('syncs city portals before the authoritative portal in each regional cluster', () => {
         expect(sources.map(source => source.id)).toEqual([
             'toronto-open-data', 'montreal-open-data', 'ottawa-hub', 'vancouver-open-data',
-            'calgary-open-data', 'edmonton-open-data', 'winnipeg-open-data',
+            'calgary-open-data', 'edmonton-open-data', 'winnipeg-open-data', 'halifax-hub',
             'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
             'mississauga-hub', 'brampton-hub', 'peel-hub'
         ]);
+    });
+
+    test('configures Halifax as an exact-publisher ArcGIS source under its portal licence', () => {
+        const halifax = getSource('halifax-hub');
+        expect(halifax).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'data-hrm.hub.arcgis.com',
+            catalogUrl: 'https://data-hrm.hub.arcgis.com/api/feed/dcat-us/1.1.json'
+        }));
+        expect(halifax.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
+        ]));
+        expect(halifax.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://data-hrm.hub.arcgis.com/pages/open-data-licence'
+            })
+        })]);
+        expect(halifax.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-1209034', relationship: 'direct',
+            includesDescendants: false
+        })]);
     });
 
     test('configures Calgary as a strict record-licensed Socrata city source', () => {

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -1,4 +1,6 @@
 const { Client, Pool } = require('pg');
+const fs = require('node:fs');
+const path = require('node:path');
 const { queryLocalMap } = require('../db/mapIndexQueries');
 const { indexMapResource } = require('../services/mapIndexPipeline');
 
@@ -318,6 +320,62 @@ spatialDescribe('PostGIS viewport integration', () => {
         expect(identifiers.rows).toEqual([
             { place_id: 'sgc-csd-4611040', scheme: 'sgc-csd', value: '4611040' },
             { place_id: 'sgc-csd-4811061', scheme: 'sgc-csd', value: '4811061' }
+        ]);
+    });
+
+    test('migration seeds distinct Halifax ancestry and one featured municipality', async () => {
+        // Reproduce the generic full-SGC slugs seen before migration 018, then
+        // re-run its SQL to prove the same-name canonical swap is safe.
+        await client.query("DELETE FROM place_aliases WHERE slug = 'halifax-ns-1209034'");
+        await client.query("UPDATE places SET slug = 'halifax-ns-1209034' WHERE id = 'sgc-csd-1209034'");
+        await client.query("UPDATE places SET slug = 'halifax-ns' WHERE id = 'sgc-cd-1209'");
+        const migration = fs.readFileSync(path.join(
+            __dirname, '..', 'sql', 'migrations', '018_halifax_place.sql'
+        ), 'utf8');
+        await client.query(migration);
+
+        const places = await client.query(`
+            SELECT id, slug, kind, parent_id, type_en, type_fr, featured,
+                   latitude, longitude, default_zoom
+            FROM places
+            WHERE id IN ('sgc-pr-12', 'sgc-cd-1209', 'sgc-csd-1209034')
+            ORDER BY CASE id
+                WHEN 'sgc-pr-12' THEN 1 WHEN 'sgc-cd-1209' THEN 2 ELSE 3 END
+        `);
+        expect(places.rows).toEqual([
+            expect.objectContaining({
+                id: 'sgc-pr-12', slug: 'nova-scotia', kind: 'province',
+                parent_id: 'ca', featured: false
+            }),
+            expect.objectContaining({
+                id: 'sgc-cd-1209', slug: 'halifax-region-ns', kind: 'region',
+                parent_id: 'sgc-pr-12', featured: false
+            }),
+            expect.objectContaining({
+                id: 'sgc-csd-1209034', slug: 'halifax-ns', kind: 'municipality',
+                parent_id: 'sgc-cd-1209', type_en: 'Regional municipality',
+                type_fr: 'Municipalité régionale', featured: true,
+                latitude: 44.6488, longitude: -63.5752, default_zoom: 8
+            })
+        ]);
+
+        const identifiers = await client.query(`
+            SELECT place_id, scheme, value FROM place_identifiers
+            WHERE place_id IN ('sgc-pr-12', 'sgc-cd-1209', 'sgc-csd-1209034')
+            ORDER BY place_id
+        `);
+        expect(identifiers.rows).toEqual([
+            { place_id: 'sgc-cd-1209', scheme: 'sgc-cd', value: '1209' },
+            { place_id: 'sgc-csd-1209034', scheme: 'sgc-csd', value: '1209034' },
+            { place_id: 'sgc-pr-12', scheme: 'sgc-pr', value: '12' }
+        ]);
+
+        const aliases = await client.query(`
+            SELECT slug, place_id FROM place_aliases
+            WHERE slug = 'halifax-ns-1209034'
+        `);
+        expect(aliases.rows).toEqual([
+            { slug: 'halifax-ns-1209034', place_id: 'sgc-csd-1209034' }
         ]);
     });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -151,6 +151,36 @@ describe('Statistics Canada SGC place normalization', () => {
         }));
     });
 
+    test('keeps the Halifax census division and featured regional municipality distinct', () => {
+        const en = [
+            { Level: '2', Code: '12', 'Class title': 'Nova Scotia' },
+            { Level: '3', Code: '1209', 'Class title': 'Halifax' },
+            { Level: '4', Code: '1209034', 'Class title': 'Halifax' }
+        ];
+        const fr = [
+            { Code: '12', 'Titres de classes': 'Nouvelle-Écosse' },
+            { Code: '1209', 'Titres de classes': 'Halifax' },
+            { Code: '1209034', 'Titres de classes': 'Halifax' }
+        ];
+        const result = normalize(en, fr);
+
+        expect(result.places.find(place => place.id === 'sgc-pr-12')).toEqual(expect.objectContaining({
+            slug: 'nova-scotia', nameFr: 'Nouvelle-Écosse', parentId: 'ca', featured: false
+        }));
+        expect(result.places.find(place => place.id === 'sgc-cd-1209')).toEqual(expect.objectContaining({
+            slug: 'halifax-region-ns', kind: 'region', parentId: 'sgc-pr-12', featured: false
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-1209034')).toEqual(expect.objectContaining({
+            slug: 'halifax-ns', kind: 'municipality', parentId: 'sgc-cd-1209',
+            typeEn: 'Regional municipality', typeFr: 'Municipalité régionale', featured: true,
+            latitude: 44.6488, longitude: -63.5752, defaultZoom: 8
+        }));
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            expect.objectContaining({ placeId: 'sgc-cd-1209', scheme: 'sgc-cd', value: '1209' }),
+            expect.objectContaining({ placeId: 'sgc-csd-1209034', scheme: 'sgc-csd', value: '1209034' })
+        ]));
+    });
+
     test('features Calgary beneath Division No. 6 with its curated viewport', () => {
         const en = [
             { Level: '2', Code: '48', 'Class title': 'Alberta' },

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -110,6 +110,14 @@ const WINNIPEG_LICENSE = {
     attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Winnipeg.'
 };
 
+const HALIFAX_LICENSE = {
+    titleEn: 'Open Government Licence – Halifax',
+    titleFr: 'Licence du gouvernement ouvert – Halifax',
+    url: 'https://data-hrm.hub.arcgis.com/pages/open-data-licence',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Halifax.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Halifax.'
+};
+
 const MISSISSAUGA_LICENSE = {
     titleEn: 'City of Mississauga Open Data Terms of Use',
     titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Mississauga',
@@ -395,6 +403,35 @@ const sources = [{
         }
     }
 }, {
+    id: 'halifax-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Halifax Regional Municipality Open Data',
+    nameFr: 'Données ouvertes de la municipalité régionale d’Halifax',
+    homepageUrl: 'https://data-hrm.hub.arcgis.com/',
+    catalogUrl: 'https://data-hrm.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-hrm.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^halifax regional municipality$/i, name: 'Halifax Regional Municipality' }
+    ],
+    authoritativePublishers: [{ publisher: /^halifax regional municipality$/i }],
+    // The official Halifax licence applies portal-wide, but only exact HRM
+    // publisher evidence is admitted. Placeholder and external records remain
+    // fail-closed, and explicit restricted terms are checked first.
+    licenseRules: [{
+        publisher: /^halifax regional municipality$/i,
+        license: HALIFAX_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^halifax regional municipality$/i,
+        placeId: 'sgc-csd-1209034',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
     id: 'oshawa-hub',
     kind: 'arcgis-hub',
     nameEn: 'City of Oshawa Open Data Hub',
@@ -649,6 +686,7 @@ module.exports = {
     CALGARY_LICENSE,
     EDMONTON_LICENSE,
     WINNIPEG_LICENSE,
+    HALIFAX_LICENSE,
     MISSISSAUGA_LICENSE,
     CC_BY_4_LICENSE,
     OGL_CANADA_LICENSE,

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -30,7 +30,8 @@ const FEATURED_PLACE_IDS = new Set([
     'sgc-csd-5915022',
     'sgc-csd-4806016',
     'sgc-csd-4811061',
-    'sgc-csd-4611040'
+    'sgc-csd-4611040',
+    'sgc-csd-1209034'
 ]);
 const MUNICIPAL_TYPES = {
     '2466023': ['City', 'Ville'],
@@ -48,7 +49,8 @@ const MUNICIPAL_TYPES = {
     '5915022': ['City', 'Ville'],
     '4806016': ['City', 'Ville'],
     '4811061': ['City', 'Ville'],
-    '4611040': ['City', 'Ville']
+    '4611040': ['City', 'Ville'],
+    '1209034': ['Regional municipality', 'Municipalité régionale']
 };
 const PLACE_VIEWPORTS = {
     '2466023': [45.5019, -73.5674, 10],
@@ -63,7 +65,8 @@ const PLACE_VIEWPORTS = {
     '5915022': [49.2827, -123.1207, 10],
     '4806016': [51.0447, -114.0719, 9],
     '4811061': [53.5461, -113.4938, 9],
-    '4611040': [49.8954, -97.1385, 9]
+    '4611040': [49.8954, -97.1385, 9],
+    '1209034': [44.6488, -63.5752, 8]
 };
 
 function slugify(value) {
@@ -133,6 +136,8 @@ function normalize(enRows, frRows) {
         if (code === '35') parentId = 'ca';
         if (code === '35') baseSlug = 'ontario';
         let slug = baseSlug;
+        if (code === '1209') slug = 'halifax-region-ns';
+        if (code === '1209034') slug = 'halifax-ns';
         if (code === '3518') slug = 'durham-on';
         if (code === '2466') slug = 'montreal-region-qc';
         if (code === '2466023') slug = 'montreal-qc';

--- a/server/sql/migrations/018_halifax_place.sql
+++ b/server/sql/migrations/018_halifax_place.sql
@@ -1,0 +1,91 @@
+-- Halifax Regional Municipality is a Statistics Canada census subdivision
+-- inside the distinct Halifax census division. Both official places share the
+-- same name, so expose the municipality at the short public slug while keeping
+-- its census-division parent as an unfeatured ancestry node.
+
+-- A previous full SGC import gives the census division the unsuffixed slug and
+-- the municipality a numeric suffix. Release the desired municipality slug
+-- before the canonical upserts below.
+UPDATE places
+SET slug = 'halifax-region-ns', updated_at = now()
+WHERE id = 'sgc-cd-1209' AND slug <> 'halifax-region-ns';
+
+-- Canonical slugs must not also remain in the alias table after an earlier
+-- normalization attempt.
+DELETE FROM place_aliases
+WHERE slug IN ('halifax-region-ns', 'halifax-ns');
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-pr-12', 'nova-scotia', 'province',
+    'Nova Scotia', 'Nouvelle-Écosse', 'Province', 'Province', 'ca',
+    NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-1209', 'halifax-region-ns', 'region',
+    'Halifax', 'Halifax', 'Census division', 'Division de recensement',
+    'sgc-pr-12', NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-csd-1209034', 'halifax-ns', 'municipality',
+    'Halifax', 'Halifax', 'Regional municipality', 'Municipalité régionale',
+    'sgc-cd-1209', 44.6488, -63.5752, 8, true, true
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+VALUES
+    ('sgc-pr-12', 'sgc-pr', '2021', '12'),
+    ('sgc-cd-1209', 'sgc-cd', '2021', '1209'),
+    ('sgc-csd-1209034', 'sgc-csd', '2021', '1209034')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;
+
+INSERT INTO place_aliases (slug, place_id)
+VALUES ('halifax-ns-1209034', 'sgc-csd-1209034')
+ON CONFLICT (slug) DO UPDATE SET place_id = EXCLUDED.place_id;


### PR DESCRIPTION
## Summary

- add Halifax Regional Municipality as a strict ArcGIS Hub source
- seed canonical Halifax SGC ancestry and a featured standalone place
- preserve portal licensing while rejecting restricted and external records
- add adapter, place, UI, migration, and deployment coverage

## Validation

- 421 default server tests
- 8 isolated PostGIS integration tests
- 107 client tests
- server/client lint and production build
- live dry run: 349 discovered, 327 admitted, 196 mappable, 0 failures