### PR TITLE
Add Surrey open data coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,14 @@ portal-wide City of Hamilton Open Data Licence applies only to the configured
 City and department publisher strings; unfamiliar, placeholder, external, and
 restricted publishers fail closed. Hamilton's census-division and subdivision
 identities are merged into one featured city, while the unrelated Northumberland
-municipality remains available as Hamilton Township. The featured local
-directory also covers Durham Region and all eight lower-tier
-municipalities, with direct feeds from Durham, Ajax, Oshawa, Pickering and the
+municipality remains available as Hamilton Township. The City of Surrey's
+official ArcGIS catalogue is also included. Surrey's
+portal-wide Open Government License applies only to exact City of Surrey
+publisher evidence; external and explicitly restricted records fail closed,
+while eligible spatial layers use the existing bounded ArcGIS viewport path.
+Surrey remains a distinct featured city beneath Greater Vancouver in the SGC
+hierarchy. The featured local directory also covers Durham Region and all eight
+lower-tier municipalities, with direct feeds from Durham, Ajax, Oshawa, Pickering and the
 explicitly open-licensed subset of Whitby.
 Clarington is represented through Durham’s regional coverage only: its current
 public web-map terms are personal/non-commercial, so no direct adapter is enabled.
@@ -93,6 +98,7 @@ npm run sync:source -- --source=vancouver-open-data --dry-run
 npm run sync:source -- --source=calgary-open-data --dry-run
 npm run sync:source -- --source=halifax-hub --dry-run
 npm run sync:source -- --source=hamilton-hub --dry-run
+npm run sync:source -- --source=surrey-hub --dry-run
 npm run sync:source -- --source=durham-hub --dry-run
 npm run sync:source -- --source=peel-hub --dry-run
 npm run sync:municipal                    # sync every enabled local source
@@ -126,6 +132,7 @@ curl 'http://localhost:3100/api/v1/places?q=Edmonton'
 curl 'http://localhost:3100/api/v1/places?q=Winnipeg'
 curl 'http://localhost:3100/api/v1/places?q=Halifax'
 curl 'http://localhost:3100/api/v1/places?q=Hamilton'
+curl 'http://localhost:3100/api/v1/places?q=Surrey'
 
 # place-filtered sources are authoritative; counts expose total + authoritative
 curl 'http://localhost:3100/api/v1/sources?place=clarington-on'
@@ -136,6 +143,7 @@ curl 'http://localhost:3100/api/v1/sources?place=edmonton-ab'
 curl 'http://localhost:3100/api/v1/sources?place=winnipeg-mb'
 curl 'http://localhost:3100/api/v1/sources?place=halifax-ns'
 curl 'http://localhost:3100/api/v1/sources?place=hamilton-on'
+curl 'http://localhost:3100/api/v1/sources?place=surrey-bc'
 
 # dataset detail - resources tagged datastore | ingested | ingestable | file-only
 curl 'http://localhost:3100/api/v1/datasets/<idOrName>'
@@ -222,7 +230,7 @@ remain in PostGIS.
 The SPA (`client/`) starts with a search plus an optional remembered place
 (All Canada remains the default). Its grouped selector shows featured regions,
 their municipalities, and standalone featured cities such as Calgary, Montréal,
-Edmonton, Halifax, Hamilton, Ottawa, Toronto, Vancouver and Winnipeg;
+Edmonton, Halifax, Hamilton, Ottawa, Surrey, Toronto, Vancouver and Winnipeg;
 search on `/places` still reaches the complete Canadian SGC hierarchy. Place
 pages combine directly local datasets with records whose parent jurisdiction
 explicitly covers that place, and label regional-only coverage instead of

