### PR TITLE
Add Hamilton open data coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,14 @@ excluded. Halifax Regional Municipality's official ArcGIS catalogue adds the
 first Atlantic standalone destination. The portal-wide Open Government Licence -
 Halifax applies only to exact Halifax Regional Municipality publisher evidence;
 placeholder, external, and explicitly restricted records remain excluded, while
-eligible spatial layers use the existing bounded ArcGIS viewport path. The
-featured local directory also covers Durham Region and all eight lower-tier
+eligible spatial layers use the existing bounded ArcGIS viewport path. The City
+of Hamilton's official ArcGIS catalogue uses the same bounded map path. Its
+portal-wide City of Hamilton Open Data Licence applies only to the configured
+City and department publisher strings; unfamiliar, placeholder, external, and
+restricted publishers fail closed. Hamilton's census-division and subdivision
+identities are merged into one featured city, while the unrelated Northumberland
+municipality remains available as Hamilton Township. The featured local
+directory also covers Durham Region and all eight lower-tier
 municipalities, with direct feeds from Durham, Ajax, Oshawa, Pickering and the
 explicitly open-licensed subset of Whitby.
 Clarington is represented through Durham’s regional coverage only: its current
@@ -86,6 +92,7 @@ npm run sync:source -- --source=ottawa-hub --dry-run
 npm run sync:source -- --source=vancouver-open-data --dry-run
 npm run sync:source -- --source=calgary-open-data --dry-run
 npm run sync:source -- --source=halifax-hub --dry-run
+npm run sync:source -- --source=hamilton-hub --dry-run
 npm run sync:source -- --source=durham-hub --dry-run
 npm run sync:source -- --source=peel-hub --dry-run
 npm run sync:municipal                    # sync every enabled local source
@@ -118,6 +125,7 @@ curl 'http://localhost:3100/api/v1/places?q=Calgary'
 curl 'http://localhost:3100/api/v1/places?q=Edmonton'
 curl 'http://localhost:3100/api/v1/places?q=Winnipeg'
 curl 'http://localhost:3100/api/v1/places?q=Halifax'
+curl 'http://localhost:3100/api/v1/places?q=Hamilton'
 
 # place-filtered sources are authoritative; counts expose total + authoritative
 curl 'http://localhost:3100/api/v1/sources?place=clarington-on'
@@ -127,6 +135,7 @@ curl 'http://localhost:3100/api/v1/sources?place=calgary-ab'
 curl 'http://localhost:3100/api/v1/sources?place=edmonton-ab'
 curl 'http://localhost:3100/api/v1/sources?place=winnipeg-mb'
 curl 'http://localhost:3100/api/v1/sources?place=halifax-ns'
+curl 'http://localhost:3100/api/v1/sources?place=hamilton-on'
 
 # dataset detail - resources tagged datastore | ingested | ingestable | file-only
 curl 'http://localhost:3100/api/v1/datasets/<idOrName>'
@@ -213,7 +222,7 @@ remain in PostGIS.
 The SPA (`client/`) starts with a search plus an optional remembered place
 (All Canada remains the default). Its grouped selector shows featured regions,
 their municipalities, and standalone featured cities such as Calgary, Montréal,
-Edmonton, Halifax, Ottawa, Toronto, Vancouver and Winnipeg;
+Edmonton, Halifax, Hamilton, Ottawa, Toronto, Vancouver and Winnipeg;
 search on `/places` still reaches the complete Canadian SGC hierarchy. Place
 pages combine directly local datasets with records whose parent jurisdiction
 explicitly covers that place, and label regional-only coverage instead of

--- a/client/src/components/PlaceSelect.test.jsx
+++ b/client/src/components/PlaceSelect.test.jsx
@@ -19,6 +19,7 @@ describe('PlaceSelect', () => {
       { id: 'sgc-csd-4811061', slug: 'edmonton-ab', kind: 'municipality', name: { en: 'Edmonton' }, parent: { id: 'sgc-cd-4811' }, dataset_count: 974 },
       { id: 'sgc-csd-4611040', slug: 'winnipeg-mb', kind: 'municipality', name: { en: 'Winnipeg' }, parent: { id: 'sgc-cd-4611' }, dataset_count: 229 },
       { id: 'sgc-csd-1209034', slug: 'halifax-ns', kind: 'municipality', name: { en: 'Halifax' }, parent: { id: 'sgc-cd-1209' }, dataset_count: 327 },
+      { id: 'sgc-cd-3525', slug: 'hamilton-on', kind: 'municipality', name: { en: 'Hamilton' }, parent: { id: 'ca-on' }, dataset_count: 376 },
     ]} />);
     const select = screen.getByRole('combobox', { name: 'Choose a place' });
     expect(select).toHaveDisplayValue('All Canada');
