### PR TITLE
Add Québec City and Laval open data coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ versioned Statistics Canada SGC hierarchy powers place-first discovery, and
 spatial resources can be explored through bounded maps before their CSV snapshot
 is loaded. Toronto's official CKAN catalogue is included as one canonical city,
 with its GeoJSON DataStore layers rebuilt into a local PostGIS viewport index.
+Québec City and Laval use the official shared Données Québec CKAN catalogue
+with exact organization and licence evidence, French-first metadata, and
+selected direct GeoJSON resources indexed locally.
 Ottawa's official ArcGIS catalogue is included as a second standalone city, with
 the City portal-wide licence and explicit Ottawa Police licensing preserved, plus
 live maps served through bounded upstream viewports. Montréal's official CKAN
@@ -93,6 +96,8 @@ npm run migrate               # idempotent, applies sql/migrations/*.sql
 node scripts/catalog-sync.js --limit 200   # small real harvest (~2 min, polite)
 npm run sync:places                       # Statistics Canada SGC hierarchy
 npm run sync:source -- --source=montreal-open-data --dry-run
+npm run sync:source -- --source=quebec-city-open-data --dry-run
+npm run sync:source -- --source=laval-open-data --dry-run
 npm run sync:source -- --source=ottawa-hub --dry-run
 npm run sync:source -- --source=vancouver-open-data --dry-run
 npm run sync:source -- --source=calgary-open-data --dry-run
@@ -126,6 +131,8 @@ curl 'http://localhost:3100/api/v1/places?featured=true'
 curl 'http://localhost:3100/api/v1/places?q=Oshawa'
 curl 'http://localhost:3100/api/v1/places?q=Mississauga'
 curl 'http://localhost:3100/api/v1/places?q=Montr%C3%A9al'
+curl 'http://localhost:3100/api/v1/places?q=Qu%C3%A9bec'
+curl 'http://localhost:3100/api/v1/places?q=Laval'
 curl 'http://localhost:3100/api/v1/places?q=Vancouver'
 curl 'http://localhost:3100/api/v1/places?q=Calgary'
 curl 'http://localhost:3100/api/v1/places?q=Edmonton'
@@ -144,6 +151,8 @@ curl 'http://localhost:3100/api/v1/sources?place=winnipeg-mb'
 curl 'http://localhost:3100/api/v1/sources?place=halifax-ns'
 curl 'http://localhost:3100/api/v1/sources?place=hamilton-on'
 curl 'http://localhost:3100/api/v1/sources?place=surrey-bc'
+curl 'http://localhost:3100/api/v1/sources?place=quebec-qc'
+curl 'http://localhost:3100/api/v1/sources?place=laval-qc'
 
 # dataset detail - resources tagged datastore | ingested | ingestable | file-only
 curl 'http://localhost:3100/api/v1/datasets/<idOrName>'
@@ -230,7 +239,8 @@ remain in PostGIS.
 The SPA (`client/`) starts with a search plus an optional remembered place
 (All Canada remains the default). Its grouped selector shows featured regions,
 their municipalities, and standalone featured cities such as Calgary, Montréal,
-Edmonton, Halifax, Hamilton, Ottawa, Surrey, Toronto, Vancouver and Winnipeg;
+Québec City, Laval, Edmonton, Halifax, Hamilton, Ottawa, Surrey, Toronto,
+Vancouver and Winnipeg;
 search on `/places` still reaches the complete Canadian SGC hierarchy. Place
 pages combine directly local datasets with records whose parent jurisdiction
 explicitly covers that place, and label regional-only coverage instead of