--- a/client/src/components/PlaceSelect.test.jsx
+++ b/client/src/components/PlaceSelect.test.jsx
@@ -20,6 +20,7 @@ describe('PlaceSelect', () => {
       { id: 'sgc-csd-4611040', slug: 'winnipeg-mb', kind: 'municipality', name: { en: 'Winnipeg' }, parent: { id: 'sgc-cd-4611' }, dataset_count: 229 },
       { id: 'sgc-csd-1209034', slug: 'halifax-ns', kind: 'municipality', name: { en: 'Halifax' }, parent: { id: 'sgc-cd-1209' }, dataset_count: 327 },
       { id: 'sgc-cd-3525', slug: 'hamilton-on', kind: 'municipality', name: { en: 'Hamilton' }, parent: { id: 'ca-on' }, dataset_count: 376 },
+      { id: 'sgc-csd-5915004', slug: 'surrey-bc', kind: 'municipality', name: { en: 'Surrey' }, parent: { id: 'sgc-cd-5915' }, dataset_count: 216 },
     ]} />);
     const select = screen.getByRole('combobox', { name: 'Choose a place' });
     expect(select).toHaveDisplayValue('All Canada');
@@ -33,6 +34,7 @@ describe('PlaceSelect', () => {
     expect(screen.getAllByRole('option', { name: /Winnipeg/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Halifax/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Hamilton/ })).toHaveLength(1);
+    expect(screen.getAllByRole('option', { name: /Surrey/ })).toHaveLength(1);
     expect([...container.querySelectorAll('optgroup')].map(group => group.label)).toEqual([
       'Featured regions', 'Municipalities in Durham', 'Municipalities in Peel', 'Featured cities', 'Other places'
     ]);

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -91,6 +91,12 @@ beforeEach(() => {
       name: { en: 'Hamilton', fr: 'Hamilton' }, type: { en: 'City', fr: 'Ville' },
       parent: { id: 'ca-on', name: { en: 'Ontario', fr: 'Ontario' } },
       dataset_count: 376, direct_dataset_count: 376, mappable_resource_count: 154
+    },
+    {
+      id: 'sgc-csd-5915004', slug: 'surrey-bc', kind: 'municipality',
+      name: { en: 'Surrey', fr: 'Surrey' }, type: { en: 'City', fr: 'Ville' },
+      parent: { id: 'sgc-cd-5915', name: { en: 'Greater Vancouver', fr: 'Greater Vancouver' } },
+      dataset_count: 216, direct_dataset_count: 216, mappable_resource_count: 180
     }
   ] });
 });