@@ -31,6 +32,7 @@ describe('PlaceSelect', () => {
     expect(screen.getAllByRole('option', { name: /Edmonton/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Winnipeg/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Halifax/ })).toHaveLength(1);
+    expect(screen.getAllByRole('option', { name: /Hamilton/ })).toHaveLength(1);
     expect([...container.querySelectorAll('optgroup')].map(group => group.label)).toEqual([
       'Featured regions', 'Municipalities in Durham', 'Municipalities in Peel', 'Featured cities', 'Other places'
     ]);

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -85,6 +85,12 @@ beforeEach(() => {
       type: { en: 'Regional municipality', fr: 'Municipalité régionale' },
       parent: { id: 'sgc-cd-1209', name: { en: 'Halifax', fr: 'Halifax' } },
       dataset_count: 327, direct_dataset_count: 327, mappable_resource_count: 196
+    },
+    {
+      id: 'sgc-cd-3525', slug: 'hamilton-on', kind: 'municipality',
+      name: { en: 'Hamilton', fr: 'Hamilton' }, type: { en: 'City', fr: 'Ville' },
+      parent: { id: 'ca-on', name: { en: 'Ontario', fr: 'Ontario' } },
+      dataset_count: 376, direct_dataset_count: 376, mappable_resource_count: 154
     }
   ] });
 });