--- a/client/src/components/PlaceSelect.test.jsx
+++ b/client/src/components/PlaceSelect.test.jsx
@@ -14,6 +14,8 @@ describe('PlaceSelect', () => {
       { id: 'sgc-cd-3506', slug: 'ottawa-on', kind: 'municipality', name: { en: 'Ottawa' }, parent: { id: 'ca-on' }, dataset_count: 392 },
       { id: 'sgc-cd-3520', slug: 'toronto-on', kind: 'municipality', name: { en: 'Toronto' }, parent: { id: 'ca-on' }, dataset_count: 556 },
       { id: 'sgc-csd-2466023', slug: 'montreal-qc', kind: 'municipality', name: { en: 'Montréal' }, parent: { id: 'sgc-cd-2466' }, dataset_count: 405 },
+      { id: 'sgc-csd-2423027', slug: 'quebec-qc', kind: 'municipality', name: { en: 'Québec' }, parent: { id: 'sgc-cd-2423' }, dataset_count: 35 },
+      { id: 'sgc-cd-2465', slug: 'laval-qc', kind: 'municipality', name: { en: 'Laval' }, parent: { id: 'sgc-pr-24' }, dataset_count: 130 },
       { id: 'sgc-csd-5915022', slug: 'vancouver-bc', kind: 'municipality', name: { en: 'Vancouver' }, parent: { id: 'sgc-cd-5915' }, dataset_count: 178 },
       { id: 'sgc-csd-4806016', slug: 'calgary-ab', kind: 'municipality', name: { en: 'Calgary' }, parent: { id: 'sgc-cd-4806' }, dataset_count: 570 },
       { id: 'sgc-csd-4811061', slug: 'edmonton-ab', kind: 'municipality', name: { en: 'Edmonton' }, parent: { id: 'sgc-cd-4811' }, dataset_count: 974 },
@@ -29,6 +31,8 @@ describe('PlaceSelect', () => {
     expect(screen.getByRole('option', { name: /Ottawa/ })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /Montréal/ })).toBeInTheDocument();
     expect(screen.getAllByRole('option', { name: /Vancouver/ })).toHaveLength(1);
+    expect(screen.getAllByRole('option', { name: /Québec/ })).toHaveLength(1);
+    expect(screen.getAllByRole('option', { name: /Laval/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Calgary/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Edmonton/ })).toHaveLength(1);
     expect(screen.getAllByRole('option', { name: /Winnipeg/ })).toHaveLength(1);

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -56,6 +56,18 @@ beforeEach(() => {
       dataset_count: 405, direct_dataset_count: 390, mappable_resource_count: 304
     },
     {
+      id: 'sgc-csd-2423027', slug: 'quebec-qc', kind: 'municipality',
+      name: { en: 'Québec', fr: 'Québec' }, type: { en: 'City', fr: 'Ville' },
+      parent: { id: 'sgc-cd-2423', name: { en: 'Québec', fr: 'Québec' } },
+      dataset_count: 35, direct_dataset_count: 35, mappable_resource_count: 24
+    },
+    {
+      id: 'sgc-cd-2465', slug: 'laval-qc', kind: 'municipality',
+      name: { en: 'Laval', fr: 'Laval' }, type: { en: 'City', fr: 'Ville' },
+      parent: { id: 'sgc-pr-24', name: { en: 'Québec', fr: 'Québec' } },
+      dataset_count: 130, direct_dataset_count: 130, mappable_resource_count: 73
+    },
+    {
       id: 'sgc-csd-5915022', slug: 'vancouver-bc', kind: 'municipality',
       name: { en: 'Vancouver', fr: 'Vancouver' }, type: { en: 'City', fr: 'Ville' },
       parent: { id: 'sgc-cd-5915', name: { en: 'Greater Vancouver', fr: 'Greater Vancouver' } },
@@ -112,6 +124,8 @@ describe('PlacesPage', () => {
     expect(screen.getByRole('link', { name: /Ottawa/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Toronto/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Montréal/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Québec/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Laval/ })).toBeInTheDocument();
     expect(screen.getAllByRole('link', { name: /Vancouver/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Calgary/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Edmonton/ })).toHaveLength(1);

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -162,6 +162,11 @@ catalogue, CSV and paginated GeoJSON endpoints from their configured portal and
 record id. Geometry tables within the row cap become immutable PMTiles in the
 private object bucket; all other admitted CSVs remain discoverable and honestly
 fall back to loadable or download-only according to row/column caps.
+Shared CKAN portals may be configured with an exact organization filter and a
+separate dataset base URL. Discovery pins the advertised count and fails closed
+on count drift, duplicate or missing package ids, truncated pages, or records
+outside the configured organization. Keep publisher and record-level licence
+rules explicit for each municipal organization.
 
 ## 6. Cron jobs
 

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -3,7 +3,8 @@ const { sources, getSource } = require('../config/catalogSources');
 describe('configured municipal catalogue sources', () => {
     test('syncs city portals before the authoritative portal in each regional cluster', () => {
         expect(sources.map(source => source.id)).toEqual([
-            'toronto-open-data', 'montreal-open-data', 'ottawa-hub', 'vancouver-open-data',
+            'toronto-open-data', 'montreal-open-data', 'quebec-city-open-data', 'laval-open-data',
+            'ottawa-hub', 'vancouver-open-data',
             'calgary-open-data', 'edmonton-open-data', 'winnipeg-open-data', 'halifax-hub',
             'hamilton-hub', 'surrey-hub',
             'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
@@ -199,6 +200,35 @@ describe('configured municipal catalogue sources', () => {
                 placeId: 'sgc-csd-2466023', relationship: 'coverage'
             })
         ]);
+    });
+
+    test('configures Québec City and Laval as filtered shared CKAN sources', () => {
+        for (const [id, organization, publisher, placeId] of [
+            ['quebec-city-open-data', 'ville-de-quebec', 'Ville de Québec', 'sgc-csd-2423027'],
+            ['laval-open-data', 'ville-de-laval', 'Ville de Laval', 'sgc-cd-2465']
+        ]) {
+            const source = getSource(id);
+            expect(source).toEqual(expect.objectContaining({
+                kind: 'ckan', metadataLanguage: 'fr', directGeoJsonMaps: true,
+                upstreamHost: 'www.donneesquebec.ca',
+                catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+                catalogOrganization: organization,
+                datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+                licenseMode: 'record-explicit'
+            }));
+            expect(source.authoritativePublishers).toEqual([
+                { publisher: expect.any(RegExp) }
+            ]);
+            expect(source.licenseRules).toEqual([expect.objectContaining({
+                publisher: expect.any(RegExp), licenseId: 'cc-by',
+                licenseTitle: 'Attribution (CC-BY 4.0)',
+                licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by'
+            })]);
+            expect(source.placeRules).toEqual([expect.objectContaining({
+                placeId, relationship: 'direct', includesDescendants: false
+            })]);
+            expect(source.authoritativePublishers[0].publisher.test(publisher)).toBe(true);
+        }
     });
 
     test('covers each direct feed without inventing a Clarington source', () => {

--- a/server/__tests__/ckanSourceAdapter.test.js
+++ b/server/__tests__/ckanSourceAdapter.test.js
@@ -3,6 +3,8 @@ const { getSource } = require('../config/catalogSources');
 
 const source = getSource('toronto-open-data');
 const montreal = getSource('montreal-open-data');
+const quebecCity = getSource('quebec-city-open-data');
+const laval = getSource('laval-open-data');
 
 function packageRecord(overrides = {}) {
     return {
@@ -35,6 +37,51 @@ describe('generic CKAN source adapter', () => {
         })).rejects.toThrow(/ended before|empty/i);
     });
 
+    test('filters shared CKAN portals and rejects duplicate or foreign records', async () => {
+        const records = [
+            packageRecord({ id: 'shared-one', organization: { name: 'ville-de-quebec' } }),
+            packageRecord({ id: 'shared-two', organization: { name: 'ville-de-quebec' } })
+        ];
+        const fetchJson = jest.fn(async url => {
+            const parsed = new URL(url);
+            expect(parsed.searchParams.get('fq')).toBe('organization:ville-de-quebec');
+            return { success: true, result: { count: 2, results: records } };
+        });
+        await expect(adapter.discover(quebecCity, { fetchJson })).resolves.toHaveLength(2);
+        expect(fetchJson).toHaveBeenCalledTimes(1);
+
+        await expect(adapter.discover(quebecCity, {
+            fetchJson: async () => ({ success: true, result: {
+                count: 2, results: [records[0], records[0]]
+            } })
+        })).rejects.toThrow(/duplicate/i);
+
+        await expect(adapter.discover(quebecCity, {
+            fetchJson: async () => ({ success: true, result: {
+                count: 2, results: [records[0], {
+                    ...records[1], organization: { name: 'other-org' }
+                }]
+            } })
+        })).rejects.toThrow(/outside its configured organization/i);
+    });
+
+    test('rejects unsafe shared organization configuration and changing counts', async () => {
+        await expect(adapter.discover({ ...quebecCity, catalogOrganization: 'ville-de-quebec&x' }, {
+            fetchJson: jest.fn()
+        })).rejects.toThrow(/unsafe/i);
+
+        const firstPage = Array.from({ length: 100 }, (_, index) => ({
+            id: 'row-' + index, organization: { name: 'ville-de-quebec' }
+        }));
+        await expect(adapter.discover(quebecCity, {
+            fetchJson: jest.fn()
+                .mockResolvedValueOnce({ success: true, result: { count: 101, results: firstPage } })
+                .mockResolvedValueOnce({ success: true, result: {
+                    count: 102, results: [{ id: 'row-100', organization: { name: 'ville-de-quebec' } }]
+                } })
+        })).rejects.toThrow(/count changed/i);
+    });
+
     test('namespaces identities, attaches Toronto licensing, and retains every DataStore resource', async () => {
         const record = packageRecord({
             resources: [{
@@ -62,7 +109,8 @@ describe('generic CKAN source adapter', () => {
         expect(result.value.dataset.keywordsEn).toEqual(['Transportation', 'Roads']);
         expect(result.value.source).toEqual(expect.objectContaining({
             isAuthoritative: true,
-            licenseUrl: 'https://open.toronto.ca/open-data-licence/'
+            licenseUrl: 'https://open.toronto.ca/open-data-licence/',
+            landingUrl: 'https://open.toronto.ca/dataset/road-centrelines/'
         }));
         expect(result.value.resources).toHaveLength(2);
         const datastore = result.value.resources.find(resource => resource.datastoreActive);
@@ -165,6 +213,43 @@ describe('generic CKAN source adapter', () => {
             organization: { id: 'third-party', title: 'Third Party' }
         }), montreal)).resolves.toEqual(expect.objectContaining({
             status: 'excluded', reason: 'unlicensed'
+        }));
+    });
+
+    test('admits exact Données Québec evidence and uses the shared dataset base URL', async () => {
+        const record = packageRecord({
+            id: 'quebec-record', name: 'fontaines-a-boire', title: 'Fontaines à boire',
+            organization: { id: 'ville-de-quebec', name: 'ville-de-quebec', title: 'Ville de Québec' },
+            license_id: 'cc-by',
+            license_title: 'Attribution (CC-BY 4.0)',
+            license_url: 'https://www.donneesquebec.ca/licence/#cc-by',
+            resources: [{
+                id: 'quebec-geojson', name: 'Fontaines GeoJSON', format: 'GeoJSON',
+                url: 'https://www.donneesquebec.ca/recherche/dataset/fontaines-a-boire/resource/quebec-geojson'
+            }]
+        });
+        const result = await adapter.enrichRecord(record, quebecCity);
+        expect(result.status).toBe('included');
+        expect(result.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseUrl: 'https://creativecommons.org/licenses/by/4.0/',
+            landingUrl: 'https://www.donneesquebec.ca/recherche/dataset/fontaines-a-boire/'
+        }));
+        expect(result.value.places).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-2423027', relationship: 'direct'
+        })]);
+        await expect(adapter.enrichRecord({ ...record, organization: {
+            id: 'ville-de-quebec', name: 'ville-de-quebec', title: 'Other Publisher'
+        } }, quebecCity)).resolves.toEqual(expect.objectContaining({
+            status: 'excluded', reason: 'unlicensed'
+        }));
+
+        const lavalResult = await adapter.enrichRecord({ ...record,
+            id: 'laval-record',
+            organization: { id: 'ville-de-laval', name: 'ville-de-laval', title: 'Ville de Laval' }
+        }, laval);
+        expect(lavalResult.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-2465'
         }));
     });
 });

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -533,6 +533,7 @@ spatialDescribe('PostGIS viewport integration', () => {
                 'laval-qc-2465', 'laval-qc-2465005', 'sgc-csd-2465005'
             )
         `);
+        await client.query("UPDATE places SET slug = 'quebec-qc-2423027-temp' WHERE id = 'sgc-csd-2423027'");
         await client.query("UPDATE places SET slug = 'quebec-qc' WHERE id = 'sgc-cd-2423'");
         await client.query("UPDATE places SET slug = 'quebec-qc-2423027' WHERE id = 'sgc-csd-2423027'");
         await client.query(`

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -524,4 +524,121 @@ spatialDescribe('PostGIS viewport integration', () => {
             place_id: 'sgc-csd-5915004', scheme: 'sgc-csd', value: '5915004'
         }]);
     });
+
+    test('migration canonicalizes Québec City and Laval with durable aliases', async () => {
+        await client.query(`
+            DELETE FROM place_aliases
+            WHERE slug IN (
+                'quebec-qc-2423', 'quebec-qc-2423027',
+                'laval-qc-2465', 'laval-qc-2465005', 'sgc-csd-2465005'
+            )
+        `);
+        await client.query("UPDATE places SET slug = 'quebec-qc' WHERE id = 'sgc-cd-2423'");
+        await client.query("UPDATE places SET slug = 'quebec-qc-2423027' WHERE id = 'sgc-csd-2423027'");
+        await client.query(`
+            UPDATE places
+            SET type_en = 'Municipality', type_fr = 'Municipalité',
+                featured = false, latitude = NULL, longitude = NULL,
+                default_zoom = NULL
+            WHERE id = 'sgc-cd-2465'
+        `);
+        await client.query(`
+            INSERT INTO places (
+                id, slug, kind, name_en, name_fr, type_en, type_fr,
+                parent_id, enabled, featured
+            ) VALUES (
+                'sgc-csd-2465005', 'laval-qc-2465005', 'municipality',
+                'Laval', 'Laval', 'Municipality', 'Municipalité',
+                'sgc-cd-2465', true, false
+            )
+        `);
+        await client.query(`
+            DELETE FROM place_identifiers
+            WHERE scheme = 'sgc-csd' AND vintage = '2021' AND value = '2465005'
+        `);
+        await client.query(`
+            INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+            VALUES ('sgc-csd-2465005', 'sgc-csd', '2021', '2465005')
+        `);
+        await client.query("UPDATE organizations SET place_id = 'sgc-csd-2465005' WHERE id = $1", [orgId]);
+        await client.query(`
+            DELETE FROM dataset_places
+            WHERE source_id = 'open-canada' AND dataset_id = $1
+        `, [datasetId]);
+        await client.query(`
+            INSERT INTO dataset_places (
+                source_id, dataset_id, place_id, relationship,
+                includes_descendants, assignment_method
+            ) VALUES ('open-canada', $1, 'sgc-csd-2465005', 'direct', false, 'source')
+        `, [datasetId]);
+
+        const migration = fs.readFileSync(path.join(
+            __dirname, '..', 'sql', 'migrations', '021_quebec_laval_places.sql'
+        ), 'utf8');
+        await client.query(migration);
+        await client.query(migration);
+
+        const places = await client.query(`
+            SELECT id, slug, kind, parent_id, type_en, type_fr, featured,
+                   latitude, longitude, default_zoom
+            FROM places
+            WHERE id IN ('sgc-cd-2423', 'sgc-csd-2423027', 'sgc-cd-2465', 'sgc-csd-2465005')
+            ORDER BY id
+        `);
+        expect(places.rows).toEqual([
+            expect.objectContaining({
+                id: 'sgc-cd-2423', slug: 'quebec-region-qc', kind: 'region',
+                parent_id: 'sgc-pr-24', type_en: 'Census division',
+                type_fr: 'Division de recensement', featured: false
+            }),
+            expect.objectContaining({
+                id: 'sgc-cd-2465', slug: 'laval-qc', kind: 'municipality',
+                parent_id: 'sgc-pr-24', type_en: 'City', type_fr: 'Ville',
+                featured: true, latitude: 45.6066, longitude: -73.7124, default_zoom: 10
+            }),
+            expect.objectContaining({
+                id: 'sgc-csd-2423027', slug: 'quebec-qc', kind: 'municipality',
+                parent_id: 'sgc-cd-2423', type_en: 'City', type_fr: 'Ville',
+                featured: true, latitude: 46.8139, longitude: -71.208, default_zoom: 10
+            })
+        ]);
+        expect(places.rows.find(row => row.id === 'sgc-csd-2465005')).toBeUndefined();
+
+        const identifiers = await client.query(`
+            SELECT place_id, scheme, value
+            FROM place_identifiers
+            WHERE place_id IN ('sgc-cd-2465', 'sgc-csd-2465005')
+            ORDER BY scheme
+        `);
+        expect(identifiers.rows).toEqual([
+            { place_id: 'sgc-cd-2465', scheme: 'sgc-cd', value: '2465' },
+            { place_id: 'sgc-cd-2465', scheme: 'sgc-csd', value: '2465005' }
+        ]);
+
+        const aliases = await client.query(`
+            SELECT slug, place_id FROM place_aliases
+            WHERE slug IN (
+                'quebec-qc-2423', 'quebec-qc-2423027',
+                'laval-qc-2465', 'laval-qc-2465005', 'sgc-csd-2465005'
+            )
+            ORDER BY slug
+        `);
+        expect(aliases.rows).toEqual([
+            { slug: 'laval-qc-2465', place_id: 'sgc-cd-2465' },
+            { slug: 'laval-qc-2465005', place_id: 'sgc-cd-2465' },
+            { slug: 'quebec-qc-2423', place_id: 'sgc-cd-2423' },
+            { slug: 'quebec-qc-2423027', place_id: 'sgc-csd-2423027' },
+            { slug: 'sgc-csd-2465005', place_id: 'sgc-cd-2465' }
+        ]);
+
+        const references = await client.query(`
+            SELECT o.place_id,
+                   EXISTS (
+                       SELECT 1 FROM dataset_places dp
+                       WHERE dp.dataset_id = $2 AND dp.place_id = 'sgc-cd-2465'
+                   ) AS dataset_moved
+            FROM organizations o WHERE o.id = $1
+        `, [orgId, datasetId]);
+        expect(references.rows).toEqual([{ place_id: 'sgc-cd-2465', dataset_moved: true }]);
+    });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -125,6 +125,54 @@ describe('Statistics Canada SGC place normalization', () => {
         }));
     });
 