@@ -112,6 +118,7 @@ describe('PlacesPage', () => {
     expect(screen.getAllByRole('link', { name: /Winnipeg/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Halifax/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Hamilton/ })).toHaveLength(1);
+    expect(screen.getAllByRole('link', { name: /Surrey/ })).toHaveLength(1);
     expect(screen.getByRole('link', { name: /Clarington/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Caledon/ })).toBeInTheDocument();

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -281,6 +281,7 @@ curl -s 'https://<your-domain>/api/v1/places?q=Vancouver'
 curl -s 'https://<your-domain>/api/v1/places?q=Calgary'
 curl -s 'https://<your-domain>/api/v1/places?q=Halifax'
 curl -s 'https://<your-domain>/api/v1/places?q=Hamilton'
+curl -s 'https://<your-domain>/api/v1/places?q=Surrey'
 curl -s 'https://<your-domain>/api/v1/places?q=Mississauga'
 curl -s 'https://<your-domain>/api/v1/places?q=Brampton'
 curl -s 'https://<your-domain>/api/v1/sources?place=clarington-on'
@@ -289,6 +290,7 @@ curl -s 'https://<your-domain>/api/v1/sources?place=ottawa-on'
 curl -s 'https://<your-domain>/api/v1/sources?place=vancouver-bc'
 curl -s 'https://<your-domain>/api/v1/sources?place=halifax-ns'
 curl -s 'https://<your-domain>/api/v1/sources?place=hamilton-on'
+curl -s 'https://<your-domain>/api/v1/sources?place=surrey-bc'
 # UI: search by place, open a mapped dataset, pan/zoom the live Map tab, then load its table snapshot
 ```
 

--- a/server/__tests__/arcgisHubAdapter.test.js
+++ b/server/__tests__/arcgisHubAdapter.test.js
@@ -302,6 +302,48 @@ describe('ArcGIS Hub adapter', () => {
         expect(placeholderFetch).toHaveBeenCalledTimes(1);
     });
 
+    test('applies Surrey portal terms only to exact City publisher evidence', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'SurreyGIS', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const source = getSource('surrey-hub');
+        const cityRecord = record({
+            landingPage: 'https://opendata-surrey.hub.arcgis.com/datasets/surrey::public-art',
+            publisher: { name: 'City of Surrey' },
+            license: '<p>Constraints go here</p>'
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+
+        expect(city.status).toBe('included');
+        expect(city.value.organization.titleEn).toBe('City of Surrey');
+        expect(city.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-5915004', relationship: 'direct', includesDescendants: false
+        }));
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'Open Government License – Surrey',
+            licenseUrl: expect.stringContaining('/pages/55089a19491a4fe59a41e059fd8af708'),
+            attributionEn: 'Contains information licensed under the Open Government License – City of Surrey.'
+        }));
+
+        const restricted = await adapter.enrichRecord({
+            ...cityRecord,
+            license: 'Available for personal, non-commercial use only.'
+        }, source, { fetchJson });
+        expect(restricted).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+
+        const external = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: 'Ministry of Education' },
+            license: null
+        }, source, { fetchJson });
+        expect(external).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+    });
+
     test('admits only explicit Brampton CC BY or Statistics Canada records', async () => {
         const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
             ? { owner: 'Brampton', type: 'Feature Service' }

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -5,7 +5,7 @@ describe('configured municipal catalogue sources', () => {
         expect(sources.map(source => source.id)).toEqual([
             'toronto-open-data', 'montreal-open-data', 'ottawa-hub', 'vancouver-open-data',
             'calgary-open-data', 'edmonton-open-data', 'winnipeg-open-data', 'halifax-hub',
-            'hamilton-hub',
+            'hamilton-hub', 'surrey-hub',
             'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
             'mississauga-hub', 'brampton-hub', 'peel-hub'
         ]);
@@ -148,6 +148,29 @@ describe('configured municipal catalogue sources', () => {
                 url: expect.stringContaining('/open-data-licence-version-20')
             })
         }));
+    });
+
+    test('configures Surrey as an exact-publisher ArcGIS source under its portal licence', () => {
+        const surrey = getSource('surrey-hub');
+        expect(surrey).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata-surrey.hub.arcgis.com',
+            catalogUrl: 'https://opendata-surrey.hub.arcgis.com/api/feed/dcat-us/1.1.json'
+        }));
+        expect(surrey.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
+        ]));
+        expect(surrey.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                titleEn: 'Open Government License – Surrey',
+                url: expect.stringContaining('/pages/55089a19491a4fe59a41e059fd8af708'),
+                attributionEn: 'Contains information licensed under the Open Government License – City of Surrey.'
+            })
+        })]);
+        expect(surrey.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-5915004', relationship: 'direct',
+            includesDescendants: false
+        })]);
     });
 
     test('configures Toronto as an authoritative CKAN city source', () => {

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -476,4 +476,52 @@ spatialDescribe('PostGIS viewport integration', () => {
             place_id: 'sgc-cd-3525', dataset_moved: true
         }]);
     });
+
+    test('migration seeds canonical featured Surrey ancestry idempotently', async () => {
+        await client.query(`
+            UPDATE places
+            SET type_en = 'Municipality', type_fr = 'Municipalité',
+                featured = false, latitude = NULL, longitude = NULL,
+                default_zoom = NULL
+            WHERE id = 'sgc-csd-5915004'
+        `);
+        const migration = fs.readFileSync(path.join(
+            __dirname, '..', 'sql', 'migrations', '020_surrey_place.sql'
+        ), 'utf8');
+        await client.query(migration);
+        await client.query(migration);
+
+        const places = await client.query(`
+            SELECT id, slug, kind, parent_id, type_en, type_fr, featured,
+                   latitude, longitude, default_zoom
+            FROM places
+            WHERE id IN ('sgc-pr-59', 'sgc-cd-5915', 'sgc-csd-5915004')
+            ORDER BY CASE id
+                WHEN 'sgc-pr-59' THEN 1 WHEN 'sgc-cd-5915' THEN 2 ELSE 3 END
+        `);
+        expect(places.rows).toEqual([
+            expect.objectContaining({
+                id: 'sgc-pr-59', slug: 'british-columbia', kind: 'province',
+                parent_id: 'ca', featured: false
+            }),
+            expect.objectContaining({
+                id: 'sgc-cd-5915', slug: 'greater-vancouver-bc', kind: 'region',
+                parent_id: 'sgc-pr-59', featured: false
+            }),
+            expect.objectContaining({
+                id: 'sgc-csd-5915004', slug: 'surrey-bc', kind: 'municipality',
+                parent_id: 'sgc-cd-5915', type_en: 'City', type_fr: 'Ville',
+                featured: true, latitude: 49.1913, longitude: -122.849,
+                default_zoom: 10
+            })
+        ]);
+
+        const identifier = await client.query(`
+            SELECT place_id, scheme, value FROM place_identifiers
+            WHERE scheme = 'sgc-csd' AND vintage = '2021' AND value = '5915004'
+        `);
+        expect(identifier.rows).toEqual([{
+            place_id: 'sgc-csd-5915004', scheme: 'sgc-csd', value: '5915004'
+        }]);
+    });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -151,6 +151,33 @@ describe('Statistics Canada SGC place normalization', () => {
         }));
     });
 
+    test('features Surrey as a canonical city beneath Greater Vancouver', () => {
+        const en = [
+            { Level: '2', Code: '59', 'Class title': 'British Columbia' },
+            { Level: '3', Code: '5915', 'Class title': 'Greater Vancouver' },
+            { Level: '4', Code: '5915004', 'Class title': 'Surrey' }
+        ];
+        const fr = [
+            { Code: '59', 'Titres de classes': 'Colombie-Britannique' },
+            { Code: '5915', 'Titres de classes': 'Greater Vancouver' },
+            { Code: '5915004', 'Titres de classes': 'Surrey' }
+        ];
+        const result = normalize(en, fr);
+
+        expect(result.places.find(place => place.id === 'sgc-csd-5915004')).toEqual(
+            expect.objectContaining({
+                slug: 'surrey-bc', kind: 'municipality', parentId: 'sgc-cd-5915',
+                typeEn: 'City', typeFr: 'Ville', featured: true,
+                latitude: 49.1913, longitude: -122.849, defaultZoom: 10
+            })
+        );
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                placeId: 'sgc-csd-5915004', scheme: 'sgc-csd', value: '5915004'
+            })
+        ]));
+    });
+
     test('keeps the Halifax census division and featured regional municipality distinct', () => {
         const en = [
             { Level: '2', Code: '12', 'Class title': 'Nova Scotia' },

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -126,6 +126,14 @@ const HAMILTON_LICENSE = {
     attributionFr: 'Contient des données du secteur public fournies selon la licence de données ouvertes de la Ville de Hamilton.'
 };
 
+const SURREY_LICENSE = {
+    titleEn: 'Open Government License – Surrey',
+    titleFr: 'Licence du gouvernement ouvert – Surrey',
+    url: 'https://opendata-surrey.hub.arcgis.com/pages/55089a19491a4fe59a41e059fd8af708',
+    attributionEn: 'Contains information licensed under the Open Government License – City of Surrey.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville de Surrey.'
+};
+
 // The feed currently publishes the City itself plus these exact department
 // paths. Keep the allowlist fail-closed: an unfamiliar publisher string must be
 // reviewed before portal-wide City terms can be applied to it.
@@ -486,6 +494,36 @@ const sources = [{
         includesDescendants: false
     }]
 }, {
+    id: 'surrey-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Surrey Open Data',
+    nameFr: 'Données ouvertes de la Ville de Surrey',
+    homepageUrl: 'https://opendata-surrey.hub.arcgis.com/',
+    catalogUrl: 'https://opendata-surrey.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-surrey.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^city of surrey$/i, name: 'City of Surrey' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of surrey$/i }],
+    // Surrey's official open-data page applies this licence portal-wide. Keep
+    // admission tied to exact City publisher evidence; generic ArcGIS
+    // placeholder text is not a restriction, while explicit restrictive terms
+    // and external publishers still fail closed.
+    licenseRules: [{
+        publisher: /^city of surrey$/i,
+        license: SURREY_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^city of surrey$/i,
+        placeId: 'sgc-csd-5915004',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
     id: 'oshawa-hub',
     kind: 'arcgis-hub',
     nameEn: 'City of Oshawa Open Data Hub',
@@ -742,6 +780,7 @@ module.exports = {
     WINNIPEG_LICENSE,
     HALIFAX_LICENSE,
     HAMILTON_LICENSE,
+    SURREY_LICENSE,
     MISSISSAUGA_LICENSE,
     CC_BY_4_LICENSE,
     OGL_CANADA_LICENSE,

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -38,7 +38,8 @@ const FEATURED_PLACE_IDS = new Set([
     'sgc-csd-4806016',
     'sgc-csd-4811061',
     'sgc-csd-4611040',
-    'sgc-csd-1209034'
+    'sgc-csd-1209034',
+    'sgc-csd-5915004'
 ]);
 const MUNICIPAL_TYPES = {
     '2466023': ['City', 'Ville'],
@@ -58,7 +59,8 @@ const MUNICIPAL_TYPES = {
     '4806016': ['City', 'Ville'],
     '4811061': ['City', 'Ville'],
     '4611040': ['City', 'Ville'],
-    '1209034': ['Regional municipality', 'Municipalité régionale']
+    '1209034': ['Regional municipality', 'Municipalité régionale'],
+    '5915004': ['City', 'Ville']
 };
 const PLACE_VIEWPORTS = {
     '2466023': [45.5019, -73.5674, 10],
@@ -75,7 +77,8 @@ const PLACE_VIEWPORTS = {
     '4806016': [51.0447, -114.0719, 9],
     '4811061': [53.5461, -113.4938, 9],
     '4611040': [49.8954, -97.1385, 9],
-    '1209034': [44.6488, -63.5752, 8]
+    '1209034': [44.6488, -63.5752, 8],
+    '5915004': [49.1913, -122.8490, 10]
 };
 
 function slugify(value) {

--- a/server/sql/migrations/020_surrey_place.sql
+++ b/server/sql/migrations/020_surrey_place.sql
@@ -1,0 +1,75 @@
+-- Surrey is a Statistics Canada census subdivision within the Greater
+-- Vancouver census division. The ancestry already exists for Vancouver, but
+-- seed it here as well so this migration remains self-contained and safe to
+-- apply before a complete SGC refresh.
+
+DELETE FROM place_aliases WHERE slug = 'surrey-bc';
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-pr-59', 'british-columbia', 'province',
+    'British Columbia', 'Colombie-Britannique',
+    'Province', 'Province', 'ca', NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-5915', 'greater-vancouver-bc', 'region',
+    'Greater Vancouver', 'Greater Vancouver',
+    'Census division', 'Division de recensement', 'sgc-pr-59',
+    NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-csd-5915004', 'surrey-bc', 'municipality',
+    'Surrey', 'Surrey', 'City', 'Ville', 'sgc-cd-5915',
+    49.1913, -122.8490, 10, true, true
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+VALUES
+    ('sgc-pr-59', 'sgc-pr', '2021', '59'),
+    ('sgc-cd-5915', 'sgc-cd', '2021', '5915'),
+    ('sgc-csd-5915004', 'sgc-csd', '2021', '5915004')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;


### PR DESCRIPTION
## What & why

Adds the City of Surrey's official ArcGIS Hub catalogue as a standalone featured city.

- admits only exact City of Surrey publisher evidence under the official portal-wide Open Government License – Surrey
- preserves the licence's required attribution and rejects external or explicitly restricted records
- assigns admitted records directly to canonical SGC place `sgc-csd-5915004`
- adds idempotent migration 020 plus SGC refresh preservation for Surrey's City/Ville type and curated viewport
- updates generic featured-place regression coverage and public operator documentation

The verified live dry run is 225 discovered, 216 included, 9 expected exclusions, 0 failures, and 180 bounded ArcGIS maps.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

- Clean PostGIS validation applied migrations 001–020 and passed all 10 isolated spatial tests.
- No dependency manifests or runtime frontend components changed.
- The City-owned record containing ArcGIS's literal `Constraints go here` placeholder is admitted under the verified portal-wide grant; external publishers and actual restrictive evidence remain fail-closed.