@@ -105,6 +111,7 @@ describe('PlacesPage', () => {
     expect(screen.getAllByRole('link', { name: /Edmonton/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Winnipeg/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Halifax/ })).toHaveLength(1);
+    expect(screen.getAllByRole('link', { name: /Hamilton/ })).toHaveLength(1);
     expect(screen.getByRole('link', { name: /Clarington/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Caledon/ })).toBeInTheDocument();

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -280,6 +280,7 @@ curl -s 'https://<your-domain>/api/v1/places?q=Montr%C3%A9al'
 curl -s 'https://<your-domain>/api/v1/places?q=Vancouver'
 curl -s 'https://<your-domain>/api/v1/places?q=Calgary'
 curl -s 'https://<your-domain>/api/v1/places?q=Halifax'
+curl -s 'https://<your-domain>/api/v1/places?q=Hamilton'
 curl -s 'https://<your-domain>/api/v1/places?q=Mississauga'
 curl -s 'https://<your-domain>/api/v1/places?q=Brampton'
 curl -s 'https://<your-domain>/api/v1/sources?place=clarington-on'
@@ -287,6 +288,7 @@ curl -s 'https://<your-domain>/api/v1/sources?place=caledon-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=ottawa-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=vancouver-bc'
 curl -s 'https://<your-domain>/api/v1/sources?place=halifax-ns'
+curl -s 'https://<your-domain>/api/v1/sources?place=hamilton-on'
 # UI: search by place, open a mapped dataset, pan/zoom the live Map tab, then load its table snapshot
 ```
 

--- a/server/__tests__/arcgisHubAdapter.test.js
+++ b/server/__tests__/arcgisHubAdapter.test.js
@@ -249,6 +249,59 @@ describe('ArcGIS Hub adapter', () => {
         expect(externalFetch).toHaveBeenCalledTimes(1);
     });
 
+    test('admits only allowlisted Hamilton City department publishers', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'Hamilton_Open_Data', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
+        const source = getSource('hamilton-hub');
+        const cityRecord = record({
+            landingPage: 'https://open.hamilton.ca/datasets/SpatialSolutions::roads',
+            publisher: { name: 'City of Hamilton;Public Works;Hamilton Water' },
+            license: null
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+
+        expect(city.status).toBe('included');
+        expect(city.value.organization.titleEn).toBe('City of Hamilton');
+        expect(city.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3525', relationship: 'direct', includesDescendants: false
+        }));
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'City of Hamilton Open Data Licence',
+            licenseUrl: expect.stringContaining('/open-data-licence-terms-and-conditions'),
+            attributionEn: 'Contains public sector Data made available under the City of Hamilton’s Open Data Licence'
+        }));
+
+        const restricted = await adapter.enrichRecord({
+            ...cityRecord,
+            license: 'Available for personal, non-commercial use only.'
+        }, source, { fetchJson });
+        expect(restricted).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+
+        const unfamiliar = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: 'City of Hamilton;External Partner' }
+        }, source, { fetchJson });
+        expect(unfamiliar).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+
+        const placeholderFetch = jest.fn(async () => ({
+            owner: 'ExternalPublisher', type: 'Feature Service'
+        }));
+        const placeholder = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: '{{source}}' }
+        }, source, { fetchJson: placeholderFetch });
+        expect(placeholder).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+        expect(placeholderFetch).toHaveBeenCalledTimes(1);
+    });
+
     test('admits only explicit Brampton CC BY or Statistics Canada records', async () => {
         const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
             ? { owner: 'Brampton', type: 'Feature Service' }

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -5,6 +5,7 @@ describe('configured municipal catalogue sources', () => {
         expect(sources.map(source => source.id)).toEqual([
             'toronto-open-data', 'montreal-open-data', 'ottawa-hub', 'vancouver-open-data',
             'calgary-open-data', 'edmonton-open-data', 'winnipeg-open-data', 'halifax-hub',
+            'hamilton-hub',
             'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
             'mississauga-hub', 'brampton-hub', 'peel-hub'
         ]);
@@ -81,6 +82,29 @@ describe('configured municipal catalogue sources', () => {
             mode: 'custom-field', section: 'Licence', field: 'Licence',
             allowed: ['Open Government Licence - Winnipeg']
         }));
+    });
+
+    test('configures Hamilton as an allowlisted City publisher under its portal licence', () => {
+        const hamilton = getSource('hamilton-hub');
+        expect(hamilton).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'open.hamilton.ca',
+            catalogUrl: 'https://open.hamilton.ca/api/feed/dcat-us/1.1.json'
+        }));
+        expect(hamilton.publisherAliases).toHaveLength(11);
+        expect(hamilton.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
+        ]));
+        expect(hamilton.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: expect.stringContaining('/open-data-licence-terms-and-conditions'),
+                attributionEn: 'Contains public sector Data made available under the City of Hamilton’s Open Data Licence'
+            })
+        })]);
+        expect(hamilton.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-cd-3525', relationship: 'direct',
+            includesDescendants: false
+        })]);
     });
 
     test('configures Vancouver as a record-licensed Opendatasoft city source', () => {

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -378,4 +378,102 @@ spatialDescribe('PostGIS viewport integration', () => {
             { slug: 'halifax-ns-1209034', place_id: 'sgc-csd-1209034' }
         ]);
     });
+
+    test('migration canonicalizes the City of Hamilton and preserves the township', async () => {
+        // Recreate the three generic SGC rows present before migration 019,
+        // including references to the duplicate City subdivision.
+        await client.query(`
+            DELETE FROM place_aliases
+            WHERE slug IN (
+                'hamilton-on-3514019', 'hamilton-on-3525',
+                'hamilton-on-3525005', 'sgc-csd-3525005'
+            )
+        `);
+        await client.query("UPDATE places SET slug = 'hamilton-on-3525' WHERE id = 'sgc-cd-3525'");
+        await client.query("UPDATE places SET slug = 'hamilton-on' WHERE id = 'sgc-csd-3514019'");
+        await client.query(`
+            INSERT INTO places (
+                id, slug, kind, name_en, name_fr, type_en, type_fr,
+                parent_id, enabled, featured
+            ) VALUES (
+                'sgc-csd-3525005', 'hamilton-on-3525005', 'municipality',
+                'Hamilton', 'Hamilton', 'Municipality', 'Municipalité',
+                'sgc-cd-3525', true, false
+            )
+        `);
+        await client.query(`
+            DELETE FROM place_identifiers
+            WHERE scheme = 'sgc-csd' AND vintage = '2021' AND value = '3525005'
+        `);
+        await client.query(`
+            INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+            VALUES ('sgc-csd-3525005', 'sgc-csd', '2021', '3525005')
+        `);
+        await client.query("UPDATE organizations SET place_id = 'sgc-csd-3525005' WHERE id = $1", [orgId]);
+        await client.query(`
+            INSERT INTO dataset_places (
+                source_id, dataset_id, place_id, relationship,
+                includes_descendants, assignment_method
+            ) VALUES ('open-canada', $1, 'sgc-csd-3525005', 'direct', false, 'source')
+        `, [datasetId]);
+
+        const migration = fs.readFileSync(path.join(
+            __dirname, '..', 'sql', 'migrations', '019_hamilton_place.sql'
+        ), 'utf8');
+        await client.query(migration);
+        await client.query(migration);
+
+        const places = await client.query(`
+            SELECT id, slug, kind, parent_id, type_en, type_fr, featured,
+                   latitude, longitude, default_zoom
+            FROM places
+            WHERE id IN ('sgc-csd-3514019', 'sgc-cd-3525', 'sgc-csd-3525005')
+            ORDER BY id
+        `);
+        expect(places.rows).toEqual([
+            expect.objectContaining({
+                id: 'sgc-cd-3525', slug: 'hamilton-on', kind: 'municipality',
+                parent_id: 'ca-on', type_en: 'City', type_fr: 'Ville', featured: true,
+                latitude: 43.2557, longitude: -79.8711, default_zoom: 9
+            }),
+            expect.objectContaining({
+                id: 'sgc-csd-3514019', slug: 'hamilton-township-on',
+                kind: 'municipality', parent_id: 'sgc-cd-3514',
+                type_en: 'Township', type_fr: 'Canton', featured: false
+            })
+        ]);
+
+        const identifiers = await client.query(`
+            SELECT scheme, value FROM place_identifiers
+            WHERE place_id = 'sgc-cd-3525' ORDER BY scheme
+        `);
+        expect(identifiers.rows).toEqual([
+            { scheme: 'sgc-cd', value: '3525' },
+            { scheme: 'sgc-csd', value: '3525005' }
+        ]);
+
+        const aliases = await client.query(`
+            SELECT slug, place_id FROM place_aliases
+            WHERE slug LIKE 'hamilton-on-%' OR slug = 'sgc-csd-3525005'
+            ORDER BY slug
+        `);
+        expect(aliases.rows).toEqual([
+            { slug: 'hamilton-on-3514019', place_id: 'sgc-csd-3514019' },
+            { slug: 'hamilton-on-3525', place_id: 'sgc-cd-3525' },
+            { slug: 'hamilton-on-3525005', place_id: 'sgc-cd-3525' },
+            { slug: 'sgc-csd-3525005', place_id: 'sgc-cd-3525' }
+        ]);
+
+        const references = await client.query(`
+            SELECT o.place_id,
+                   EXISTS (
+                       SELECT 1 FROM dataset_places dp
+                       WHERE dp.dataset_id = $2 AND dp.place_id = 'sgc-cd-3525'
+                   ) AS dataset_moved
+            FROM organizations o WHERE o.id = $1
+        `, [orgId, datasetId]);
+        expect(references.rows).toEqual([{
+            place_id: 'sgc-cd-3525', dataset_moved: true
+        }]);
+    });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -285,4 +285,36 @@ describe('Statistics Canada SGC place normalization', () => {
             expect.objectContaining({ scheme: 'sgc-csd', value: '3520005' })
         ]);
     });
+
+    test('merges the City of Hamilton while disambiguating Hamilton Township', () => {
+        const en = [
+            { Level: '2', Code: '35', 'Class title': 'Ontario' },
+            { Level: '3', Code: '3514', 'Class title': 'Northumberland' },
+            { Level: '4', Code: '3514019', 'Class title': 'Hamilton' },
+            { Level: '3', Code: '3525', 'Class title': 'Hamilton' },
+            { Level: '4', Code: '3525005', 'Class title': 'Hamilton' }
+        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
+        const result = normalize(en, fr);
+
+        expect(result.places.find(place => place.id === 'sgc-csd-3514019')).toEqual(
+            expect.objectContaining({
+                slug: 'hamilton-township-on', kind: 'municipality',
+                parentId: 'sgc-cd-3514', typeEn: 'Township', typeFr: 'Canton',
+                featured: false
+            })
+        );
+        expect(result.places.find(place => place.id === 'sgc-cd-3525')).toEqual(
+            expect.objectContaining({
+                slug: 'hamilton-on', kind: 'municipality', parentId: 'ca-on',
+                typeEn: 'City', typeFr: 'Ville', featured: true,
+                latitude: 43.2557, longitude: -79.8711, defaultZoom: 9
+            })
+        );
+        expect(result.places.find(place => place.id === 'sgc-csd-3525005')).toBeUndefined();
+        expect(result.identifiers.filter(item => item.placeId === 'sgc-cd-3525')).toEqual([
+            expect.objectContaining({ scheme: 'sgc-cd', value: '3525' }),
+            expect.objectContaining({ scheme: 'sgc-csd', value: '3525005' })
+        ]);
+    });
 });

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -118,6 +118,31 @@ const HALIFAX_LICENSE = {
     attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Halifax.'
 };
 
+const HAMILTON_LICENSE = {
+    titleEn: 'City of Hamilton Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Hamilton',
+    url: 'https://www.hamilton.ca/city-council/data-maps/open-data/open-data-licence-terms-and-conditions',
+    attributionEn: 'Contains public sector Data made available under the City of Hamilton’s Open Data Licence',
+    attributionFr: 'Contient des données du secteur public fournies selon la licence de données ouvertes de la Ville de Hamilton.'
+};
+
+// The feed currently publishes the City itself plus these exact department
+// paths. Keep the allowlist fail-closed: an unfamiliar publisher string must be
+// reviewed before portal-wide City terms can be applied to it.
+const HAMILTON_PUBLISHER_PATTERNS = [
+    /^city of hamilton$/i,
+    /^city of hamilton;\s*corporate services;\s*information technology$/i,
+    /^city of hamilton;\s*planning and economic development;\s*planning$/i,
+    /^city of hamilton;\s*public works;\s*transportation operations & maintenance$/i,
+    /^city of hamilton,\s*corporate services,\s*information technology,\s*business applications,\s*spatial solutions and data services$/i,
+    /^city of hamilton;\s*public works;\s*hamilton water$/i,
+    /^city of hamilton;\s*public works;\s*engineering services$/i,
+    /^city of hamilton;\s*planning and economic development;\s*transportation planning and parking$/i,
+    /^city of hamilton;\s*public works;\s*environmental services$/i,
+    /^city of hamilton;\s*planning and economic development;\s*parking and by-law services$/i,
+    /^city of hamilton;;$/i
+];
+
 const MISSISSAUGA_LICENSE = {
     titleEn: 'City of Mississauga Open Data Terms of Use',
     titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Mississauga',
@@ -432,6 +457,35 @@ const sources = [{
         includesDescendants: false
     }]
 }, {
+    id: 'hamilton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Hamilton Open Data',
+    nameFr: 'Données ouvertes de la Ville de Hamilton',
+    homepageUrl: 'https://open.hamilton.ca/',
+    catalogUrl: 'https://open.hamilton.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open.hamilton.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: HAMILTON_PUBLISHER_PATTERNS.map(publisher => ({
+        publisher, name: 'City of Hamilton'
+    })),
+    authoritativePublishers: [{ publisher: /^city of hamilton$/i }],
+    // The official licence governs the open-data catalogue. Apply it only
+    // after an exact configured City/department publisher match and after the
+    // restricted-terms check above.
+    licenseRules: [{
+        publisher: /^city of hamilton$/i,
+        license: HAMILTON_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^city of hamilton$/i,
+        placeId: 'sgc-cd-3525',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
     id: 'oshawa-hub',
     kind: 'arcgis-hub',
     nameEn: 'City of Oshawa Open Data Hub',
@@ -687,6 +741,7 @@ module.exports = {
     EDMONTON_LICENSE,
     WINNIPEG_LICENSE,
     HALIFAX_LICENSE,
+    HAMILTON_LICENSE,
     MISSISSAUGA_LICENSE,
     CC_BY_4_LICENSE,
     OGL_CANADA_LICENSE,

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -10,9 +10,16 @@ const PROVINCES = {
     '46': 'mb', '47': 'sk', '48': 'ab', '59': 'bc', '60': 'yt', '61': 'nt', '62': 'nu'
 };
 const TERRITORIES = new Set(['60', '61', '62']);
+const SINGLE_TIER_CITY_CSD = {
+    '3506008': 'sgc-cd-3506',
+    '3520005': 'sgc-cd-3520',
+    '3525005': 'sgc-cd-3525'
+};
+const SINGLE_TIER_CITY_CD = new Set(['3506', '3520', '3525']);
 const FEATURED_PLACE_IDS = new Set([
     'sgc-cd-3506',
     'sgc-cd-3520',
+    'sgc-cd-3525',
     'ca-on-durham',
     'sgc-csd-3518005',
     'sgc-csd-3518039',
@@ -35,6 +42,7 @@ const FEATURED_PLACE_IDS = new Set([
 ]);
 const MUNICIPAL_TYPES = {
     '2466023': ['City', 'Ville'],
+    '3514019': ['Township', 'Canton'],
     '3518005': ['Town', 'Ville'],
     '3518039': ['Township', 'Canton'],
     '3518017': ['Municipality', 'Municipalité'],
@@ -55,6 +63,7 @@ const MUNICIPAL_TYPES = {
 const PLACE_VIEWPORTS = {
     '2466023': [45.5019, -73.5674, 10],
     '3506': [45.4215, -75.6972, 9],
+    '3525': [43.2557, -79.8711, 9],
     '3518': [44.0569, -78.8570, 9],
     '3518013': [43.8971, -78.8658, 11],
     '3520': [43.6532, -79.3832, 10],
@@ -98,11 +107,11 @@ function normalize(enRows, frRows) {
         const fr = frByCode.get(code) || {};
         const nameEn = String(row['Class title'] || '').trim();
         const nameFr = String(fr['Titres de classes'] || nameEn).trim();
-        // Ottawa and Toronto are each simultaneously a census division and a
-        // census subdivision. Keep both official identifiers while exposing
-        // one canonical single-tier city for each.
-        if (level === 4 && ['3506008', '3520005'].includes(code)) {
-            const placeId = code === '3506008' ? 'sgc-cd-3506' : 'sgc-cd-3520';
+        // Ottawa, Toronto and Hamilton are each simultaneously a census
+        // division and a census subdivision. Keep both official identifiers
+        // while exposing one canonical single-tier city for each.
+        if (level === 4 && SINGLE_TIER_CITY_CSD[code]) {
+            const placeId = SINGLE_TIER_CITY_CSD[code];
             identifiers.push({ placeId, scheme: 'sgc-csd', vintage: '2021', value: code });
             continue;
         }
@@ -117,11 +126,11 @@ function normalize(enRows, frRows) {
             baseSlug = slugify(nameEn);
         } else if (level === 3) {
             id = code === '3518' ? 'ca-on-durham' : 'sgc-cd-' + code;
-            kind = ['3506', '3520'].includes(code) ? 'municipality' : 'region';
+            kind = SINGLE_TIER_CITY_CD.has(code) ? 'municipality' : 'region';
             parentId = code.slice(0, 2) === '35' ? 'ca-on' : 'sgc-pr-' + code.slice(0, 2);
             scheme = 'sgc-cd';
-            typeEn = ['3506', '3520'].includes(code) ? 'City' : 'Census division';
-            typeFr = ['3506', '3520'].includes(code) ? 'Ville' : 'Division de recensement';
+            typeEn = SINGLE_TIER_CITY_CD.has(code) ? 'City' : 'Census division';
+            typeFr = SINGLE_TIER_CITY_CD.has(code) ? 'Ville' : 'Division de recensement';
             baseSlug = slugify(nameEn) + '-' + provinceAbbr;
         } else {
             id = code === '3518013' ? 'ca-on-oshawa' : 'sgc-csd-' + code;
@@ -142,7 +151,9 @@ function normalize(enRows, frRows) {
         if (code === '2466') slug = 'montreal-region-qc';
         if (code === '2466023') slug = 'montreal-qc';
         if (code === '3506') slug = 'ottawa-on';
+        if (code === '3514019') slug = 'hamilton-township-on';
         if (code === '3520') slug = 'toronto-on';
+        if (code === '3525') slug = 'hamilton-on';
         if (code === '3518013') slug = 'oshawa-on';
         if (code === '3518') {
             typeEn = 'Regional municipality';

--- a/server/sql/migrations/019_hamilton_place.sql
+++ b/server/sql/migrations/019_hamilton_place.sql
@@ -1,0 +1,114 @@
+-- The City of Hamilton is simultaneously Statistics Canada census division
+-- 3525 and census subdivision 3525005. CanQuery exposes one canonical city
+-- while keeping both official identifiers. The unrelated Township of Hamilton
+-- in Northumberland receives an explicit township slug so the major city can
+-- own /places/hamilton-on.
+
+-- Canonical place slugs must never also remain in the alias table.
+DELETE FROM place_aliases
+WHERE slug IN ('hamilton-on', 'hamilton-township-on');
+
+-- Seed the township ancestry as well as renaming an existing full-SGC import.
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-3514', 'northumberland-on', 'region',
+    'Northumberland', 'Northumberland', 'Census division', 'Division de recensement',
+    'ca-on', NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-csd-3514019', 'hamilton-township-on', 'municipality',
+    'Hamilton', 'Hamilton', 'Township', 'Canton', 'sgc-cd-3514',
+    NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-3525', 'hamilton-on', 'municipality',
+    'Hamilton', 'Hamilton', 'City', 'Ville', 'ca-on',
+    43.2557, -79.8711, 9, true, true
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+-- Preserve links that may have been created against the duplicate city
+-- subdivision before removing it. Overlapping links remain harmless.
+INSERT INTO dataset_places (
+    source_id, dataset_id, place_id, relationship,
+    includes_descendants, assignment_method
+)
+SELECT source_id, dataset_id, 'sgc-cd-3525', relationship,
+       includes_descendants, assignment_method
+FROM dataset_places
+WHERE place_id = 'sgc-csd-3525005'
+ON CONFLICT (source_id, dataset_id, place_id, relationship) DO UPDATE SET
+    includes_descendants = EXCLUDED.includes_descendants,
+    assignment_method = EXCLUDED.assignment_method;
+
+DELETE FROM dataset_places WHERE place_id = 'sgc-csd-3525005';
+UPDATE organizations SET place_id = 'sgc-cd-3525'
+WHERE place_id = 'sgc-csd-3525005';
+DELETE FROM place_identifiers WHERE place_id = 'sgc-csd-3525005';
+
+INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+VALUES
+    ('sgc-cd-3514', 'sgc-cd', '2021', '3514'),
+    ('sgc-csd-3514019', 'sgc-csd', '2021', '3514019'),
+    ('sgc-cd-3525', 'sgc-cd', '2021', '3525'),
+    ('sgc-cd-3525', 'sgc-csd', '2021', '3525005')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;
+
+DELETE FROM places WHERE id = 'sgc-csd-3525005';
+
+INSERT INTO place_aliases (slug, place_id)
+VALUES
+    ('hamilton-on-3514019', 'sgc-csd-3514019'),
+    ('hamilton-on-3525', 'sgc-cd-3525'),
+    ('hamilton-on-3525005', 'sgc-cd-3525'),
+    ('sgc-csd-3525005', 'sgc-cd-3525')
+ON CONFLICT (slug) DO UPDATE SET place_id = EXCLUDED.place_id;


### PR DESCRIPTION
## Summary
- add the official City of Hamilton ArcGIS Hub source with a fail-closed publisher allowlist
- merge Hamilton census-division/subdivision identities into one featured city while disambiguating Hamilton Township
- preserve bounded ArcGIS maps, licence provenance, aliases, and future SGC refresh behavior

## Validation
- server lint and 424 default-run tests
- 9 isolated PostGIS tests after migrations 001-019
- client lint, 107 tests, and production build
- live dry run: 463 discovered, 376 admitted, 154 mappable, 87 expected exclusions, 0 failures