+    test('keeps the Québec census division distinct from its featured city', () => {
+        const en = [
+            { Level: '2', Code: '24', 'Class title': 'Quebec' },
+            { Level: '3', Code: '2423', 'Class title': 'Québec' },
+            { Level: '4', Code: '2423027', 'Class title': 'Québec' },
+            { Level: '4', Code: '2423057', 'Class title': "L'Ancienne-Lorette" }
+        ];
+        const fr = [
+            { Code: '24', 'Titres de classes': 'Québec' },
+            { Code: '2423', 'Titres de classes': 'Québec' },
+            { Code: '2423027', 'Titres de classes': 'Québec' },
+            { Code: '2423057', 'Titres de classes': "L'Ancienne-Lorette" }
+        ];
+        const result = normalize(en, fr);
+        expect(result.places.find(place => place.id === 'sgc-cd-2423')).toEqual(expect.objectContaining({
+            slug: 'quebec-region-qc', kind: 'region', parentId: 'sgc-pr-24', featured: false
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-2423027')).toEqual(expect.objectContaining({
+            slug: 'quebec-qc', kind: 'municipality', parentId: 'sgc-cd-2423',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 46.8139, longitude: -71.208, defaultZoom: 10
+        }));
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            expect.objectContaining({ placeId: 'sgc-cd-2423', scheme: 'sgc-cd', value: '2423' }),
+            expect.objectContaining({ placeId: 'sgc-csd-2423027', scheme: 'sgc-csd', value: '2423027' })
+        ]));
+    });
+
+    test('merges Laval census-division and subdivision identities into one city', () => {
+        const en = [
+            { Level: '2', Code: '24', 'Class title': 'Quebec' },
+            { Level: '3', Code: '2465', 'Class title': 'Laval' },
+            { Level: '4', Code: '2465005', 'Class title': 'Laval' }
+        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
+        const result = normalize(en, fr);
+        const laval = result.places.filter(place => place.nameEn === 'Laval');
+        expect(laval).toEqual([expect.objectContaining({
+            id: 'sgc-cd-2465', slug: 'laval-qc', kind: 'municipality',
+            parentId: 'sgc-pr-24', typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 45.6066, longitude: -73.7124, defaultZoom: 10
+        })]);
+        expect(result.identifiers.filter(item => item.placeId === 'sgc-cd-2465')).toEqual([
+            expect.objectContaining({ scheme: 'sgc-cd', value: '2465' }),
+            expect.objectContaining({ scheme: 'sgc-csd', value: '2465005' })
+        ]);
+    });
+
     test('features Vancouver as a canonical city beneath Greater Vancouver', () => {
         const en = [
             { Level: '2', Code: '59', 'Class title': 'British Columbia' },

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -270,6 +270,74 @@ const sources = [{
         }
     ]
 }, {
+    id: 'quebec-city-open-data',
+    kind: 'ckan',
+    nameEn: 'Québec City Open Data',
+    nameFr: 'Données ouvertes de la Ville de Québec',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-quebec',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-quebec',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-quebec',
+    defaultOrganizationName: 'ville-de-quebec',
+    defaultOrganizationTitleEn: 'Québec City',
+    defaultOrganizationTitleFr: 'Ville de Québec',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de québec$/i }],
+    licenseRules: [{
+        publisher: /^ville de québec$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de québec$/i,
+        placeId: 'sgc-csd-2423027',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'laval-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Laval Open Data',
+    nameFr: 'Données ouvertes de la Ville de Laval',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-laval',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-laval',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-laval',
+    defaultOrganizationName: 'ville-de-laval',
+    defaultOrganizationTitleEn: 'City of Laval',
+    defaultOrganizationTitleFr: 'Ville de Laval',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de laval$/i }],
+    licenseRules: [{
+        publisher: /^ville de laval$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de laval$/i,
+        placeId: 'sgc-cd-2465',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
     id: 'ottawa-hub',
     kind: 'arcgis-hub',
     nameEn: 'City of Ottawa Open Data',

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -13,10 +13,13 @@ const TERRITORIES = new Set(['60', '61', '62']);
 const SINGLE_TIER_CITY_CSD = {
     '3506008': 'sgc-cd-3506',
     '3520005': 'sgc-cd-3520',
-    '3525005': 'sgc-cd-3525'
+    '3525005': 'sgc-cd-3525',
+    '2465005': 'sgc-cd-2465'
 };
-const SINGLE_TIER_CITY_CD = new Set(['3506', '3520', '3525']);
+const SINGLE_TIER_CITY_CD = new Set(['2465', '3506', '3520', '3525']);
 const FEATURED_PLACE_IDS = new Set([
+    'sgc-csd-2423027',
+    'sgc-cd-2465',
     'sgc-cd-3506',
     'sgc-cd-3520',
     'sgc-cd-3525',
@@ -42,6 +45,8 @@ const FEATURED_PLACE_IDS = new Set([
     'sgc-csd-5915004'
 ]);
 const MUNICIPAL_TYPES = {
+    '2423027': ['City', 'Ville'],
+    '2465005': ['City', 'Ville'],
     '2466023': ['City', 'Ville'],
     '3514019': ['Township', 'Canton'],
     '3518005': ['Town', 'Ville'],
@@ -63,6 +68,8 @@ const MUNICIPAL_TYPES = {
     '5915004': ['City', 'Ville']
 };
 const PLACE_VIEWPORTS = {
+    '2423027': [46.8139, -71.2080, 10],
+    '2465': [45.6066, -73.7124, 10],
     '2466023': [45.5019, -73.5674, 10],
     '3506': [45.4215, -75.6972, 9],
     '3525': [43.2557, -79.8711, 9],
@@ -110,9 +117,10 @@ function normalize(enRows, frRows) {
         const fr = frByCode.get(code) || {};
         const nameEn = String(row['Class title'] || '').trim();
         const nameFr = String(fr['Titres de classes'] || nameEn).trim();
-        // Ottawa, Toronto and Hamilton are each simultaneously a census
-        // division and a census subdivision. Keep both official identifiers
-        // while exposing one canonical single-tier city for each.
+        // Québec remains a distinct city subdivision under its multi-city
+        // census division. Laval, Ottawa, Toronto and Hamilton are each
+        // single-tier census divisions with a matching city subdivision;
+        // preserve both official identifiers while exposing one city.
         if (level === 4 && SINGLE_TIER_CITY_CSD[code]) {
             const placeId = SINGLE_TIER_CITY_CSD[code];
             identifiers.push({ placeId, scheme: 'sgc-csd', vintage: '2021', value: code });
@@ -151,8 +159,11 @@ function normalize(enRows, frRows) {
         if (code === '1209') slug = 'halifax-region-ns';
         if (code === '1209034') slug = 'halifax-ns';
         if (code === '3518') slug = 'durham-on';
+        if (code === '2423') slug = 'quebec-region-qc';
+        if (code === '2423027') slug = 'quebec-qc';
         if (code === '2466') slug = 'montreal-region-qc';
         if (code === '2466023') slug = 'montreal-qc';
+        if (code === '2465') slug = 'laval-qc';
         if (code === '3506') slug = 'ottawa-on';
         if (code === '3514019') slug = 'hamilton-township-on';
         if (code === '3520') slug = 'toronto-on';

--- a/server/services/ckanSourceAdapter.js
+++ b/server/services/ckanSourceAdapter.js
@@ -138,10 +138,12 @@ function licenseFor(record, source) {
         const id = clean(record.license_id);
         const title = clean(record.license_title);
         const url = clean(record.license_url);
+        const publisher = publisherName(record, source);
         const rule = rules.find(item =>
             patternMatches(item.licenseId, id) &&
             patternMatches(item.licenseTitle, title) &&
-            patternMatches(item.licenseUrl, url)
+            patternMatches(item.licenseUrl, url) &&
+            patternMatches(item.publisher, publisher)
         );
         return rule ? rule.license : null;
     }
@@ -200,19 +202,41 @@ function canonicalKey(identity) {
 async function discover(source, options = {}) {
     const fetchJson = options.fetchJson || fetchPublicJson;
     const records = [];
+    const catalogOrganization = clean(source.catalogOrganization);
+    if (catalogOrganization && !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(catalogOrganization)) {
+        throw new Error('CKAN source has an unsafe catalog organization slug');
+    }
     let total = null;
+    const seen = new Set();
     for (let start = 0; total == null || start < total; start += PAGE_SIZE) {
         const url = new URL(source.catalogUrl.replace(/\/+$/, '') + '/package_search');
         url.searchParams.set('rows', String(PAGE_SIZE));
         url.searchParams.set('start', String(start));
         url.searchParams.set('sort', 'id asc');
+        if (catalogOrganization) url.searchParams.set('fq', 'organization:' + catalogOrganization);
         const body = await fetchJson(url.href, options.http);
         const result = body && body.success !== false ? body.result : null;
         if (!result || !Array.isArray(result.results) || !Number.isInteger(Number(result.count))) {
             throw new Error('CKAN source returned an invalid package_search response');
         }
-        total = Number(result.count);
-        records.push(...result.results);
+        const pageTotal = Number(result.count);
+        if (pageTotal < 0) throw new Error('CKAN source returned an invalid package_search count');
+        if (total == null) total = pageTotal;
+        else if (pageTotal !== total) throw new Error('CKAN source catalogue count changed while paging');
+        for (const record of result.results) {
+            const identity = identityFor(record);
+            if (!identity) throw new Error('CKAN source returned a package without an id');
+            const key = canonicalKey(identity);
+            if (seen.has(key)) throw new Error('CKAN source returned a duplicate package id');
+            seen.add(key);
+            if (catalogOrganization) {
+                const organization = record && record.organization || {};
+                if (clean(organization.name).toLowerCase() !== catalogOrganization.toLowerCase()) {
+                    throw new Error('CKAN source returned a package outside its configured organization');
+                }
+            }
+            records.push(record);
+        }
         if (result.results.length === 0) break;
     }
     if (total === 0 || records.length === 0) throw new Error('CKAN source returned an empty catalogue');
@@ -299,7 +323,9 @@ async function enrichRecord(record, source) {
                 sourceId: source.id,
                 externalId: canonicalKey(externalId),
                 datasetId,
-                landingUrl: source.homepageUrl.replace(/\/+$/, '') + '/dataset/' + encodeURIComponent(record.name) + '/',
+                landingUrl: (source.datasetBaseUrl ||
+                    source.homepageUrl.replace(/\/+$/, '') + '/dataset').replace(/\/+$/, '') +
+                    '/' + encodeURIComponent(record.name) + '/',
                 licenseTitleEn: licence.titleEn || null,
                 licenseTitleFr: licence.titleFr || null,
                 licenseUrl: licence.url,

--- a/server/sql/migrations/021_quebec_laval_places.sql
+++ b/server/sql/migrations/021_quebec_laval_places.sql
@@ -1,0 +1,143 @@
+-- Canonicalize Québec City and Laval in the 2021 Statistics Canada hierarchy.
+-- Québec (CD 2423) contains multiple municipalities, so its city remains the
+-- CSD 2423027 beneath a distinct regional place. Laval's CD 2465 is a
+-- single-tier city with CSD 2465005, so CanQuery exposes one canonical city
+-- while retaining both official identifiers.
+
+-- Release the public Québec region slug before assigning the city slug.
+UPDATE places
+SET slug = 'quebec-region-qc', updated_at = now()
+WHERE id = 'sgc-cd-2423' AND slug <> 'quebec-region-qc';
+
+-- Canonical slugs must not also remain aliases after an earlier refresh.
+DELETE FROM place_aliases
+WHERE slug IN (
+    'quebec-region-qc', 'quebec-qc', 'quebec-qc-2423',
+    'quebec-qc-2423027', 'laval-qc', 'laval-qc-2465',
+    'laval-qc-2465005', 'sgc-csd-2465005'
+);
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-pr-24', 'quebec', 'province',
+    'Quebec', 'Québec', 'Province', 'Province', 'ca',
+    NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-2423', 'quebec-region-qc', 'region',
+    'Québec', 'Québec', 'Census division', 'Division de recensement',
+    'sgc-pr-24', NULL, NULL, NULL, true, false
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-csd-2423027', 'quebec-qc', 'municipality',
+    'Québec', 'Québec', 'City', 'Ville', 'sgc-cd-2423',
+    46.8139, -71.2080, 10, true, true
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+-- Laval is a single-tier city in the SGC. Move any existing references from
+-- the generic subdivision row before removing that duplicate place.
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES (
+    'sgc-cd-2465', 'laval-qc', 'municipality',
+    'Laval', 'Laval', 'City', 'Ville', 'sgc-pr-24',
+    45.6066, -73.7124, 10, true, true
+) ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+INSERT INTO dataset_places (
+    source_id, dataset_id, place_id, relationship,
+    includes_descendants, assignment_method
+)
+SELECT source_id, dataset_id, 'sgc-cd-2465', relationship,
+       includes_descendants, assignment_method
+FROM dataset_places
+WHERE place_id = 'sgc-csd-2465005'
+ON CONFLICT (source_id, dataset_id, place_id, relationship) DO UPDATE SET
+    includes_descendants = EXCLUDED.includes_descendants,
+    assignment_method = EXCLUDED.assignment_method;
+
+DELETE FROM dataset_places WHERE place_id = 'sgc-csd-2465005';
+UPDATE organizations SET place_id = 'sgc-cd-2465'
+WHERE place_id = 'sgc-csd-2465005';
+
+DELETE FROM place_identifiers WHERE place_id = 'sgc-csd-2465005';
+DELETE FROM places WHERE id = 'sgc-csd-2465005';
+
+INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+VALUES
+    ('sgc-pr-24', 'sgc-pr', '2021', '24'),
+    ('sgc-cd-2423', 'sgc-cd', '2021', '2423'),
+    ('sgc-csd-2423027', 'sgc-csd', '2021', '2423027'),
+    ('sgc-cd-2465', 'sgc-cd', '2021', '2465'),
+    ('sgc-cd-2465', 'sgc-csd', '2021', '2465005')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;
+
+INSERT INTO place_aliases (slug, place_id)
+VALUES
+    ('quebec-qc-2423', 'sgc-cd-2423'),
+    ('quebec-qc-2423027', 'sgc-csd-2423027'),
+    ('laval-qc-2465', 'sgc-cd-2465'),
+    ('laval-qc-2465005', 'sgc-cd-2465'),
+    ('sgc-csd-2465005', 'sgc-cd-2465')
+ON CONFLICT (slug) DO UPDATE SET place_id = EXCLUDED.place_id;


### PR DESCRIPTION
## What & why

Adds Québec City and Laval as featured French-first municipal sources through the shared Données Québec CKAN catalogue. The adapter now supports exact organization filtering, stable count/identity validation, publisher-aware record licence rules, and shared dataset landing URLs. Migration 021 canonicalizes both city identities, and direct GeoJSON candidates use the existing PostGIS map queue.

## Checklist

- [x] `server`: `npm run lint && npm test` pass locally
- [x] `client`: `npm run lint && npm test && npm run build` pass locally
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

Live dry-runs match the audited baselines: Québec City 35 admitted datasets / 26 map candidates; Laval 130 admitted datasets / 73 map candidates. Migration 021 is covered by the isolated PostGIS integration suite.