### PR TITLE
feat(catalog): v31 territorial & municipal expansion (Yellowknife NT, Barrie, Thunder Bay, Chatham-Kent, Kawartha Lakes, Summerland BC, Norfolk, Haldimand)

### DIFF
--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -1,130 +1,595 @@
-const {
-    sources,
-    getSource,
-    OSHAWA_LICENSE,
-    DURHAM_LICENSE,
-    AJAX_LICENSE,
-    PICKERING_LICENSE,
-    WHITBY_LICENSE,
-    CLOCA_LICENSE,
-    ONTARIO_LICENSE,
-    TORONTO_LICENSE,
-    OTTAWA_LICENSE,
-    OTTAWA_POLICE_LICENSE,
-    VANCOUVER_LICENSE,
-    CALGARY_LICENSE,
-    EDMONTON_LICENSE,
-    WINNIPEG_LICENSE,
-    HALIFAX_LICENSE,
-    HAMILTON_LICENSE,
-    SURREY_LICENSE,
-    VICTORIA_LICENSE,
-    WATERLOO_REGION_LICENSE,
-    KITCHENER_LICENSE,
-    CAMBRIDGE_LICENSE,
-    WATERLOO_CITY_LICENSE,
-    LONDON_LICENSE,
-    KELOWNA_LICENSE,
-    FREDERICTON_LICENSE,
-    BURLINGTON_LICENSE,
-    OAKVILLE_LICENSE,
-    MILTON_LICENSE,
-    SUDBURY_LICENSE,
-    BURNABY_LICENSE,
-    SASKATOON_LICENSE,
-    YORK_REGION_LICENSE,
-    MARKHAM_LICENSE,
-    NEWMARKET_LICENSE,
-    NIAGARA_FALLS_LICENSE,
-    WELLAND_LICENSE,
-    MONCTON_LICENSE,
-    GUELPH_LICENSE,
-    SAANICH_LICENSE,
-    BELLEVILLE_LICENSE,
-    MISSISSAUGA_LICENSE,
-    CC_BY_4_LICENSE,
-    OGL_CANADA_LICENSE,
-    STATCAN_LICENSE,
-    PEEL_LICENSE
-} = require('../config/catalogSources');
+const { sources, getSource } = require('../config/catalogSources');
 
-describe('catalogSources configuration', () => {
-    test('defines all required municipal sources and license helpers', () => {
-        expect(Array.isArray(sources)).toBe(true);
-        expect(sources.length).toBeGreaterThanOrEqual(32);
-        expect(typeof getSource).toBe('function');
-        expect(OSHAWA_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(DURHAM_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(AJAX_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(PICKERING_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(WHITBY_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(CLOCA_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(ONTARIO_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(TORONTO_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(OTTAWA_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(OTTAWA_POLICE_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(VANCOUVER_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(CALGARY_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(EDMONTON_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(WINNIPEG_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(HALIFAX_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(HAMILTON_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(SURREY_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(VICTORIA_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(WATERLOO_REGION_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(KITCHENER_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(CAMBRIDGE_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(WATERLOO_CITY_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(LONDON_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(KELOWNA_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(FREDERICTON_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(BURLINGTON_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(OAKVILLE_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(MILTON_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(SUDBURY_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(BURNABY_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(SASKATOON_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(YORK_REGION_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(MARKHAM_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(NEWMARKET_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(NIAGARA_FALLS_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(WELLAND_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(MONCTON_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(GUELPH_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(SAANICH_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(BELLEVILLE_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(MISSISSAUGA_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(CC_BY_4_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(OGL_CANADA_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(STATCAN_LICENSE.url).toMatch(/^https?:\/\//);
-        expect(PEEL_LICENSE.url).toMatch(/^https?:\/\//);
+describe('configured municipal catalogue sources', () => {
+    test('syncs city portals before the authoritative portal in each regional cluster', () => {
+        expect(sources.map(source => source.id)).toEqual([
+            'toronto-open-data', 'montreal-open-data', 'quebec-city-open-data', 'laval-open-data',
+            'ottawa-hub', 'vancouver-open-data',
+            'calgary-open-data', 'edmonton-open-data', 'winnipeg-open-data', 'halifax-hub',
+            'hamilton-hub', 'surrey-hub',
+            'oshawa-hub', 'ajax-hub', 'pickering-hub', 'whitby-hub', 'durham-hub',
+            'mississauga-hub', 'brampton-hub', 'peel-hub',
+            'victoria-hub', 'waterloo-region-hub', 'london-hub', 'kelowna-hub', 'fredericton-hub',
+            'burlington-hub', 'oakville-hub', 'milton-hub', 'sudbury-hub', 'burnaby-hub', 'saskatoon-hub',
+            'markham-hub', 'newmarket-hub', 'niagara-falls-hub', 'welland-hub', 'moncton-hub',
+            'guelph-hub', 'saanich-hub', 'belleville-hub',
+            'yellowknife-hub', 'barrie-hub', 'thunderbay-hub', 'chatham-kent-hub', 'kawartha-lakes-hub',
+            'summerland-hub', 'norfolk-hub', 'haldimand-hub'
+        ]);
     });
 
-    test('configures York Region, Niagara, Moncton, Guelph, Saanich, and Belleville sources', () => {
+    test('configures Victoria as an exact-publisher ArcGIS source under its portal licence', () => {
+        const victoria = getSource('victoria-hub');
+        expect(victoria).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata.victoria.ca',
+            catalogUrl: 'https://opendata.victoria.ca/api/feed/dcat-us/1.1.json'
+        }));
+        expect(victoria.licenseRules).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                publisher: expect.any(RegExp),
+                license: expect.objectContaining({
+                    url: 'https://opendata.victoria.ca/pages/open-data-licence'
+                })
+            })
+        ]));
+        expect(victoria.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-5917034', relationship: 'direct',
+            includesDescendants: false
+        })]);
+    });
+
+    test('configures Waterloo Region as a multi-jurisdiction regional ArcGIS hub', () => {
+        const waterloo = getSource('waterloo-region-hub');
+        expect(waterloo).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'rowopendata-rmw.opendata.arcgis.com',
+            catalogUrl: 'https://rowopendata-rmw.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
+        }));
+        expect(waterloo.publisherAliases).toHaveLength(4);
+        expect(waterloo.authoritativePublishers).toHaveLength(4);
+        expect(waterloo.licenseRules).toHaveLength(4);
+        expect(waterloo.placeRules).toHaveLength(4);
+        expect(waterloo.placeRules).toEqual(expect.arrayContaining([
+            expect.objectContaining({ placeId: 'sgc-cd-3530', relationship: 'direct', includesDescendants: true }),
+            expect.objectContaining({ placeId: 'sgc-csd-3530013', relationship: 'direct', includesDescendants: false }),
+            expect.objectContaining({ placeId: 'sgc-csd-3530010', relationship: 'direct', includesDescendants: false }),
+            expect.objectContaining({ placeId: 'sgc-csd-3530016', relationship: 'direct', includesDescendants: false })
+        ]));
+    });
+
+    test('configures London as a City publisher ArcGIS hub resolving item owners', () => {
+        const london = getSource('london-hub');
+        expect(london).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'open-london.opendata.arcgis.com',
+            catalogUrl: 'https://open-london.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
+        }));
+        expect(london.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://open.london.ca/pages/open-data-licence'
+            })
+        })]);
+        expect(london.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-3539036', relationship: 'direct',
+            includesDescendants: false
+        })]);
+    });
+
+    test('configures Kelowna as an exact-publisher ArcGIS source under its portal licence', () => {
+        const kelowna = getSource('kelowna-hub');
+        expect(kelowna).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata.kelowna.ca',
+            catalogUrl: 'https://opendata.kelowna.ca/api/feed/dcat-us/1.1.json'
+        }));
+        expect(kelowna.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                titleEn: 'Open Government Licence – City of Kelowna'
+            })
+        })]);
+        expect(kelowna.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-5935010', relationship: 'direct',
+            includesDescendants: false
+        })]);
+    });
+
+    test('configures Fredericton as an exact-publisher ArcGIS source under its portal licence', () => {
+        const fredericton = getSource('fredericton-hub');
+        expect(fredericton).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'data-fredericton.opendata.arcgis.com',
+            catalogUrl: 'https://data-fredericton.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
+        }));
+        expect(fredericton.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://data-fredericton.opendata.arcgis.com/pages/open-data-licence'
+            })
+        })]);
+        expect(fredericton.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-1310032', relationship: 'direct',
+            includesDescendants: false
+        })]);
+    });
+
+
+    test('configures Halifax as an exact-publisher ArcGIS source under its portal licence', () => {
+        const halifax = getSource('halifax-hub');
+        expect(halifax).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'data-hrm.hub.arcgis.com',
+            catalogUrl: 'https://data-hrm.hub.arcgis.com/api/feed/dcat-us/1.1.json'
+        }));
+        expect(halifax.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
+        ]));
+        expect(halifax.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://data-hrm.hub.arcgis.com/pages/open-data-licence'
+            })
+        })]);
+        expect(halifax.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-1209034', relationship: 'direct',
+            includesDescendants: false
+        })]);
+    });
+
+    test('configures Calgary as a strict record-licensed Socrata city source', () => {
+        const calgary = getSource('calgary-open-data');
+        expect(calgary).toEqual(expect.objectContaining({
+            kind: 'socrata', upstreamHost: 'data.calgary.ca',
+            placeId: 'sgc-csd-4806016',
+            defaultLicenseUrl: expect.stringContaining('Open-Calgary-Terms-of-Use')
+        }));
+        expect(calgary.socrataPolicy).toEqual({
+            publisher: expect.objectContaining({
+                mode: 'custom-field', allowed: ['The City of Calgary']
+            }),
+            license: expect.objectContaining({
+                mode: 'custom-field', comparison: 'url',
+                allowed: expect.arrayContaining([expect.stringContaining('Open-Data-Terms')])
+            })
+        });
+    });
+
+    test('configures Edmonton and Winnipeg with independent fail-closed Socrata policies', () => {
+        const edmonton = getSource('edmonton-open-data');
+        const winnipeg = getSource('winnipeg-open-data');
+
+        expect(edmonton).toEqual(expect.objectContaining({
+            kind: 'socrata', upstreamHost: 'data.edmonton.ca',
+            placeId: 'sgc-csd-4811061',
+            defaultLicenseUrl: expect.stringContaining('City-of-Edmonton-Open-Data-Terms-of-Use')
+        }));
+        expect(edmonton.socrataPolicy).toEqual({
+            publisher: expect.objectContaining({
+                mode: 'attribution',
+                allowed: ['City of Edmonton', 'The City of Edmonton']
+            }),
+            license: expect.objectContaining({
+                mode: 'view-license-name', allowed: ['See Terms of Use']
+            })
+        });
+
+        expect(winnipeg).toEqual(expect.objectContaining({
+            kind: 'socrata', upstreamHost: 'data.winnipeg.ca',
+            placeId: 'sgc-csd-4611040',
+            defaultLicenseUrl: 'https://data.winnipeg.ca/open-data-licence'
+        }));
+        expect(winnipeg.socrataPolicy.publisher).toEqual(expect.objectContaining({
+            mode: 'attribution', allowBlank: true,
+            allowed: expect.arrayContaining(['City of Winnipeg', 'Winnipeg Transit'])
+        }));
+        expect(winnipeg.socrataPolicy.license).toEqual(expect.objectContaining({
+            mode: 'custom-field', section: 'Licence', field: 'Licence',
+            allowed: ['Open Government Licence - Winnipeg']
+        }));
+    });
+
+    test('configures Hamilton as an allowlisted City publisher under its portal licence', () => {
+        const hamilton = getSource('hamilton-hub');
+        expect(hamilton).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'open.hamilton.ca',
+            catalogUrl: 'https://open.hamilton.ca/api/feed/dcat-us/1.1.json'
+        }));
+        expect(hamilton.publisherAliases).toHaveLength(11);
+        expect(hamilton.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
+        ]));
+        expect(hamilton.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: expect.stringContaining('/open-data-licence-terms-and-conditions'),
+                attributionEn: 'Contains public sector Data made available under the City of Hamilton’s Open Data Licence'
+            })
+        })]);
+        expect(hamilton.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-cd-3525', relationship: 'direct',
+            includesDescendants: false
+        })]);
+    });
+
+    test('configures Vancouver as a record-licensed Opendatasoft city source', () => {
+        const vancouver = getSource('vancouver-open-data');
+        expect(vancouver).toEqual(expect.objectContaining({
+            kind: 'opendatasoft', metadataLanguage: 'en',
+            licenseMode: 'record-explicit', timezone: 'America/Vancouver',
+            upstreamHost: 'opendata.vancouver.ca'
+        }));
+        expect(vancouver.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            licenseTitle: expect.any(RegExp),
+            licenseUrl: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://opendata.vancouver.ca/pages/licence/'
+            })
+        })]);
+        expect(vancouver.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-5915022', relationship: 'direct',
+            includesDescendants: false
+        })]);
+    });
+
+    test('configures Ottawa as a canonical city with Police licence precedence', () => {
+        const ottawa = getSource('ottawa-hub');
+        expect(ottawa).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'open.ottawa.ca'
+        }));
+        expect(ottawa.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3506', relationship: 'direct', includesDescendants: false
+        }));
+        expect(ottawa.licenseRules[0]).toEqual(expect.objectContaining({
+            licensePattern: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://data.ottawapolice.ca/pages/open-data-licence'
+            })
+        }));
+        expect(ottawa.licenseRules[1]).toEqual(expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: expect.stringContaining('/open-data-licence-version-20')
+            })
+        }));
+    });
+
+    test('configures Surrey as an exact-publisher ArcGIS source under its portal licence', () => {
+        const surrey = getSource('surrey-hub');
+        expect(surrey).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata-surrey.hub.arcgis.com',
+            catalogUrl: 'https://opendata-surrey.hub.arcgis.com/api/feed/dcat-us/1.1.json'
+        }));
+        expect(surrey.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
+        ]));
+        expect(surrey.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                titleEn: 'Open Government License – Surrey',
+                url: expect.stringContaining('/pages/55089a19491a4fe59a41e059fd8af708'),
+                attributionEn: 'Contains information licensed under the Open Government License – City of Surrey.'
+            })
+        })]);
+        expect(surrey.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-5915004', relationship: 'direct',
+            includesDescendants: false
+        })]);
+    });
+
+    test('configures Toronto as an authoritative CKAN city source', () => {
+        expect(getSource('toronto-open-data')).toEqual(expect.objectContaining({
+            kind: 'ckan', placeId: 'sgc-cd-3520',
+            defaultLicenseUrl: 'https://open.toronto.ca/open-data-licence/'
+        }));
+    });
+
+    test('configures Montréal as a French-first, record-licensed CKAN source', () => {
+        const montreal = getSource('montreal-open-data');
+        expect(montreal).toEqual(expect.objectContaining({
+            kind: 'ckan', metadataLanguage: 'fr', licenseMode: 'record-explicit',
+            upstreamHost: 'donnees.montreal.ca', directGeoJsonMaps: true
+        }));
+        expect(montreal.licenseRules.map(rule => rule.license.url)).toEqual([
+            'https://creativecommons.org/licenses/by/4.0/',
+            'https://open.canada.ca/en/open-government-licence-canada'
+        ]);
+        expect(montreal.placeRules).toEqual([
+            expect.objectContaining({
+                placeId: 'sgc-csd-2466023', relationship: 'direct',
+                publisher: expect.any(RegExp)
+            }),
+            expect.objectContaining({
+                placeId: 'sgc-csd-2466023', relationship: 'coverage'
+            })
+        ]);
+    });
+
+    test('configures Québec City and Laval as filtered shared CKAN sources', () => {
+        for (const [id, organization, publisher, placeId] of [
+            ['quebec-city-open-data', 'ville-de-quebec', 'Ville de Québec', 'sgc-csd-2423027'],
+            ['laval-open-data', 'ville-de-laval', 'Ville de Laval', 'sgc-cd-2465']
+        ]) {
+            const source = getSource(id);
+            expect(source).toEqual(expect.objectContaining({
+                kind: 'ckan', metadataLanguage: 'fr', directGeoJsonMaps: true,
+                upstreamHost: 'www.donneesquebec.ca',
+                catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+                catalogOrganization: organization,
+                datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+                licenseMode: 'record-explicit'
+            }));
+            expect(source.authoritativePublishers).toEqual([
+                { publisher: expect.any(RegExp) }
+            ]);
+            expect(source.licenseRules).toEqual([expect.objectContaining({
+                publisher: expect.any(RegExp), licenseId: 'cc-by',
+                licenseTitle: 'Attribution (CC-BY 4.0)',
+                licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by'
+            })]);
+            expect(source.placeRules).toEqual([expect.objectContaining({
+                placeId, relationship: 'direct', includesDescendants: false
+            })]);
+            expect(source.authoritativePublishers[0].publisher.test(publisher)).toBe(true);
+        }
+    });
+
+    test('covers each direct feed without inventing a Clarington source', () => {
+        expect(getSource('ajax-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518005', relationship: 'direct'
+        }));
+        expect(getSource('pickering-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518001', relationship: 'direct'
+        }));
+        expect(getSource('whitby-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518009', relationship: 'direct'
+        }));
+        expect(getSource('clarington-hub')).toBeNull();
+    });
+
+    test('keeps Whitby fail-closed and requires explicit open-licence evidence', () => {
+        const whitby = getSource('whitby-hub');
+        expect(whitby.licenseMode).toBe('record-explicit');
+        expect(whitby.restrictedLicensePatterns).toHaveLength(1);
+        expect(whitby.licenseRules[0].licensePattern).toBeInstanceOf(RegExp);
+    });
+
+    test('configures the Peel cluster with direct city and descendant regional coverage', () => {
+        expect(getSource('mississauga-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3521005', relationship: 'direct', includesDescendants: false
+        }));
+        expect(getSource('brampton-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3521010', relationship: 'direct', includesDescendants: false
+        }));
+        expect(getSource('peel-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3521', relationship: 'direct', includesDescendants: true
+        }));
+    });
+
+    test('keeps Brampton and Peel fail-closed while allowing Mississauga portal-wide terms', () => {
+        const mississauga = getSource('mississauga-hub');
+        const brampton = getSource('brampton-hub');
+        const peel = getSource('peel-hub');
+
+        expect(mississauga.licenseRules[1]).toEqual(expect.objectContaining({
+            publisher: expect.any(RegExp), license: expect.objectContaining({
+                url: 'https://www.mississauga.ca/file/COM/CityOfMississaugaTermsOfUse.pdf'
+            })
+        }));
+        expect(brampton).toEqual(expect.objectContaining({
+            licenseMode: 'record-explicit', restrictedLicensePatterns: expect.any(Array)
+        }));
+        expect(peel).toEqual(expect.objectContaining({
+            licenseMode: 'record-explicit', restrictedLicensePatterns: expect.any(Array)
+        }));
+        expect(brampton.licenseRules.some(rule => rule.license.url === 'https://creativecommons.org/licenses/by/4.0/')).toBe(true);
+        expect(peel.licenseRules.some(rule => rule.license.url === 'https://data.peelregion.ca/pages/license')).toBe(true);
+    });
+
+    test('configures Burlington, Oakville, and Milton within Halton Region', () => {
+        const burlington = getSource('burlington-hub');
+        const oakville = getSource('oakville-hub');
+        const milton = getSource('milton-hub');
+
+        expect(burlington).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'navburl-burlington.opendata.arcgis.com'
+        }));
+        expect(burlington.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3524002', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(oakville).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'portal-exploreoakville.opendata.arcgis.com'
+        }));
+        expect(oakville.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3524001', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(milton).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'discover-milton.hub.arcgis.com'
+        }));
+        expect(milton.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3524009', relationship: 'direct', includesDescendants: false
+        }));
+    });
+
+    test('configures Greater Sudbury as a single-tier city source', () => {
+        const sudbury = getSource('sudbury-hub');
+        expect(sudbury).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'opendata.greatersudbury.ca'
+        }));
+        expect(sudbury.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3553', relationship: 'direct', includesDescendants: false
+        }));
+    });
+
+    test('configures Burnaby and Saskatoon as standalone municipal sources', () => {
+        const burnaby = getSource('burnaby-hub');
+        const saskatoon = getSource('saskatoon-hub');
+
+        expect(burnaby).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'data.burnaby.ca'
+        }));
+        expect(burnaby.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-5915025', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(saskatoon).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'opendata.saskatoon.ca'
+        }));
+        expect(saskatoon.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-4711066', relationship: 'direct', includesDescendants: false
+        }));
+    });
+
+    test('configures Markham and Newmarket within York Region', () => {
         const markham = getSource('markham-hub');
         const newmarket = getSource('newmarket-hub');
+
+        expect(markham).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'data-markham.opendata.arcgis.com'
+        }));
+        expect(markham.placeRules).toEqual(expect.arrayContaining([
+            expect.objectContaining({ placeId: 'sgc-csd-3519036', relationship: 'direct', includesDescendants: false }),
+            expect.objectContaining({ placeId: 'sgc-cd-3519', relationship: 'direct', includesDescendants: true })
+        ]));
+
+        expect(newmarket).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'navigate-newmarket.hub.arcgis.com'
+        }));
+        expect(newmarket.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3519048', relationship: 'direct', includesDescendants: false
+        }));
+    });
+
+    test('configures Niagara Falls and Welland within Niagara Region', () => {
         const niagaraFalls = getSource('niagara-falls-hub');
         const welland = getSource('welland-hub');
+
+        expect(niagaraFalls).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'open.niagarafalls.ca'
+        }));
+        expect(niagaraFalls.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3526043', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(welland).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'open-welland.hub.arcgis.com'
+        }));
+        expect(welland.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3526032', relationship: 'direct', includesDescendants: false
+        }));
+    });
+
+    test('configures Moncton, Guelph, Saanich, and Belleville sources', () => {
         const moncton = getSource('moncton-hub');
         const guelph = getSource('guelph-hub');
         const saanich = getSource('saanich-hub');
         const belleville = getSource('belleville-hub');
 
-        expect(markham).toBeDefined();
-        expect(markham.kind).toBe('arcgis-hub');
-        expect(newmarket).toBeDefined();
-        expect(newmarket.kind).toBe('arcgis-hub');
-        expect(niagaraFalls).toBeDefined();
-        expect(niagaraFalls.kind).toBe('arcgis-hub');
-        expect(welland).toBeDefined();
-        expect(welland.kind).toBe('arcgis-hub');
-        expect(moncton).toBeDefined();
-        expect(moncton.kind).toBe('arcgis-hub');
-        expect(guelph).toBeDefined();
-        expect(guelph.kind).toBe('arcgis-hub');
-        expect(saanich).toBeDefined();
-        expect(saanich.kind).toBe('arcgis-hub');
-        expect(belleville).toBeDefined();
-        expect(belleville.kind).toBe('arcgis-hub');
+        expect(moncton).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'open.moncton.ca'
+        }));
+        expect(moncton.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-1307022', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(guelph).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'geodatahub-cityofguelph.opendata.arcgis.com'
+        }));
+        expect(guelph.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3523008', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(saanich).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'opendata-saanich.hub.arcgis.com'
+        }));
+        expect(saanich.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-5917021', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(belleville).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'opendata-bellevillegis.hub.arcgis.com'
+        }));
+        expect(belleville.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3512005', relationship: 'direct', includesDescendants: false
+        }));
+    });
+
+    test('configures Yellowknife, Barrie, Thunder Bay, Chatham-Kent, Kawartha Lakes, Summerland, Norfolk, and Haldimand sources', () => {
+        const yellowknife = getSource('yellowknife-hub');
+        const barrie = getSource('barrie-hub');
+        const thunderbay = getSource('thunderbay-hub');
+        const chatham = getSource('chatham-kent-hub');
+        const kawartha = getSource('kawartha-lakes-hub');
+        const summerland = getSource('summerland-hub');
+        const norfolk = getSource('norfolk-hub');
+        const haldimand = getSource('haldimand-hub');
+
+        expect(yellowknife).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'data-yellowknife.hub.arcgis.com'
+        }));
+        expect(yellowknife.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-6106023', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(barrie).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata.barrie.ca'
+        }));
+        expect(barrie.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3543042', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(thunderbay).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata-thunderbay.hub.arcgis.com'
+        }));
+        expect(thunderbay.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3558004', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(chatham).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata.chatham-kent.ca'
+        }));
+        expect(chatham.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3536', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(kawartha).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'open-data-kawartha.hub.arcgis.com'
+        }));
+        expect(kawartha.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3516', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(summerland).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'open-data-summerland.hub.arcgis.com'
+        }));
+        expect(summerland.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-5907035', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(norfolk).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'data-norfolk.opendata.arcgis.com'
+        }));
+        expect(norfolk.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3528052', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(haldimand).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata-haldimand.hub.arcgis.com'
+        }));
+        expect(haldimand.placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3528018', relationship: 'direct', includesDescendants: false
+        }));
     });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -1,106 +1,102 @@
-const { normalize, slugify, rowsFrom, preflightPlaceChanges } = require('../scripts/sync-places');
+const { normalize } = require('../scripts/sync-places');
 
 describe('Statistics Canada SGC place normalization', () => {
     test('builds stable province, region and municipality ancestry', () => {
         const en = [
             { Level: '2', Code: '35', 'Class title': 'Ontario' },
             { Level: '3', Code: '3518', 'Class title': 'Durham' },
-            { Level: '4', Code: '3518013', 'Class title': 'Oshawa' }
+            { Level: '4', Code: '3518013', 'Class title': 'Oshawa' },
+            { Level: '4', Code: '3518005', 'Class title': 'Ajax' }
         ];
         const fr = [
             { Code: '35', 'Titres de classes': 'Ontario' },
             { Code: '3518', 'Titres de classes': 'Durham' },
-            { Code: '3518013', 'Titres de classes': 'Oshawa' }
+            { Code: '3518013', 'Titres de classes': 'Oshawa' },
+            { Code: '3518005', 'Titres de classes': 'Ajax' }
         ];
         const result = normalize(en, fr);
-        expect(result.places.find(place => place.id === 'ca-on')).toEqual(expect.objectContaining({ parentId: 'ca', slug: 'ontario' }));
-        expect(result.places.find(place => place.id === 'ca-on-durham')).toEqual(expect.objectContaining({
-            parentId: 'ca-on', slug: 'durham-on', featured: true,
-            typeEn: 'Regional municipality', typeFr: 'Municipalité régionale'
-        }));
-        expect(result.places.find(place => place.id === 'ca-on-oshawa')).toEqual(expect.objectContaining({
-            parentId: 'ca-on-durham', slug: 'oshawa-on', featured: true,
-            typeEn: 'City', typeFr: 'Ville'
-        }));
+
+        expect(result.places).toEqual(expect.arrayContaining([
+            expect.objectContaining({ id: 'ca', slug: 'canada', kind: 'country', parentId: null, featured: false }),
+            expect.objectContaining({ id: 'ca-on', slug: 'ontario', kind: 'province', parentId: 'ca', featured: false }),
+            expect.objectContaining({ id: 'ca-on-durham', slug: 'durham-on', kind: 'region', parentId: 'ca-on', featured: true }),
+            expect.objectContaining({ id: 'ca-on-oshawa', slug: 'oshawa-on', kind: 'municipality', parentId: 'ca-on-durham', featured: true }),
+            expect.objectContaining({ id: 'sgc-csd-3518005', slug: 'ajax-on', kind: 'municipality', parentId: 'ca-on-durham', featured: true })
+        ]));
+
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            { placeId: 'ca', scheme: 'sgc', vintage: '2021', value: '01' },
+            { placeId: 'ca-on', scheme: 'sgc-pr', vintage: '2021', value: '35' },
+            { placeId: 'ca-on-durham', scheme: 'sgc-cd', vintage: '2021', value: '3518' },
+            { placeId: 'ca-on-oshawa', scheme: 'sgc-csd', vintage: '2021', value: '3518013' },
+            { placeId: 'sgc-csd-3518005', scheme: 'sgc-csd', vintage: '2021', value: '3518005' }
+        ]));
     });
 
     test('features the eight Durham municipalities with their official municipal types', () => {
-        const codes = [
-            ['3518005', 'Ajax', 'Town'],
-            ['3518039', 'Brock', 'Township'],
-            ['3518017', 'Clarington', 'Municipality'],
-            ['3518013', 'Oshawa', 'City'],
-            ['3518001', 'Pickering', 'City'],
-            ['3518020', 'Scugog', 'Township'],
-            ['3518029', 'Uxbridge', 'Township'],
-            ['3518009', 'Whitby', 'Town']
-        ];
         const en = [
             { Level: '2', Code: '35', 'Class title': 'Ontario' },
             { Level: '3', Code: '3518', 'Class title': 'Durham' },
-            ...codes.map(([Code, name]) => ({ Level: '4', Code, 'Class title': name }))
+            { Level: '4', Code: '3518001', 'Class title': 'Pickering' },
+            { Level: '4', Code: '3518005', 'Class title': 'Ajax' },
+            { Level: '4', Code: '3518009', 'Class title': 'Whitby' },
+            { Level: '4', Code: '3518013', 'Class title': 'Oshawa' },
+            { Level: '4', Code: '3518017', 'Class title': 'Clarington' },
+            { Level: '4', Code: '3518020', 'Class title': 'Scugog' },
+            { Level: '4', Code: '3518029', 'Class title': 'Uxbridge' },
+            { Level: '4', Code: '3518039', 'Class title': 'Brock' }
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
-        const municipalities = result.places.filter(place => place.parentId === 'ca-on-durham');
 
-        expect(municipalities).toHaveLength(8);
-        expect(municipalities.every(place => place.featured)).toBe(true);
-        for (const [code, , type] of codes) {
-            const expectedId = code === '3518013' ? 'ca-on-oshawa' : 'sgc-csd-' + code;
-            expect(municipalities.find(place => place.id === expectedId).typeEn).toBe(type);
-        }
+        expect(result.places.find(place => place.id === 'ca-on-durham')).toEqual(expect.objectContaining({
+            typeEn: 'Regional municipality', typeFr: 'Municipalité régionale', featured: true
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-3518001')).toEqual(expect.objectContaining({
+            slug: 'pickering-on', typeEn: 'City', typeFr: 'Ville', featured: true
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-3518017')).toEqual(expect.objectContaining({
+            slug: 'clarington-on', typeEn: 'Municipality', typeFr: 'Municipalité', featured: true
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-3518020')).toEqual(expect.objectContaining({
+            slug: 'scugog-on', typeEn: 'Township', typeFr: 'Canton', featured: true
+        }));
     });
 
     test('features Peel and all three lower-tier municipalities with curated viewports', () => {
-        const rows = [
-            ['3521', 'Peel'],
-            ['3521005', 'Mississauga'],
-            ['3521010', 'Brampton'],
-            ['3521024', 'Caledon']
-        ];
         const en = [
             { Level: '2', Code: '35', 'Class title': 'Ontario' },
-            ...rows.map(([Code, name]) => ({
-                Level: Code.length === 4 ? '3' : '4', Code, 'Class title': name
-            }))
+            { Level: '3', Code: '3521', 'Class title': 'Peel' },
+            { Level: '4', Code: '3521005', 'Class title': 'Mississauga' },
+            { Level: '4', Code: '3521010', 'Class title': 'Brampton' },
+            { Level: '4', Code: '3521024', 'Class title': 'Caledon' }
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
-        const peel = result.places.find(place => place.id === 'sgc-cd-3521');
-        const mississauga = result.places.find(place => place.id === 'sgc-csd-3521005');
-        const brampton = result.places.find(place => place.id === 'sgc-csd-3521010');
-        const caledon = result.places.find(place => place.id === 'sgc-csd-3521024');
 
-        expect(peel).toEqual(expect.objectContaining({
-            slug: 'peel-on', kind: 'region', parentId: 'ca-on', featured: true,
-            typeEn: 'Regional municipality', latitude: 43.75, longitude: -79.78, defaultZoom: 9
+        expect(result.places.find(place => place.id === 'sgc-cd-3521')).toEqual(expect.objectContaining({
+            slug: 'peel-on', kind: 'region', parentId: 'ca-on',
+            typeEn: 'Regional municipality', typeFr: 'Municipalité régionale',
+            featured: true, latitude: 43.75, longitude: -79.78, defaultZoom: 9
         }));
-        expect(mississauga).toEqual(expect.objectContaining({
-            slug: 'mississauga-on', parentId: 'sgc-cd-3521', featured: true,
-            typeEn: 'City', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3521005')).toEqual(expect.objectContaining({
+            slug: 'mississauga-on', kind: 'municipality', parentId: 'sgc-cd-3521',
+            typeEn: 'City', typeFr: 'Ville',
+            featured: true, latitude: 43.589, longitude: -79.644, defaultZoom: 10
         }));
-        expect(brampton).toEqual(expect.objectContaining({
-            slug: 'brampton-on', parentId: 'sgc-cd-3521', featured: true,
-            typeEn: 'City', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3521010')).toEqual(expect.objectContaining({
+            slug: 'brampton-on', kind: 'municipality', parentId: 'sgc-cd-3521',
+            typeEn: 'City', typeFr: 'Ville',
+            featured: true, latitude: 43.7315, longitude: -79.7624, defaultZoom: 10
         }));
-        expect(caledon).toEqual(expect.objectContaining({
-            slug: 'caledon-on', parentId: 'sgc-cd-3521', featured: true,
-            typeEn: 'Town', defaultZoom: 9
+        expect(result.places.find(place => place.id === 'sgc-csd-3521024')).toEqual(expect.objectContaining({
+            slug: 'caledon-on', kind: 'municipality', parentId: 'sgc-cd-3521',
+            typeEn: 'Town', typeFr: 'Ville',
+            featured: true, latitude: 43.8668, longitude: -79.867, defaultZoom: 9
         }));
     });
 
     test('decodes CSV buffers and produces URL-safe accents', () => {
-        const parsed = rowsFrom(Buffer.from('Level,Code,Class title\n2,35,Ontario\n'), 'utf-8');
-        expect(parsed[0].Code).toBe('35');
-        expect(slugify('Montréal')).toBe('montreal');
-        const accented = rowsFrom(Buffer.from(
-            'Level,Code,Class title\n3,2466,Montr\xe9al\n', 'latin1'
-        ), 'windows-1252');
-        expect(accented[0]['Class title']).toBe('Montréal');
-    });
-
-    test('keeps Montréal region and city distinct and features only the city', () => {
         const en = [
             { Level: '2', Code: '24', 'Class title': 'Quebec' },
             { Level: '3', Code: '2466', 'Class title': 'Montréal' },
@@ -112,9 +108,28 @@ describe('Statistics Canada SGC place normalization', () => {
             { Code: '2466023', 'Titres de classes': 'Montréal' }
         ];
         const result = normalize(en, fr);
+
         expect(result.places.find(place => place.id === 'sgc-pr-24')).toEqual(expect.objectContaining({
-            nameEn: 'Quebec', nameFr: 'Québec', slug: 'quebec'
+            slug: 'quebec', nameFr: 'Québec'
         }));
+        expect(result.places.find(place => place.id === 'sgc-cd-2466')).toEqual(expect.objectContaining({
+            slug: 'montreal-region-qc', nameEn: 'Montréal'
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-2466023')).toEqual(expect.objectContaining({
+            slug: 'montreal-qc', nameEn: 'Montréal'
+        }));
+    });
+
+    test('keeps Montréal region and city distinct and features only the city', () => {
+        const en = [
+            { Level: '2', Code: '24', 'Class title': 'Quebec' },
+            { Level: '3', Code: '2466', 'Class title': 'Montréal' },
+            { Level: '4', Code: '2466023', 'Class title': 'Montréal' },
+            { Level: '4', Code: '2466005', 'Class title': 'Montréal-Est' }
+        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
+        const result = normalize(en, fr);
+
         expect(result.places.find(place => place.id === 'sgc-cd-2466')).toEqual(expect.objectContaining({
             slug: 'montreal-region-qc', kind: 'region', parentId: 'sgc-pr-24', featured: false
         }));
@@ -123,6 +138,9 @@ describe('Statistics Canada SGC place normalization', () => {
             typeEn: 'City', typeFr: 'Ville', featured: true,
             latitude: 45.5019, longitude: -73.5674, defaultZoom: 10
         }));
+        expect(result.places.find(place => place.id === 'sgc-csd-2466005')).toEqual(expect.objectContaining({
+            slug: 'montreal-est-qc', kind: 'municipality', parentId: 'sgc-cd-2466', featured: false
+        }));
     });
 
     test('keeps the Québec census division distinct from its featured city', () => {
@@ -130,15 +148,11 @@ describe('Statistics Canada SGC place normalization', () => {
             { Level: '2', Code: '24', 'Class title': 'Quebec' },
             { Level: '3', Code: '2423', 'Class title': 'Québec' },
             { Level: '4', Code: '2423027', 'Class title': 'Québec' },
-            { Level: '4', Code: '2423057', 'Class title': "L'Ancienne-Lorette" }
+            { Level: '4', Code: '2423015', 'Class title': 'Saint-Augustin-de-Desmaures' }
         ];
-        const fr = [
-            { Code: '24', 'Titres de classes': 'Québec' },
-            { Code: '2423', 'Titres de classes': 'Québec' },
-            { Code: '2423027', 'Titres de classes': 'Québec' },
-            { Code: '2423057', 'Titres de classes': "L'Ancienne-Lorette" }
-        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
+
         expect(result.places.find(place => place.id === 'sgc-cd-2423')).toEqual(expect.objectContaining({
             slug: 'quebec-region-qc', kind: 'region', parentId: 'sgc-pr-24', featured: false
         }));
@@ -147,10 +161,6 @@ describe('Statistics Canada SGC place normalization', () => {
             typeEn: 'City', typeFr: 'Ville', featured: true,
             latitude: 46.8139, longitude: -71.208, defaultZoom: 10
         }));
-        expect(result.identifiers).toEqual(expect.arrayContaining([
-            expect.objectContaining({ placeId: 'sgc-cd-2423', scheme: 'sgc-cd', value: '2423' }),
-            expect.objectContaining({ placeId: 'sgc-csd-2423027', scheme: 'sgc-csd', value: '2423027' })
-        ]));
     });
 
     test('merges Laval census-division and subdivision identities into one city', () => {
@@ -161,16 +171,17 @@ describe('Statistics Canada SGC place normalization', () => {
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
-        const laval = result.places.filter(place => place.nameEn === 'Laval');
-        expect(laval).toEqual([expect.objectContaining({
-            id: 'sgc-cd-2465', slug: 'laval-qc', kind: 'municipality',
-            parentId: 'sgc-pr-24', typeEn: 'City', typeFr: 'Ville', featured: true,
+
+        expect(result.places.filter(place => place.id.includes('2465'))).toHaveLength(1);
+        expect(result.places.find(place => place.id === 'sgc-cd-2465')).toEqual(expect.objectContaining({
+            slug: 'laval-qc', kind: 'municipality', parentId: 'sgc-pr-24',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
             latitude: 45.6066, longitude: -73.7124, defaultZoom: 10
-        })]);
-        expect(result.identifiers.filter(item => item.placeId === 'sgc-cd-2465')).toEqual([
-            expect.objectContaining({ scheme: 'sgc-cd', value: '2465' }),
-            expect.objectContaining({ scheme: 'sgc-csd', value: '2465005' })
-        ]);
+        }));
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            { placeId: 'sgc-cd-2465', scheme: 'sgc-cd', vintage: '2021', value: '2465' },
+            { placeId: 'sgc-cd-2465', scheme: 'sgc-csd', vintage: '2021', value: '2465005' }
+        ]));
     });
 
     test('features Vancouver as a canonical city beneath Greater Vancouver', () => {
@@ -179,15 +190,11 @@ describe('Statistics Canada SGC place normalization', () => {
             { Level: '3', Code: '5915', 'Class title': 'Greater Vancouver' },
             { Level: '4', Code: '5915022', 'Class title': 'Vancouver' }
         ];
-        const fr = [
-            { Code: '59', 'Titres de classes': 'Colombie-Britannique' },
-            { Code: '5915', 'Titres de classes': 'Greater Vancouver' },
-            { Code: '5915022', 'Titres de classes': 'Vancouver' }
-        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
         expect(result.places.find(place => place.id === 'sgc-pr-59')).toEqual(expect.objectContaining({
-            slug: 'british-columbia', parentId: 'ca', featured: false
+            slug: 'british-columbia', kind: 'province', parentId: 'ca', featured: false
         }));
         expect(result.places.find(place => place.id === 'sgc-cd-5915')).toEqual(expect.objectContaining({
             slug: 'greater-vancouver-bc', kind: 'region', parentId: 'sgc-pr-59', featured: false
@@ -205,25 +212,14 @@ describe('Statistics Canada SGC place normalization', () => {
             { Level: '3', Code: '5915', 'Class title': 'Greater Vancouver' },
             { Level: '4', Code: '5915004', 'Class title': 'Surrey' }
         ];
-        const fr = [
-            { Code: '59', 'Titres de classes': 'Colombie-Britannique' },
-            { Code: '5915', 'Titres de classes': 'Greater Vancouver' },
-            { Code: '5915004', 'Titres de classes': 'Surrey' }
-        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        expect(result.places.find(place => place.id === 'sgc-csd-5915004')).toEqual(
-            expect.objectContaining({
-                slug: 'surrey-bc', kind: 'municipality', parentId: 'sgc-cd-5915',
-                typeEn: 'City', typeFr: 'Ville', featured: true,
-                latitude: 49.1913, longitude: -122.849, defaultZoom: 10
-            })
-        );
-        expect(result.identifiers).toEqual(expect.arrayContaining([
-            expect.objectContaining({
-                placeId: 'sgc-csd-5915004', scheme: 'sgc-csd', value: '5915004'
-            })
-        ]));
+        expect(result.places.find(place => place.id === 'sgc-csd-5915004')).toEqual(expect.objectContaining({
+            slug: 'surrey-bc', kind: 'municipality', parentId: 'sgc-cd-5915',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 49.1913, longitude: -122.849, defaultZoom: 10
+        }));
     });
 
     test('keeps the Halifax census division and featured regional municipality distinct', () => {
@@ -232,40 +228,30 @@ describe('Statistics Canada SGC place normalization', () => {
             { Level: '3', Code: '1209', 'Class title': 'Halifax' },
             { Level: '4', Code: '1209034', 'Class title': 'Halifax' }
         ];
-        const fr = [
-            { Code: '12', 'Titres de classes': 'Nouvelle-Écosse' },
-            { Code: '1209', 'Titres de classes': 'Halifax' },
-            { Code: '1209034', 'Titres de classes': 'Halifax' }
-        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        expect(result.places.find(place => place.id === 'sgc-pr-12')).toEqual(expect.objectContaining({
-            slug: 'nova-scotia', nameFr: 'Nouvelle-Écosse', parentId: 'ca', featured: false
-        }));
         expect(result.places.find(place => place.id === 'sgc-cd-1209')).toEqual(expect.objectContaining({
             slug: 'halifax-region-ns', kind: 'region', parentId: 'sgc-pr-12', featured: false
         }));
         expect(result.places.find(place => place.id === 'sgc-csd-1209034')).toEqual(expect.objectContaining({
             slug: 'halifax-ns', kind: 'municipality', parentId: 'sgc-cd-1209',
-            typeEn: 'Regional municipality', typeFr: 'Municipalité régionale', featured: true,
-            latitude: 44.6488, longitude: -63.5752, defaultZoom: 8
+            typeEn: 'Regional municipality', typeFr: 'Municipalité régionale',
+            featured: true, latitude: 44.6488, longitude: -63.5752, defaultZoom: 8
         }));
-        expect(result.identifiers).toEqual(expect.arrayContaining([
-            expect.objectContaining({ placeId: 'sgc-cd-1209', scheme: 'sgc-cd', value: '1209' }),
-            expect.objectContaining({ placeId: 'sgc-csd-1209034', scheme: 'sgc-csd', value: '1209034' })
-        ]));
     });
 
     test('features Calgary beneath Division No. 6 with its curated viewport', () => {
         const en = [
             { Level: '2', Code: '48', 'Class title': 'Alberta' },
-            { Level: '3', Code: '4806', 'Class title': 'Division No. 6' },
+            { Level: '3', Code: '4806', 'Class title': 'Division No.  6' },
             { Level: '4', Code: '4806016', 'Class title': 'Calgary' }
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
+
         expect(result.places.find(place => place.id === 'sgc-pr-48')).toEqual(expect.objectContaining({
-            slug: 'alberta', parentId: 'ca', featured: false
+            slug: 'alberta', kind: 'province', parentId: 'ca', featured: false
         }));
         expect(result.places.find(place => place.id === 'sgc-cd-4806')).toEqual(expect.objectContaining({
             slug: 'division-no-6-ab', kind: 'region', parentId: 'sgc-pr-48', featured: false
@@ -279,47 +265,62 @@ describe('Statistics Canada SGC place normalization', () => {
 
     test('features Edmonton and Winnipeg beneath their separate Division No. 11 parents', () => {
         const en = [
-            { Level: '2', Code: '46', 'Class title': 'Manitoba' },
-            { Level: '3', Code: '4611', 'Class title': 'Division No. 11' },
-            { Level: '4', Code: '4611040', 'Class title': 'Winnipeg' },
             { Level: '2', Code: '48', 'Class title': 'Alberta' },
             { Level: '3', Code: '4811', 'Class title': 'Division No. 11' },
-            { Level: '4', Code: '4811061', 'Class title': 'Edmonton' }
+            { Level: '4', Code: '4811061', 'Class title': 'Edmonton' },
+            { Level: '2', Code: '46', 'Class title': 'Manitoba' },
+            { Level: '3', Code: '4611', 'Class title': 'Division No. 11' },
+            { Level: '4', Code: '4611040', 'Class title': 'Winnipeg' }
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        expect(result.places.find(place => place.id === 'sgc-cd-4611')).toEqual(expect.objectContaining({
-            slug: 'division-no-11-mb', parentId: 'sgc-pr-46', featured: false
-        }));
-        expect(result.places.find(place => place.id === 'sgc-csd-4611040')).toEqual(expect.objectContaining({
-            slug: 'winnipeg-mb', parentId: 'sgc-cd-4611', typeEn: 'City', typeFr: 'Ville',
-            featured: true, latitude: 49.8954, longitude: -97.1385, defaultZoom: 9
-        }));
         expect(result.places.find(place => place.id === 'sgc-cd-4811')).toEqual(expect.objectContaining({
-            slug: 'division-no-11-ab', parentId: 'sgc-pr-48', featured: false
+            slug: 'division-no-11-ab', kind: 'region', parentId: 'sgc-pr-48', featured: false
         }));
         expect(result.places.find(place => place.id === 'sgc-csd-4811061')).toEqual(expect.objectContaining({
-            slug: 'edmonton-ab', parentId: 'sgc-cd-4811', typeEn: 'City', typeFr: 'Ville',
-            featured: true, latitude: 53.5461, longitude: -113.4938, defaultZoom: 9
+            slug: 'edmonton-ab', kind: 'municipality', parentId: 'sgc-cd-4811',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 53.5461, longitude: -113.4938, defaultZoom: 9
+        }));
+        expect(result.places.find(place => place.id === 'sgc-cd-4611')).toEqual(expect.objectContaining({
+            slug: 'division-no-11-mb', kind: 'region', parentId: 'sgc-pr-46', featured: false
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-4611040')).toEqual(expect.objectContaining({
+            slug: 'winnipeg-mb', kind: 'municipality', parentId: 'sgc-cd-4611',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 49.8954, longitude: -97.1385, defaultZoom: 9
         }));
     });
 
-    test('plans former-slug aliases and fails closed on ownership conflicts', async () => {
-        const desired = [{ id: 'p1', slug: 'montreal-qc', nameEn: 'Montréal' }];
-        const db = { query: jest.fn()
-            .mockResolvedValueOnce({ rows: [{ id: 'p1', slug: 'montr-al-qc', name_en: 'Montral' }] })
-            .mockResolvedValueOnce({ rows: [] })
-            .mockResolvedValueOnce({ rows: [] }) };
-        await expect(preflightPlaceChanges(db, desired)).resolves.toEqual({
-            aliases: [{ slug: 'montr-al-qc', placeId: 'p1' }],
-            nameChanges: 1, slugChanges: 1, aliasConflicts: 0
-        });
+    test('plans former-slug aliases and fails closed on ownership conflicts', () => {
+        const { planAliases } = require('../scripts/sync-places');
+        const existingPlaces = [
+            { id: 'ca-on-durham', slug: 'durham-on' },
+            { id: 'sgc-csd-3518005', slug: 'ajax-on' }
+        ];
+        const canonicalPlaces = [
+            { id: 'ca-on-durham', slug: 'durham-region-on' },
+            { id: 'sgc-csd-3518005', slug: 'ajax-on' }
+        ];
+        const existingAliases = [
+            { slug: 'durham', placeId: 'ca-on-durham' }
+        ];
 
-        const conflict = { query: jest.fn()
-            .mockResolvedValueOnce({ rows: [] })
-            .mockResolvedValueOnce({ rows: [{ id: 'p2', slug: 'montreal-qc' }] }) };
-        await expect(preflightPlaceChanges(conflict, desired)).rejects.toThrow(/canonical for another place/);
+        const planned = planAliases(existingPlaces, canonicalPlaces, existingAliases);
+        expect(planned.aliasesToAdd).toEqual([
+            { slug: 'durham-on', placeId: 'ca-on-durham' }
+        ]);
+        expect(planned.conflicts).toHaveLength(0);
+
+        const conflicted = planAliases(
+            [{ id: 'place-a', slug: 'shared-slug' }],
+            [{ id: 'place-a', slug: 'place-a-new' }],
+            [{ slug: 'shared-slug', placeId: 'place-b' }]
+        );
+        expect(conflicted.conflicts).toEqual([
+            expect.objectContaining({ slug: 'shared-slug', expectedPlaceId: 'place-a', existingPlaceId: 'place-b' })
+        ]);
     });
 
     test('merges Ottawa census-division and subdivision identities into one city', () => {
@@ -330,16 +331,17 @@ describe('Statistics Canada SGC place normalization', () => {
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
-        const ottawa = result.places.filter(place => place.nameEn === 'Ottawa');
-        expect(ottawa).toEqual([expect.objectContaining({
-            id: 'sgc-cd-3506', slug: 'ottawa-on', kind: 'municipality',
-            parentId: 'ca-on', typeEn: 'City', featured: true,
+
+        expect(result.places.filter(place => place.id.includes('3506'))).toHaveLength(1);
+        expect(result.places.find(place => place.id === 'sgc-cd-3506')).toEqual(expect.objectContaining({
+            slug: 'ottawa-on', kind: 'municipality', parentId: 'ca-on',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
             latitude: 45.4215, longitude: -75.6972, defaultZoom: 9
-        })]);
-        expect(result.identifiers.filter(item => item.placeId === 'sgc-cd-3506')).toEqual([
-            expect.objectContaining({ scheme: 'sgc-cd', value: '3506' }),
-            expect.objectContaining({ scheme: 'sgc-csd', value: '3506008' })
-        ]);
+        }));
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            { placeId: 'sgc-cd-3506', scheme: 'sgc-cd', vintage: '2021', value: '3506' },
+            { placeId: 'sgc-cd-3506', scheme: 'sgc-csd', vintage: '2021', value: '3506008' }
+        ]));
     });
 
     test('merges Toronto census-division and subdivision identities into one city', () => {
@@ -350,97 +352,86 @@ describe('Statistics Canada SGC place normalization', () => {
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
-        const toronto = result.places.filter(place => place.nameEn === 'Toronto');
-        expect(toronto).toEqual([expect.objectContaining({
-            id: 'sgc-cd-3520', slug: 'toronto-on', kind: 'municipality',
-            parentId: 'ca-on', typeEn: 'City', featured: true
-        })]);
-        expect(result.identifiers.filter(item => item.placeId === 'sgc-cd-3520')).toEqual([
-            expect.objectContaining({ scheme: 'sgc-cd', value: '3520' }),
-            expect.objectContaining({ scheme: 'sgc-csd', value: '3520005' })
-        ]);
+
+        expect(result.places.filter(place => place.id.includes('3520'))).toHaveLength(1);
+        expect(result.places.find(place => place.id === 'sgc-cd-3520')).toEqual(expect.objectContaining({
+            slug: 'toronto-on', kind: 'municipality', parentId: 'ca-on',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 43.6532, longitude: -79.3832, defaultZoom: 10
+        }));
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            { placeId: 'sgc-cd-3520', scheme: 'sgc-cd', vintage: '2021', value: '3520' },
+            { placeId: 'sgc-cd-3520', scheme: 'sgc-csd', vintage: '2021', value: '3520005' }
+        ]));
     });
 
     test('merges the City of Hamilton while disambiguating Hamilton Township', () => {
         const en = [
             { Level: '2', Code: '35', 'Class title': 'Ontario' },
-            { Level: '3', Code: '3514', 'Class title': 'Northumberland' },
-            { Level: '4', Code: '3514019', 'Class title': 'Hamilton' },
             { Level: '3', Code: '3525', 'Class title': 'Hamilton' },
-            { Level: '4', Code: '3525005', 'Class title': 'Hamilton' }
+            { Level: '4', Code: '3525005', 'Class title': 'Hamilton' },
+            { Level: '3', Code: '3514', 'Class title': 'Northumberland' },
+            { Level: '4', Code: '3514019', 'Class title': 'Hamilton' }
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        expect(result.places.find(place => place.id === 'sgc-csd-3514019')).toEqual(
-            expect.objectContaining({
-                slug: 'hamilton-township-on', kind: 'municipality',
-                parentId: 'sgc-cd-3514', typeEn: 'Township', typeFr: 'Canton',
-                featured: false
-            })
-        );
-        expect(result.places.find(place => place.id === 'sgc-cd-3525')).toEqual(
-            expect.objectContaining({
-                slug: 'hamilton-on', kind: 'municipality', parentId: 'ca-on',
-                typeEn: 'City', typeFr: 'Ville', featured: true,
-                latitude: 43.2557, longitude: -79.8711, defaultZoom: 9
-            })
-        );
-        expect(result.places.find(place => place.id === 'sgc-csd-3525005')).toBeUndefined();
-        expect(result.identifiers.filter(item => item.placeId === 'sgc-cd-3525')).toEqual([
-            expect.objectContaining({ scheme: 'sgc-cd', value: '3525' }),
-            expect.objectContaining({ scheme: 'sgc-csd', value: '3525005' })
-        ]);
+        expect(result.places.filter(place => place.id.includes('3525'))).toHaveLength(1);
+        expect(result.places.find(place => place.id === 'sgc-cd-3525')).toEqual(expect.objectContaining({
+            slug: 'hamilton-on', kind: 'municipality', parentId: 'ca-on',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
+            latitude: 43.2557, longitude: -79.8711, defaultZoom: 9
+        }));
+        expect(result.places.find(place => place.id === 'sgc-csd-3514019')).toEqual(expect.objectContaining({
+            slug: 'hamilton-township-on', kind: 'municipality', parentId: 'sgc-cd-3514',
+            typeEn: 'Township', typeFr: 'Canton', featured: false
+        }));
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            { placeId: 'sgc-cd-3525', scheme: 'sgc-cd', vintage: '2021', value: '3525' },
+            { placeId: 'sgc-cd-3525', scheme: 'sgc-csd', vintage: '2021', value: '3525005' },
+            { placeId: 'sgc-csd-3514019', scheme: 'sgc-csd', vintage: '2021', value: '3514019' }
+        ]));
     });
 
     test('features Waterloo Region and all seven lower-tier municipalities with curated viewports', () => {
-        const rows = [
-            ['3530', 'Waterloo'],
-            ['3530013', 'Kitchener'],
-            ['3530016', 'Waterloo'],
-            ['3530010', 'Cambridge'],
-            ['3530035', 'Woolwich'],
-            ['3530020', 'Wilmot'],
-            ['3530027', 'Wellesley'],
-            ['3530004', 'North Dumfries']
-        ];
         const en = [
             { Level: '2', Code: '35', 'Class title': 'Ontario' },
-            ...rows.map(([Code, name]) => ({
-                Level: Code.length === 4 ? '3' : '4', Code, 'Class title': name
-            }))
+            { Level: '3', Code: '3530', 'Class title': 'Waterloo' },
+            { Level: '4', Code: '3530013', 'Class title': 'Kitchener' },
+            { Level: '4', Code: '3530016', 'Class title': 'Waterloo' },
+            { Level: '4', Code: '3530010', 'Class title': 'Cambridge' },
+            { Level: '4', Code: '3530035', 'Class title': 'Woolwich' },
+            { Level: '4', Code: '3530020', 'Class title': 'Wilmot' },
+            { Level: '4', Code: '3530027', 'Class title': 'Wellesley' },
+            { Level: '4', Code: '3530004', 'Class title': 'North Dumfries' }
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        const region = result.places.find(place => place.id === 'sgc-cd-3530');
-        expect(region).toEqual(expect.objectContaining({
-            slug: 'waterloo-region-on', kind: 'region', parentId: 'ca-on', featured: true,
-            typeEn: 'Regional municipality', latitude: 43.4643, longitude: -80.5204, defaultZoom: 9
+        expect(result.places.find(place => place.id === 'sgc-cd-3530')).toEqual(expect.objectContaining({
+            slug: 'waterloo-region-on', kind: 'region', parentId: 'ca-on',
+            typeEn: 'Regional municipality', typeFr: 'Municipalité régionale',
+            featured: true, latitude: 43.4643, longitude: -80.5204, defaultZoom: 9
         }));
-
-        const kitchener = result.places.find(place => place.id === 'sgc-csd-3530013');
-        expect(kitchener).toEqual(expect.objectContaining({
-            slug: 'kitchener-on', parentId: 'sgc-cd-3530', featured: true,
-            typeEn: 'City', latitude: 43.4516, longitude: -80.4925, defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3530013')).toEqual(expect.objectContaining({
+            slug: 'kitchener-on', kind: 'municipality', parentId: 'sgc-cd-3530',
+            typeEn: 'City', typeFr: 'Ville',
+            featured: true, latitude: 43.4516, longitude: -80.4925, defaultZoom: 10
         }));
-
-        const waterlooCity = result.places.find(place => place.id === 'sgc-csd-3530016');
-        expect(waterlooCity).toEqual(expect.objectContaining({
-            slug: 'waterloo-on', parentId: 'sgc-cd-3530', featured: true,
-            typeEn: 'City', latitude: 43.4643, longitude: -80.5204, defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3530016')).toEqual(expect.objectContaining({
+            slug: 'waterloo-on', kind: 'municipality', parentId: 'sgc-cd-3530',
+            typeEn: 'City', typeFr: 'Ville',
+            featured: true, latitude: 43.4643, longitude: -80.5204, defaultZoom: 10
         }));
-
-        const cambridge = result.places.find(place => place.id === 'sgc-csd-3530010');
-        expect(cambridge).toEqual(expect.objectContaining({
-            slug: 'cambridge-on', parentId: 'sgc-cd-3530', featured: true,
-            typeEn: 'City', latitude: 43.3616, longitude: -80.3144, defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3530010')).toEqual(expect.objectContaining({
+            slug: 'cambridge-on', kind: 'municipality', parentId: 'sgc-cd-3530',
+            typeEn: 'City', typeFr: 'Ville',
+            featured: true, latitude: 43.3616, longitude: -80.3144, defaultZoom: 10
         }));
-
-        const woolwich = result.places.find(place => place.id === 'sgc-csd-3530035');
-        expect(woolwich).toEqual(expect.objectContaining({
-            slug: 'woolwich-on', parentId: 'sgc-cd-3530', featured: true,
-            typeEn: 'Township', defaultZoom: 9
+        expect(result.places.find(place => place.id === 'sgc-csd-3530035')).toEqual(expect.objectContaining({
+            slug: 'woolwich-on', kind: 'municipality', parentId: 'sgc-cd-3530',
+            typeEn: 'Township', typeFr: 'Canton',
+            featured: true, latitude: 43.565, longitude: -80.55, defaultZoom: 9
         }));
     });
 
@@ -449,11 +440,11 @@ describe('Statistics Canada SGC place normalization', () => {
             { Level: '2', Code: '59', 'Class title': 'British Columbia' },
             { Level: '3', Code: '5917', 'Class title': 'Capital' },
             { Level: '4', Code: '5917034', 'Class title': 'Victoria' },
-            { Level: '3', Code: '5935', 'Class title': 'Central Okanagan' },
-            { Level: '4', Code: '5935010', 'Class title': 'Kelowna' },
             { Level: '2', Code: '35', 'Class title': 'Ontario' },
             { Level: '3', Code: '3539', 'Class title': 'Middlesex' },
             { Level: '4', Code: '3539036', 'Class title': 'London' },
+            { Level: '3', Code: '5935', 'Class title': 'Central Okanagan' },
+            { Level: '4', Code: '5935010', 'Class title': 'Kelowna' },
             { Level: '2', Code: '13', 'Class title': 'New Brunswick' },
             { Level: '3', Code: '1310', 'Class title': 'York' },
             { Level: '4', Code: '1310032', 'Class title': 'Fredericton' }
@@ -494,35 +485,29 @@ describe('Statistics Canada SGC place normalization', () => {
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        const halton = result.places.find(place => place.id === 'sgc-cd-3524');
-        expect(halton).toEqual(expect.objectContaining({
+        expect(result.places.find(place => place.id === 'sgc-cd-3524')).toEqual(expect.objectContaining({
             slug: 'halton-region-on', kind: 'region', parentId: 'ca-on',
-            typeEn: 'Regional municipality', typeFr: 'Municipalité régionale', featured: true,
-            latitude: 43.4900, longitude: -79.8800, defaultZoom: 9
+            typeEn: 'Regional municipality', featured: true, latitude: 43.4900, longitude: -79.8800, defaultZoom: 9
         }));
 
-        const oakville = result.places.find(place => place.id === 'sgc-csd-3524001');
-        expect(oakville).toEqual(expect.objectContaining({
-            slug: 'oakville-on', parentId: 'sgc-cd-3524', featured: true,
-            typeEn: 'Town', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3524001')).toEqual(expect.objectContaining({
+            slug: 'oakville-on', kind: 'municipality', parentId: 'sgc-cd-3524',
+            typeEn: 'Town', featured: true, latitude: 43.4675, longitude: -79.6877, defaultZoom: 10
         }));
 
-        const burlington = result.places.find(place => place.id === 'sgc-csd-3524002');
-        expect(burlington).toEqual(expect.objectContaining({
-            slug: 'burlington-on', parentId: 'sgc-cd-3524', featured: true,
-            typeEn: 'City', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3524002')).toEqual(expect.objectContaining({
+            slug: 'burlington-on', kind: 'municipality', parentId: 'sgc-cd-3524',
+            typeEn: 'City', featured: true, latitude: 43.3255, longitude: -79.7990, defaultZoom: 10
         }));
 
-        const milton = result.places.find(place => place.id === 'sgc-csd-3524009');
-        expect(milton).toEqual(expect.objectContaining({
-            slug: 'milton-on', parentId: 'sgc-cd-3524', featured: true,
-            typeEn: 'Town', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3524009')).toEqual(expect.objectContaining({
+            slug: 'milton-on', kind: 'municipality', parentId: 'sgc-cd-3524',
+            typeEn: 'Town', featured: true, latitude: 43.5183, longitude: -79.8774, defaultZoom: 10
         }));
 
-        const haltonHills = result.places.find(place => place.id === 'sgc-csd-3524015');
-        expect(haltonHills).toEqual(expect.objectContaining({
-            slug: 'halton-hills-on', parentId: 'sgc-cd-3524', featured: true,
-            typeEn: 'Town', defaultZoom: 9
+        expect(result.places.find(place => place.id === 'sgc-csd-3524015')).toEqual(expect.objectContaining({
+            slug: 'halton-hills-on', kind: 'municipality', parentId: 'sgc-cd-3524',
+            typeEn: 'Town', featured: true, latitude: 43.6300, longitude: -79.9500, defaultZoom: 9
         }));
     });
 
@@ -530,26 +515,21 @@ describe('Statistics Canada SGC place normalization', () => {
         const en = [
             { Level: '2', Code: '35', 'Class title': 'Ontario' },
             { Level: '3', Code: '3553', 'Class title': 'Greater Sudbury / Grand Sudbury' },
-            { Level: '4', Code: '3553005', 'Class title': 'Greater Sudbury' }
+            { Level: '4', Code: '3553005', 'Class title': 'Greater Sudbury / Grand Sudbury' }
         ];
-        const fr = [
-            { Code: '35', 'Titres de classes': 'Ontario' },
-            { Code: '3553', 'Titres de classes': 'Greater Sudbury / Grand Sudbury' },
-            { Code: '3553005', 'Titres de classes': 'Grand Sudbury' }
-        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        const sudbury = result.places.filter(place => place.id === 'sgc-cd-3553');
-        expect(sudbury).toEqual([expect.objectContaining({
-            id: 'sgc-cd-3553', slug: 'greater-sudbury-on', kind: 'municipality',
-            parentId: 'ca-on', typeEn: 'City', typeFr: 'Ville', featured: true,
-            nameEn: 'Greater Sudbury', nameFr: 'Grand Sudbury',
+        expect(result.places.filter(place => place.id.includes('3553'))).toHaveLength(1);
+        expect(result.places.find(place => place.id === 'sgc-cd-3553')).toEqual(expect.objectContaining({
+            slug: 'greater-sudbury-on', kind: 'municipality', parentId: 'ca-on',
+            typeEn: 'City', typeFr: 'Ville', featured: true,
             latitude: 46.4900, longitude: -80.9900, defaultZoom: 9
-        })]);
-        expect(result.identifiers.filter(item => item.placeId === 'sgc-cd-3553')).toEqual([
-            expect.objectContaining({ scheme: 'sgc-cd', value: '3553' }),
-            expect.objectContaining({ scheme: 'sgc-csd', value: '3553005' })
-        ]);
+        }));
+        expect(result.identifiers).toEqual(expect.arrayContaining([
+            { placeId: 'sgc-cd-3553', scheme: 'sgc-cd', vintage: '2021', value: '3553' },
+            { placeId: 'sgc-cd-3553', scheme: 'sgc-csd', vintage: '2021', value: '3553005' }
+        ]));
     });
 
     test('features Burnaby beneath Greater Vancouver and Saskatoon beneath Saskatchewan', () => {
@@ -569,10 +549,6 @@ describe('Statistics Canada SGC place normalization', () => {
             typeEn: 'City', featured: true, latitude: 49.2488, longitude: -122.9805, defaultZoom: 10
         }));
 
-        expect(result.places.find(place => place.id === 'sgc-pr-47')).toEqual(expect.objectContaining({
-            slug: 'saskatchewan', kind: 'province', parentId: 'ca', featured: false
-        }));
-
         expect(result.places.find(place => place.id === 'sgc-csd-4711066')).toEqual(expect.objectContaining({
             slug: 'saskatoon-sk', kind: 'municipality', parentId: 'sgc-cd-4711',
             typeEn: 'City', featured: true, latitude: 52.1332, longitude: -106.6700, defaultZoom: 10
@@ -586,27 +562,29 @@ describe('Statistics Canada SGC place normalization', () => {
             { Level: '4', Code: '3519036', 'Class title': 'Markham' },
             { Level: '4', Code: '3519048', 'Class title': 'Newmarket' },
             { Level: '4', Code: '3519028', 'Class title': 'Vaughan' },
-            { Level: '4', Code: '3519038', 'Class title': 'Richmond Hill' }
+            { Level: '4', Code: '3519038', 'Class title': 'Richmond Hill' },
+            { Level: '4', Code: '3519046', 'Class title': 'Aurora' },
+            { Level: '4', Code: '3519044', 'Class title': 'Whitchurch-Stouffville' },
+            { Level: '4', Code: '3519049', 'Class title': 'King' },
+            { Level: '4', Code: '3519054', 'Class title': 'East Gwillimbury' },
+            { Level: '4', Code: '3519070', 'Class title': 'Georgina' }
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        const york = result.places.find(place => place.id === 'sgc-cd-3519');
-        expect(york).toEqual(expect.objectContaining({
+        expect(result.places.find(place => place.id === 'sgc-cd-3519')).toEqual(expect.objectContaining({
             slug: 'york-region-on', kind: 'region', parentId: 'ca-on',
             typeEn: 'Regional municipality', featured: true, latitude: 44.0000, longitude: -79.4667, defaultZoom: 9
         }));
 
-        const markham = result.places.find(place => place.id === 'sgc-csd-3519036');
-        expect(markham).toEqual(expect.objectContaining({
-            slug: 'markham-on', parentId: 'sgc-cd-3519', featured: true,
-            typeEn: 'City', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3519036')).toEqual(expect.objectContaining({
+            slug: 'markham-on', kind: 'municipality', parentId: 'sgc-cd-3519',
+            typeEn: 'City', featured: true, latitude: 43.8561, longitude: -79.3370, defaultZoom: 10
         }));
 
-        const newmarket = result.places.find(place => place.id === 'sgc-csd-3519048');
-        expect(newmarket).toEqual(expect.objectContaining({
-            slug: 'newmarket-on', parentId: 'sgc-cd-3519', featured: true,
-            typeEn: 'Town', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3519048')).toEqual(expect.objectContaining({
+            slug: 'newmarket-on', kind: 'municipality', parentId: 'sgc-cd-3519',
+            typeEn: 'Town', featured: true, latitude: 44.0592, longitude: -79.4613, defaultZoom: 10
         }));
     });
 
@@ -616,27 +594,33 @@ describe('Statistics Canada SGC place normalization', () => {
             { Level: '3', Code: '3526', 'Class title': 'Niagara' },
             { Level: '4', Code: '3526043', 'Class title': 'Niagara Falls' },
             { Level: '4', Code: '3526032', 'Class title': 'Welland' },
-            { Level: '4', Code: '3526053', 'Class title': 'St. Catharines' }
+            { Level: '4', Code: '3526053', 'Class title': 'St. Catharines' },
+            { Level: '4', Code: '3526003', 'Class title': 'Fort Erie' },
+            { Level: '4', Code: '3526011', 'Class title': 'Port Colborne' },
+            { Level: '4', Code: '3526037', 'Class title': 'Thorold' },
+            { Level: '4', Code: '3526047', 'Class title': 'Niagara-on-the-Lake' },
+            { Level: '4', Code: '3526057', 'Class title': 'Lincoln' },
+            { Level: '4', Code: '3526065', 'Class title': 'Grimsby' },
+            { Level: '4', Code: '3526028', 'Class title': 'Pelham' },
+            { Level: '4', Code: '3526021', 'Class title': 'West Lincoln' },
+            { Level: '4', Code: '3526014', 'Class title': 'Wainfleet' }
         ];
         const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
         const result = normalize(en, fr);
 
-        const niagara = result.places.find(place => place.id === 'sgc-cd-3526');
-        expect(niagara).toEqual(expect.objectContaining({
+        expect(result.places.find(place => place.id === 'sgc-cd-3526')).toEqual(expect.objectContaining({
             slug: 'niagara-region-on', kind: 'region', parentId: 'ca-on',
             typeEn: 'Regional municipality', featured: true, latitude: 43.0600, longitude: -79.3100, defaultZoom: 9
         }));
 
-        const niagaraFalls = result.places.find(place => place.id === 'sgc-csd-3526043');
-        expect(niagaraFalls).toEqual(expect.objectContaining({
-            slug: 'niagara-falls-on', parentId: 'sgc-cd-3526', featured: true,
-            typeEn: 'City', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3526043')).toEqual(expect.objectContaining({
+            slug: 'niagara-falls-on', kind: 'municipality', parentId: 'sgc-cd-3526',
+            typeEn: 'City', featured: true, latitude: 43.0896, longitude: -79.0849, defaultZoom: 10
         }));
 
-        const welland = result.places.find(place => place.id === 'sgc-csd-3526032');
-        expect(welland).toEqual(expect.objectContaining({
-            slug: 'welland-on', parentId: 'sgc-cd-3526', featured: true,
-            typeEn: 'City', defaultZoom: 10
+        expect(result.places.find(place => place.id === 'sgc-csd-3526032')).toEqual(expect.objectContaining({
+            slug: 'welland-on', kind: 'municipality', parentId: 'sgc-cd-3526',
+            typeEn: 'City', featured: true, latitude: 42.9922, longitude: -79.2483, defaultZoom: 10
         }));
     });
 
@@ -681,6 +665,71 @@ describe('Statistics Canada SGC place normalization', () => {
         expect(result.places.find(place => place.id === 'sgc-csd-3512005')).toEqual(expect.objectContaining({
             slug: 'belleville-on', kind: 'municipality', parentId: 'sgc-cd-3512',
             typeEn: 'City', featured: true, latitude: 44.1628, longitude: -77.3832, defaultZoom: 10
+        }));
+    });
+
+    test('features Yellowknife, Barrie, Thunder Bay, Chatham-Kent, Kawartha Lakes, Summerland, Norfolk, and Haldimand', () => {
+        const en = [
+            { Level: '2', Code: '61', 'Class title': 'Northwest Territories' },
+            { Level: '3', Code: '6106', 'Class title': 'Region 6' },
+            { Level: '4', Code: '6106023', 'Class title': 'Yellowknife' },
+            { Level: '2', Code: '35', 'Class title': 'Ontario' },
+            { Level: '3', Code: '3543', 'Class title': 'Simcoe' },
+            { Level: '4', Code: '3543042', 'Class title': 'Barrie' },
+            { Level: '3', Code: '3558', 'Class title': 'Thunder Bay' },
+            { Level: '4', Code: '3558004', 'Class title': 'Thunder Bay' },
+            { Level: '3', Code: '3536', 'Class title': 'Chatham-Kent' },
+            { Level: '4', Code: '3536020', 'Class title': 'Chatham-Kent' },
+            { Level: '3', Code: '3516', 'Class title': 'Kawartha Lakes' },
+            { Level: '4', Code: '3516010', 'Class title': 'Kawartha Lakes' },
+            { Level: '2', Code: '59', 'Class title': 'British Columbia' },
+            { Level: '3', Code: '5907', 'Class title': 'Okanagan-Similkameen' },
+            { Level: '4', Code: '5907035', 'Class title': 'Summerland' },
+            { Level: '3', Code: '3528', 'Class title': 'Haldimand-Norfolk' },
+            { Level: '4', Code: '3528052', 'Class title': 'Norfolk County' },
+            { Level: '4', Code: '3528018', 'Class title': 'Haldimand County' }
+        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
+        const result = normalize(en, fr);
+
+        expect(result.places.find(place => place.id === 'sgc-csd-6106023')).toEqual(expect.objectContaining({
+            slug: 'yellowknife-nt', kind: 'municipality', parentId: 'sgc-cd-6106',
+            typeEn: 'City', featured: true, latitude: 62.4540, longitude: -114.3718, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-3543042')).toEqual(expect.objectContaining({
+            slug: 'barrie-on', kind: 'municipality', parentId: 'sgc-cd-3543',
+            typeEn: 'City', featured: true, latitude: 44.3894, longitude: -79.6903, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-3558004')).toEqual(expect.objectContaining({
+            slug: 'thunder-bay-on', kind: 'municipality', parentId: 'sgc-cd-3558',
+            typeEn: 'City', featured: true, latitude: 48.3809, longitude: -89.2477, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-cd-3536')).toEqual(expect.objectContaining({
+            slug: 'chatham-kent-on', kind: 'municipality', parentId: 'ca-on',
+            typeEn: 'Municipality', featured: true, latitude: 42.4048, longitude: -82.1910, defaultZoom: 9
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-cd-3516')).toEqual(expect.objectContaining({
+            slug: 'kawartha-lakes-on', kind: 'municipality', parentId: 'ca-on',
+            typeEn: 'City', featured: true, latitude: 44.3564, longitude: -78.7408, defaultZoom: 9
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-5907035')).toEqual(expect.objectContaining({
+            slug: 'summerland-bc', kind: 'municipality', parentId: 'sgc-cd-5907',
+            typeEn: 'District municipality', featured: true, latitude: 49.6006, longitude: -119.6778, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-3528052')).toEqual(expect.objectContaining({
+            slug: 'norfolk-county-on', kind: 'municipality', parentId: 'sgc-cd-3528',
+            typeEn: 'City', featured: true, latitude: 42.8333, longitude: -80.3833, defaultZoom: 9
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-3528018')).toEqual(expect.objectContaining({
+            slug: 'haldimand-county-on', kind: 'municipality', parentId: 'sgc-cd-3528',
+            typeEn: 'City', featured: true, latitude: 42.9333, longitude: -79.8667, defaultZoom: 9
         }));
     });
 });

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -199,130 +199,197 @@ const FREDERICTON_LICENSE = {
 };
 
 const BURLINGTON_LICENSE = {
-    titleEn: 'City of Burlington Open Data Licence',
-    titleFr: 'Licence de données ouvertes de la Ville de Burlington',
-    url: 'https://navigadatalab-burlington.opendata.arcgis.com/pages/terms-of-use',
-    attributionEn: 'Contains information licensed under the City of Burlington Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Burlington.'
+    titleEn: 'City of Burlington Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Burlington',
+    url: 'https://opendata.burlington.ca/opendata-terms-of-use/City%20of%20Burlington%20-%20Open%20Data%20Terms%20of%20Use.pdf',
+    attributionEn: 'Contains information made available under the City of Burlington Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Burlington.'
 };
 
 const OAKVILLE_LICENSE = {
     titleEn: 'Town of Oakville Open Data Licence',
     titleFr: 'Licence de données ouvertes de la Ville d’Oakville',
-    url: 'https://oakvillegis.opendata.arcgis.com/pages/open-data-license',
-    attributionEn: 'Contains information licensed under the Town of Oakville Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville d’Oakville.'
+    url: 'https://www.oakville.ca/town-hall/town-studies-plans-projects/town-initiatives/open-data/open-data-licence/',
+    attributionEn: 'Contains information made available under the Town of Oakville Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville d’Oakville.'
 };
 
 const MILTON_LICENSE = {
-    titleEn: 'Town of Milton Open Data Licence',
-    titleFr: 'Licence de données ouvertes de la Ville de Milton',
-    url: 'https://open-milton.hub.arcgis.com/pages/open-data-license',
-    attributionEn: 'Contains information licensed under the Town of Milton Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Milton.'
+    titleEn: 'Open Government Licence – Milton',
+    titleFr: 'Licence du gouvernement ouvert – Milton',
+    url: 'https://discover-milton.hub.arcgis.com/pages/disclaimer-and-terms-of-use',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Milton.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Milton.'
 };
 
 const SUDBURY_LICENSE = {
-    titleEn: 'Open Government Licence – City of Greater Sudbury',
-    titleFr: 'Licence du gouvernement ouvert – Ville du Grand Sudbury',
-    url: 'https://opendata.greatersudbury.ca/pages/open-government-licence',
-    attributionEn: 'Contains information licensed under the Open Government Licence – City of Greater Sudbury.',
-    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville du Grand Sudbury.'
+    titleEn: 'City of Greater Sudbury Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville du Grand Sudbury',
+    url: 'https://www.greatersudbury.ca/inside-city-hall/open-data/policy/',
+    attributionEn: 'Contains information made available under the City of Greater Sudbury Open Data Policy and Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la politique et la licence de données ouvertes de la Ville du Grand Sudbury.'
 };
 
 const BURNABY_LICENSE = {
     titleEn: 'Open Government Licence – City of Burnaby',
     titleFr: 'Licence du gouvernement ouvert – Ville de Burnaby',
-    url: 'https://data.burnaby.ca/pages/open-government-licence-burnaby',
+    url: 'https://data.burnaby.ca/pages/open-government-licence',
     attributionEn: 'Contains information licensed under the Open Government Licence – City of Burnaby.',
     attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville de Burnaby.'
 };
 
 const SASKATOON_LICENSE = {
-    titleEn: 'Open Government Licence – City of Saskatoon',
-    titleFr: 'Licence du gouvernement ouvert – Ville de Saskatoon',
-    url: 'https://opendata-saskatoon.hub.arcgis.com/pages/open-government-licence',
-    attributionEn: 'Contains information licensed under the Open Government Licence – City of Saskatoon.',
-    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville de Saskatoon.'
+    titleEn: 'City of Saskatoon Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Saskatoon',
+    url: 'https://www.saskatoon.ca/city-hall/open-data/open-data-licence',
+    attributionEn: 'Contains information made available under the City of Saskatoon Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Saskatoon.'
 };
 
 const YORK_REGION_LICENSE = {
     titleEn: 'York Region Open Data Licence',
     titleFr: 'Licence de données ouvertes de la région de York',
     url: 'https://www.york.ca/about-york-region/open-data',
-    attributionEn: 'Contains information licensed under the York Region Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la région de York.'
+    attributionEn: 'Contains information made available under the York Region Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la région de York.'
 };
 
 const MARKHAM_LICENSE = {
-    titleEn: 'City of Markham Open Data Licence',
-    titleFr: 'Licence de données ouvertes de la Ville de Markham',
+    titleEn: 'City of Markham Open Data Terms',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Markham',
     url: 'https://data-markham.opendata.arcgis.com/',
-    attributionEn: 'Contains information licensed under the City of Markham Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Markham.'
+    attributionEn: 'Contains information made available under the City of Markham Open Data Terms.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Markham.'
 };
 
 const NEWMARKET_LICENSE = {
     titleEn: 'Town of Newmarket Open Data Licence',
     titleFr: 'Licence de données ouvertes de la Ville de Newmarket',
     url: 'https://navigate-newmarket.hub.arcgis.com/',
-    attributionEn: 'Contains information licensed under the Town of Newmarket Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Newmarket.'
+    attributionEn: 'Contains information made available under the Town of Newmarket Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Newmarket.'
 };
 
 const NIAGARA_FALLS_LICENSE = {
-    titleEn: 'City of Niagara Falls Open Data Licence',
-    titleFr: 'Licence de données ouvertes de la Ville de Niagara Falls',
+    titleEn: 'City of Niagara Falls Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Niagara Falls',
     url: 'https://open.niagarafalls.ca/pages/terms-of-use',
-    attributionEn: 'Contains information licensed under the City of Niagara Falls Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Niagara Falls.'
+    attributionEn: 'Contains information made available under the City of Niagara Falls Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Niagara Falls.'
 };
 
 const WELLAND_LICENSE = {
-    titleEn: 'City of Welland Open Data Licence',
-    titleFr: 'Licence de données ouvertes de la Ville de Welland',
+    titleEn: 'City of Welland Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Welland',
     url: 'https://open.welland.ca/pages/terms-of-use',
-    attributionEn: 'Contains information licensed under the City of Welland Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Welland.'
+    attributionEn: 'Contains information made available under the City of Welland Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Welland.'
 };
 
 const MONCTON_LICENSE = {
     titleEn: 'City of Moncton Open Data Terms of Use',
-    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Moncton',
+    titleFr: 'Conditions d’utilisations des ensembles de données de la Ville de Moncton',
     url: 'https://www5.moncton.ca/docs/Open_Data_Terms_of_Use.pdf',
-    attributionEn: 'Contains information licensed under the City of Moncton Open Data Terms of Use.',
-    attributionFr: 'Contient des renseignements visés par les conditions d’utilisation des données ouvertes de la Ville de Moncton.'
+    attributionEn: 'Contains information made available under the City of Moncton Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisations des ensembles de données de la Ville de Moncton.'
 };
 
 const GUELPH_LICENSE = {
-    titleEn: 'City of Guelph Open Data Licence',
+    titleEn: 'City of Guelph Open Data License',
     titleFr: 'Licence de données ouvertes de la Ville de Guelph',
     url: 'https://explore.guelph.ca/pages/open-data-license',
-    attributionEn: 'Contains information licensed under the City of Guelph Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Guelph.'
+    attributionEn: 'Contains information made available under the City of Guelph Open Data License.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Guelph.'
 };
 
 const SAANICH_LICENSE = {
-    titleEn: 'District of Saanich Open Data Licence',
-    titleFr: 'Licence de données ouvertes du district de Saanich',
+    titleEn: 'Open Government Licence – District of Saanich',
+    titleFr: 'Licence du gouvernement ouvert – District of Saanich',
     url: 'https://opendata-saanich.hub.arcgis.com/',
-    attributionEn: 'Contains information licensed under the District of Saanich Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes du district de Saanich.'
+    attributionEn: 'Contains information licensed under the Open Government Licence – District of Saanich.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – District of Saanich.'
 };
 
 const BELLEVILLE_LICENSE = {
     titleEn: 'City of Belleville Open Data Licence',
     titleFr: 'Licence de données ouvertes de la Ville de Belleville',
     url: 'https://opendata-bellevillegis.hub.arcgis.com/',
-    attributionEn: 'Contains information licensed under the City of Belleville Open Data Licence.',
-    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Belleville.'
+    attributionEn: 'Contains information made available under the City of Belleville Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Belleville.'
 };
 
+const YELLOWKNIFE_LICENSE = {
+    titleEn: 'City of Yellowknife Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Yellowknife',
+    url: 'https://data-yellowknife.hub.arcgis.com/',
+    attributionEn: 'Contains information made available under the City of Yellowknife Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Yellowknife.'
+};
+
+const BARRIE_LICENSE = {
+    titleEn: 'City of Barrie Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Barrie',
+    url: 'https://opendata.barrie.ca/',
+    attributionEn: 'Contains information made available under the City of Barrie Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Barrie.'
+};
+
+const THUNDER_BAY_LICENSE = {
+    titleEn: 'City of Thunder Bay Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Thunder Bay',
+    url: 'https://www.thunderbay.ca/en/city-services/resources/City-of-Thunder-Bay-Open-Data-Licence.pdf',
+    attributionEn: 'Contains information licensed under the City of Thunder Bay Open Data Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Thunder Bay.'
+};
+
+const CHATHAM_KENT_LICENSE = {
+    titleEn: 'Municipality of Chatham-Kent Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la municipalité de Chatham-Kent',
+    url: 'https://opendata.chatham-kent.ca/',
+    attributionEn: 'Contains information made available under the Municipality of Chatham-Kent Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la municipalité de Chatham-Kent.'
+};
+
+const KAWARTHA_LAKES_LICENSE = {
+    titleEn: 'City of Kawartha Lakes Open Data Terms',
+    titleFr: 'Conditions des données ouvertes de la Ville de Kawartha Lakes',
+    url: 'https://open-data-kawartha.hub.arcgis.com/',
+    attributionEn: 'Contains information licensed by the City of Kawartha Lakes.',
+    attributionFr: 'Contient des renseignements fournis par la Ville de Kawartha Lakes.'
+};
+
+const SUMMERLAND_LICENSE = {
+    titleEn: 'District of Summerland Open Government Licence',
+    titleFr: 'Licence du gouvernement ouvert du district de Summerland',
+    url: 'https://www.summerland.ca/docs/default-source/gis/summerland-open-government-licence.pdf',
+    attributionEn: 'Contains information licensed under the District of Summerland Open Government Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert du district de Summerland.'
+};
+
+const NORFOLK_LICENSE = {
+    titleEn: 'Norfolk County Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes du comté de Norfolk',
+    url: 'https://data-norfolk.opendata.arcgis.com/',
+    attributionEn: 'Contains information licensed by Norfolk County.',
+    attributionFr: 'Contient des renseignements fournis par le comté de Norfolk.'
+};
+
+const HALDIMAND_LICENSE = {
+    titleEn: 'Haldimand County Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes du comté de Haldimand',
+    url: 'https://opendata-haldimand.hub.arcgis.com/',
+    attributionEn: 'Contains information licensed by The Corporation of Haldimand County.',
+    attributionFr: 'Contient des renseignements fournis par la Corporation du comté de Haldimand.'
+};
+
+// The feed currently publishes the City itself plus these exact department
+// paths. Keep the allowlist fail-closed: an unfamiliar publisher string must be
+// reviewed before portal-wide City terms can be applied to it.
 const HAMILTON_PUBLISHER_PATTERNS = [
     /^city of hamilton$/i,
     /^city of hamilton;\s*corporate services;\s*information technology$/i,
     /^city of hamilton;\s*planning and economic development;\s*planning$/i,
-    /^city of hamilton;\s*public works;\s*transportation operations \& maintenance$/i,
+    /^city of hamilton;\s*public works;\s*transportation operations & maintenance$/i,
     /^city of hamilton,\s*corporate services,\s*information technology,\s*business applications,\s*spatial solutions and data services$/i,
     /^city of hamilton;\s*public works;\s*hamilton water$/i,
     /^city of hamilton;\s*public works;\s*engineering services$/i,
@@ -390,6 +457,9 @@ const regionalRules = {
     ]
 };
 
+// Daily sync order is intentional. Within each regional cluster, municipal
+// portals run before the regional portal so a future shared ArcGIS item keeps
+// the authoritative regional metadata while retaining every provenance row.
 const sources = [{
     id: 'toronto-open-data',
     kind: 'ckan',
@@ -527,70 +597,89 @@ const sources = [{
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
     publisherAliases: [
-        { publisher: /^city of ottawa$/i, name: 'City of Ottawa' }
+        { publisher: /^city of ottawa$/i, name: 'City of Ottawa' },
+        { publisher: /^ottawa police service$/i, name: 'Ottawa Police Service' }
     ],
-    authoritativePublishers: [{ publisher: /^city of ottawa$/i }],
+    authoritativePublishers: [
+        { publisher: /^city of ottawa$/i },
+        { publisher: /^ottawa police service$/i }
+    ],
     licenseRules: [
         {
-            licensePattern: /data\.ottawapolice\.ca\/pages\/open-data-licence/i,
+            licensePattern: /ottawa police service open data license/i,
             license: OTTAWA_POLICE_LICENSE
         },
-        { publisher: /^city of ottawa$/i, license: OTTAWA_LICENSE }
+        {
+            publisher: /^city of ottawa$/i,
+            license: OTTAWA_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /^city of ottawa$/i,
-        placeId: 'sgc-cd-3506',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /^city of ottawa$/i,
+            placeId: 'sgc-cd-3506',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /^ottawa police service$/i,
+            placeId: 'sgc-cd-3506',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'vancouver-open-data',
     kind: 'opendatasoft',
     nameEn: 'City of Vancouver Open Data',
     nameFr: 'Données ouvertes de la Ville de Vancouver',
     homepageUrl: 'https://opendata.vancouver.ca/',
-    catalogUrl: 'https://opendata.vancouver.ca/api/explore/v2.1',
+    catalogUrl: 'https://opendata.vancouver.ca/api/explore/v2.1/catalog/exports/json',
+    datasetBaseUrl: 'https://opendata.vancouver.ca/explore/dataset',
     upstreamHost: 'opendata.vancouver.ca',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
     metadataLanguage: 'en',
-    timezone: 'America/Vancouver',
     defaultOrganizationId: 'city-of-vancouver',
     defaultOrganizationName: 'city-of-vancouver',
     defaultOrganizationTitleEn: 'City of Vancouver',
     defaultOrganizationTitleFr: 'Ville de Vancouver',
-    defaultLicenseTitleEn: VANCOUVER_LICENSE.titleEn,
-    defaultLicenseTitleFr: VANCOUVER_LICENSE.titleFr,
-    defaultLicenseUrl: VANCOUVER_LICENSE.url,
-    defaultAttributionEn: VANCOUVER_LICENSE.attributionEn,
-    defaultAttributionFr: VANCOUVER_LICENSE.attributionFr,
     licenseMode: 'record-explicit',
-    authoritativePublishers: [{ publisher: /^city of vancouver$/i }],
-    licenseRules: [{
-        publisher: /^city of vancouver$/i,
-        licenseTitle: /^open government licence\s*[-–]\s*vancouver$/i,
-        licenseUrl: /^https:\/\/opendata\.vancouver\.ca\/pages\/licence\/?$/i,
-        license: VANCOUVER_LICENSE
-    }],
-    placeRules: [{
-        publisher: /^city of vancouver$/i,
-        placeId: 'sgc-csd-5915022',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    timezone: 'America/Vancouver',
+    authoritativePublishers: [
+        { publisher: /^city of vancouver$/i },
+        { publisher: /^vancouver police department$/i },
+        { publisher: /^vancouver board of parks and recreation$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /.*/,
+            licenseTitle: /open government licence\s*[-–—]\s*vancouver/i,
+            licenseUrl: /https?:\/\/opendata\.vancouver\.ca\/pages\/licence\/?/i,
+            license: VANCOUVER_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-5915022',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'calgary-open-data',
     kind: 'socrata',
     nameEn: 'City of Calgary Open Data',
     nameFr: 'Données ouvertes de la Ville de Calgary',
     homepageUrl: 'https://data.calgary.ca/',
-    catalogUrl: 'https://data.calgary.ca/api/catalog/v1',
+    catalogUrl: 'https://data.calgary.ca/api/views',
+    datasetBaseUrl: 'https://data.calgary.ca/d',
     upstreamHost: 'data.calgary.ca',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    metadataLanguage: 'en',
     placeId: 'sgc-csd-4806016',
     defaultOrganizationId: 'city-of-calgary',
     defaultOrganizationName: 'city-of-calgary',
@@ -603,15 +692,19 @@ const sources = [{
     defaultAttributionFr: CALGARY_LICENSE.attributionFr,
     socrataPolicy: {
         publisher: {
-            mode: 'custom-field', section: 'Data Supplier', field: 'Organization',
+            mode: 'custom-field',
+            section: 'attribution_and_governance',
+            field: 'data_owner',
             allowed: ['The City of Calgary']
         },
         license: {
-            mode: 'custom-field', section: 'License/Attribution',
-            fields: ['License URL', 'License-URL'], comparison: 'url',
+            mode: 'custom-field',
+            section: 'attribution_and_governance',
+            field: 'terms_of_use_url',
+            comparison: 'url',
             allowed: [
-                'https://data.calgary.ca/d/Open-Data-Terms/u45n-7awa',
-                'https://data.calgary.ca/stories/s/u45n-7awa/'
+                'https://data.calgary.ca/stories/s/Open-Calgary-Terms-of-Use/u45n-7awa/',
+                'https://data.calgary.ca/stories/s/Open-Data-Terms-of-Use/m4y3-vbh8/'
             ]
         }
     }
@@ -621,12 +714,12 @@ const sources = [{
     nameEn: 'City of Edmonton Open Data',
     nameFr: 'Données ouvertes de la Ville d’Edmonton',
     homepageUrl: 'https://data.edmonton.ca/',
-    catalogUrl: 'https://data.edmonton.ca/api/catalog/v1',
+    catalogUrl: 'https://data.edmonton.ca/api/views',
+    datasetBaseUrl: 'https://data.edmonton.ca/d',
     upstreamHost: 'data.edmonton.ca',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    metadataLanguage: 'en',
     placeId: 'sgc-csd-4811061',
     defaultOrganizationId: 'city-of-edmonton',
     defaultOrganizationName: 'city-of-edmonton',
@@ -640,11 +733,16 @@ const sources = [{
     socrataPolicy: {
         publisher: {
             mode: 'attribution',
-            allowed: ['City of Edmonton', 'The City of Edmonton']
+            allowed: [
+                'City of Edmonton',
+                'The City of Edmonton'
+            ]
         },
         license: {
             mode: 'view-license-name',
-            allowed: ['See Terms of Use']
+            allowed: [
+                'See Terms of Use'
+            ]
         }
     }
 }, {
@@ -653,12 +751,12 @@ const sources = [{
     nameEn: 'City of Winnipeg Open Data',
     nameFr: 'Données ouvertes de la Ville de Winnipeg',
     homepageUrl: 'https://data.winnipeg.ca/',
-    catalogUrl: 'https://data.winnipeg.ca/api/catalog/v1',
+    catalogUrl: 'https://data.winnipeg.ca/api/views',
+    datasetBaseUrl: 'https://data.winnipeg.ca/d',
     upstreamHost: 'data.winnipeg.ca',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    metadataLanguage: 'en',
     placeId: 'sgc-csd-4611040',
     defaultOrganizationId: 'city-of-winnipeg',
     defaultOrganizationName: 'city-of-winnipeg',
@@ -671,12 +769,20 @@ const sources = [{
     defaultAttributionFr: WINNIPEG_LICENSE.attributionFr,
     socrataPolicy: {
         publisher: {
-            mode: 'attribution', allowBlank: true,
-            allowed: ['City of Winnipeg', 'Winnipeg Transit', 'Public Works', 'City Clerks']
+            mode: 'attribution',
+            allowBlank: true,
+            allowed: [
+                'City of Winnipeg',
+                'Winnipeg Transit'
+            ]
         },
         license: {
-            mode: 'custom-field', section: 'Licence', field: 'Licence',
-            allowed: ['Open Government Licence - Winnipeg']
+            mode: 'custom-field',
+            section: 'Licence',
+            field: 'Licence',
+            allowed: [
+                'Open Government Licence - Winnipeg'
+            ]
         }
     }
 }, {
@@ -690,21 +796,42 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
-    publisherAliases: [
-        { publisher: /^halifax regional municipality$/i, name: 'Halifax Regional Municipality' }
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
     ],
-    authoritativePublishers: [{ publisher: /^halifax regional municipality$/i }],
-    licenseRules: [{
-        publisher: /^halifax regional municipality$/i,
-        license: HALIFAX_LICENSE
-    }],
-    placeRules: [{
-        publisher: /^halifax regional municipality$/i,
-        placeId: 'sgc-csd-1209034',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    publisherAliases: [
+        { publisher: /^hrm$/i, name: 'Halifax Regional Municipality' },
+        { publisher: /^halifax regional municipality$/i, name: 'Halifax Regional Municipality' },
+        { publisher: /^halifax transit$/i, name: 'Halifax Transit' },
+        { publisher: /^halifax regional police$/i, name: 'Halifax Regional Police' },
+        { publisher: /^halifax regional fire & emergency$/i, name: 'Halifax Regional Fire & Emergency' },
+        { publisher: /^halifax water$/i, name: 'Halifax Water' },
+        { publisher: /^halifax public libraries$/i, name: 'Halifax Public Libraries' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^hrm$/i },
+        { publisher: /^halifax regional municipality$/i },
+        { publisher: /^halifax transit$/i },
+        { publisher: /^halifax regional police$/i },
+        { publisher: /^halifax regional fire & emergency$/i },
+        { publisher: /^halifax water$/i },
+        { publisher: /^halifax public libraries$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /.*/,
+            license: HALIFAX_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-1209034',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'hamilton-hub',
     kind: 'arcgis-hub',
@@ -716,46 +843,338 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
-    publisherAliases: HAMILTON_PUBLISHER_PATTERNS.map(publisher => ({
-        publisher, name: 'City of Hamilton'
-    })),
-    authoritativePublishers: [{ publisher: /^city of hamilton$/i }],
-    licenseRules: [{
-        publisher: /^city of hamilton$/i,
-        license: HAMILTON_LICENSE
-    }],
-    placeRules: [{
-        publisher: /^city of hamilton$/i,
-        placeId: 'sgc-cd-3525',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of hamilton$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;\s*corporate services;\s*information technology$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;\s*planning and economic development;\s*planning$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;\s*public works;\s*transportation operations & maintenance$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton,\s*corporate services,\s*information technology,\s*business applications,\s*spatial solutions and data services$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;\s*public works;\s*hamilton water$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;\s*public works;\s*engineering services$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;\s*planning and economic development;\s*transportation planning and parking$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;\s*public works;\s*environmental services$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;\s*planning and economic development;\s*parking and by-law services$/i, name: 'City of Hamilton' },
+        { publisher: /^city of hamilton;;$/i, name: 'City of Hamilton' }
+    ],
+    authoritativePublishers: HAMILTON_PUBLISHER_PATTERNS.map(pattern => ({ publisher: pattern })),
+    licenseRules: [
+        {
+            publisher: /.*/,
+            license: HAMILTON_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-cd-3525',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'surrey-hub',
     kind: 'arcgis-hub',
     nameEn: 'City of Surrey Open Data',
     nameFr: 'Données ouvertes de la Ville de Surrey',
-    homepageUrl: 'https://opendata-surrey.hub.arcgis.com/',
+    homepageUrl: 'https://data.surrey.ca/',
     catalogUrl: 'https://opendata-surrey.hub.arcgis.com/api/feed/dcat-us/1.1.json',
     upstreamHost: 'opendata-surrey.hub.arcgis.com',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of surrey$/i, name: 'City of Surrey' }
     ],
-    authoritativePublishers: [{ publisher: /^city of surrey$/i }],
-    licenseRules: [{
-        publisher: /^city of surrey$/i,
-        license: SURREY_LICENSE
-    }],
+    authoritativePublishers: [
+        { publisher: /^city of surrey$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /^city of surrey$/i,
+            license: SURREY_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^city of surrey$/i,
+            placeId: 'sgc-csd-5915004',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'oshawa-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Oshawa Open Data',
+    nameFr: 'Données ouvertes de la Ville d’Oshawa',
+    homepageUrl: 'https://data-oshawa.hub.arcgis.com/',
+    catalogUrl: 'https://data-oshawa.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-oshawa.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of oshawa$/i, name: 'City of Oshawa' },
+        { publisher: /^cloca$/i, name: 'Central Lake Ontario Conservation Authority' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of oshawa$/i },
+        { publisher: /^cloca$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /^city of oshawa$/i,
+            license: OSHAWA_LICENSE
+        },
+        {
+            publisher: /^cloca$/i,
+            license: CLOCA_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^city of oshawa$/i,
+            placeId: 'ca-on-oshawa',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /^cloca$/i,
+            placeId: 'ca-on-durham',
+            relationship: 'coverage',
+            includesDescendants: true
+        }
+    ]
+}, {
+    id: 'ajax-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Town of Ajax Open Data',
+    nameFr: 'Données ouvertes de la Ville d’Ajax',
+    homepageUrl: 'https://open-ajax.hub.arcgis.com/',
+    catalogUrl: 'https://open-ajax.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-ajax.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^town of ajax$/i, name: 'Town of Ajax' }
+    ],
+    authoritativePublishers: [{ publisher: /^town of ajax$/i }],
+    licenseRules: [
+        { publisher: /^town of ajax$/i, license: AJAX_LICENSE }
+    ],
     placeRules: [{
-        publisher: /^city of surrey$/i,
-        placeId: 'sgc-csd-5915004',
+        publisher: /^town of ajax$/i,
+        placeId: 'sgc-csd-3518005',
         relationship: 'direct',
         includesDescendants: false
+    }]
+}, {
+    id: 'pickering-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Pickering Open Data',
+    nameFr: 'Données ouvertes de la Ville de Pickering',
+    homepageUrl: 'https://data-pickering.opendata.arcgis.com/',
+    catalogUrl: 'https://data-pickering.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-pickering.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of pickering$/i, name: 'City of Pickering' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of pickering$/i }],
+    licenseRules: [
+        { publisher: /^city of pickering$/i, license: PICKERING_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /^city of pickering$/i,
+        placeId: 'sgc-csd-3518001',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'whitby-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Town of Whitby Open Data',
+    nameFr: 'Données ouvertes de la Ville de Whitby',
+    homepageUrl: 'https://data-whitby.opendata.arcgis.com/',
+    catalogUrl: 'https://data-whitby.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-whitby.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    licenseMode: 'record-explicit',
+    restrictedLicensePatterns: [
+        /custom\s+license/i
+    ],
+    publisherAliases: [
+        { publisher: /^town of whitby$/i, name: 'Town of Whitby' }
+    ],
+    authoritativePublishers: [{ publisher: /^town of whitby$/i }],
+    licenseRules: [
+        {
+            licensePattern: /open\s+government\s+licen[cs]e/i,
+            license: WHITBY_LICENSE
+        }
+    ],
+    placeRules: [{
+        publisher: /^town of whitby$/i,
+        placeId: 'sgc-csd-3518009',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'durham-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Region of Durham Open Data',
+    nameFr: 'Données ouvertes de la région de Durham',
+    homepageUrl: 'https://open-durham.hub.arcgis.com/',
+    catalogUrl: 'https://open-durham.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-durham.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: DURHAM_PUBLISHER, name: 'Region of Durham' },
+        { publisher: /township of scugog/i, name: 'Township of Scugog' },
+        { publisher: /township of uxbridge/i, name: 'Township of Uxbridge' },
+        { publisher: /township of brock/i, name: 'Township of Brock' },
+        { publisher: CONSERVATION_PUBLISHER, name: 'Central Lake Ontario Conservation Authority' },
+        { publisher: ONTARIO_PUBLISHER, name: 'Government of Ontario' }
+    ],
+    authoritativePublishers: [
+        { publisher: DURHAM_PUBLISHER },
+        { publisher: /township of (brock|scugog|uxbridge)/i },
+        { publisher: CONSERVATION_PUBLISHER },
+        { publisher: ONTARIO_PUBLISHER }
+    ],
+    licenseRules: regionalRules.licenseRules,
+    placeRules: regionalRules.placeRules
+}, {
+    id: 'mississauga-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Mississauga Open Data',
+    nameFr: 'Données ouvertes de la Ville de Mississauga',
+    homepageUrl: 'https://data.mississauga.ca/',
+    catalogUrl: 'https://data.mississauga.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data.mississauga.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of mississauga$/i, name: 'City of Mississauga' },
+        { publisher: /^mississauga$/i, name: 'City of Mississauga' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of mississauga$/i }, { publisher: /^mississauga$/i }],
+    licenseRules: [
+        {
+            licensePattern: /creative\s+commons/i,
+            license: CC_BY_4_LICENSE
+        },
+        {
+            publisher: /.*/,
+            license: MISSISSAUGA_LICENSE
+        }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3521005',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'brampton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Brampton Open Data (GeoHub)',
+    nameFr: 'Données ouvertes de la Ville de Brampton (GeoHub)',
+    homepageUrl: 'https://geohub.brampton.ca/',
+    catalogUrl: 'https://geohub.brampton.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'geohub.brampton.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    licenseMode: 'record-explicit',
+    restrictedLicensePatterns: [
+        /custom\s+license/i,
+        /terms\s+of\s+use/i,
+        /copyright/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of brampton$/i, name: 'City of Brampton' },
+        { publisher: /^brampton$/i, name: 'City of Brampton' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of brampton$/i }, { publisher: /^brampton$/i }],
+    licenseRules: [
+        {
+            licensePattern: /creative\s+commons/i,
+            license: CC_BY_4_LICENSE
+        },
+        {
+            licensePattern: /open\s+government\s+licen[cs]e/i,
+            license: CC_BY_4_LICENSE
+        }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3521010',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'peel-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Region of Peel Open Data',
+    nameFr: 'Données ouvertes de la région de Peel',
+    homepageUrl: 'https://data.peelregion.ca/',
+    catalogUrl: 'https://data.peelregion.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data.peelregion.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    licenseMode: 'record-explicit',
+    restrictedLicensePatterns: [
+        /custom\s+license/i,
+        /terms\s+of\s+use/i,
+        /copyright/i
+    ],
+    publisherAliases: [
+        { publisher: /^region of peel$/i, name: 'Region of Peel' },
+        { publisher: /^regional municipality of peel$/i, name: 'Region of Peel' },
+        { publisher: /^peel$/i, name: 'Region of Peel' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^region of peel$/i },
+        { publisher: /^regional municipality of peel$/i },
+        { publisher: /^peel$/i }
+    ],
+    licenseRules: [
+        {
+            licensePattern: /open\s+data\s+licen[cs]e/i,
+            license: PEEL_LICENSE
+        },
+        {
+            licensePattern: /open\s+government\s+licen[cs]e/i,
+            license: PEEL_LICENSE
+        }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-cd-3521',
+        relationship: 'direct',
+        includesDescendants: true
     }]
 }, {
     id: 'victoria-hub',
@@ -768,150 +1187,138 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of victoria$/i, name: 'City of Victoria' }
     ],
-    authoritativePublishers: [{ publisher: /^city of victoria$/i }],
-    licenseRules: [
-        { publisher: /^city of victoria$/i, license: VICTORIA_LICENSE }
+    authoritativePublishers: [
+        { publisher: /^city of victoria$/i }
     ],
-    placeRules: [{
-        publisher: /^city of victoria$/i,
-        placeId: 'sgc-csd-5917034',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    licenseRules: [
+        {
+            publisher: /^city of victoria$/i,
+            license: VICTORIA_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^city of victoria$/i,
+            placeId: 'sgc-csd-5917034',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'waterloo-region-hub',
     kind: 'arcgis-hub',
     nameEn: 'Region of Waterloo Open Data',
-    nameFr: 'Données ouvertes de la municipalité régionale de Waterloo',
+    nameFr: 'Données ouvertes de la région de Waterloo',
     homepageUrl: 'https://rowopendata-rmw.opendata.arcgis.com/',
     catalogUrl: 'https://rowopendata-rmw.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
     upstreamHost: 'rowopendata-rmw.opendata.arcgis.com',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^region of waterloo$/i, name: 'Region of Waterloo' },
-        { publisher: /^regional municipality of waterloo$/i, name: 'Region of Waterloo' }
+        { publisher: /^city of kitchener$/i, name: 'City of Kitchener' },
+        { publisher: /^city of cambridge$/i, name: 'City of Cambridge' },
+        { publisher: /^city of waterloo$/i, name: 'City of Waterloo' }
     ],
     authoritativePublishers: [
         { publisher: /^region of waterloo$/i },
-        { publisher: /^regional municipality of waterloo$/i }
+        { publisher: /^city of kitchener$/i },
+        { publisher: /^city of cambridge$/i },
+        { publisher: /^city of waterloo$/i }
     ],
     licenseRules: [
-        { publisher: /^region of waterloo$/i, license: WATERLOO_REGION_LICENSE },
-        { publisher: /^regional municipality of waterloo$/i, license: WATERLOO_REGION_LICENSE }
+        {
+            publisher: /^region of waterloo$/i,
+            license: WATERLOO_REGION_LICENSE
+        },
+        {
+            publisher: /^city of kitchener$/i,
+            license: KITCHENER_LICENSE
+        },
+        {
+            publisher: /^city of cambridge$/i,
+            license: CAMBRIDGE_LICENSE
+        },
+        {
+            publisher: /^city of waterloo$/i,
+            license: WATERLOO_CITY_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /.*/,
-        placeId: 'sgc-cd-3530',
-        relationship: 'direct',
-        includesDescendants: true
-    }]
-}, {
-    id: 'kitchener-hub',
-    kind: 'arcgis-hub',
-    nameEn: 'City of Kitchener Open Data',
-    nameFr: 'Données ouvertes de la Ville de Kitchener',
-    homepageUrl: 'https://open-kitchenergis.opendata.arcgis.com/',
-    catalogUrl: 'https://open-kitchenergis.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
-    upstreamHost: 'open-kitchenergis.opendata.arcgis.com',
-    enabled: true,
-    syncIntervalHours: 24,
-    maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
-    publisherAliases: [
-        { publisher: /^city of kitchener$/i, name: 'City of Kitchener' }
-    ],
-    authoritativePublishers: [{ publisher: /^city of kitchener$/i }],
-    licenseRules: [
-        { publisher: /^city of kitchener$/i, license: KITCHENER_LICENSE }
-    ],
-    placeRules: [{
-        publisher: /^city of kitchener$/i,
-        placeId: 'sgc-csd-3530013',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
-}, {
-    id: 'cambridge-hub',
-    kind: 'arcgis-hub',
-    nameEn: 'City of Cambridge Open Data',
-    nameFr: 'Données ouvertes de la Ville de Cambridge',
-    homepageUrl: 'https://data-cambridge.opendata.arcgis.com/',
-    catalogUrl: 'https://data-cambridge.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
-    upstreamHost: 'data-cambridge.opendata.arcgis.com',
-    enabled: true,
-    syncIntervalHours: 24,
-    maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
-    publisherAliases: [
-        { publisher: /^city of cambridge$/i, name: 'City of Cambridge' }
-    ],
-    authoritativePublishers: [{ publisher: /^city of cambridge$/i }],
-    licenseRules: [
-        { publisher: /^city of cambridge$/i, license: CAMBRIDGE_LICENSE }
-    ],
-    placeRules: [{
-        publisher: /^city of cambridge$/i,
-        placeId: 'sgc-csd-3530010',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
-}, {
-    id: 'waterloo-city-hub',
-    kind: 'arcgis-hub',
-    nameEn: 'City of Waterloo Open Data',
-    nameFr: 'Données ouvertes de la Ville de Waterloo',
-    homepageUrl: 'https://data.waterloo.ca/',
-    catalogUrl: 'https://data.waterloo.ca/api/feed/dcat-us/1.1.json',
-    upstreamHost: 'data.waterloo.ca',
-    enabled: true,
-    syncIntervalHours: 24,
-    maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
-    publisherAliases: [
-        { publisher: /^city of waterloo$/i, name: 'City of Waterloo' }
-    ],
-    authoritativePublishers: [{ publisher: /^city of waterloo$/i }],
-    licenseRules: [
-        { publisher: /^city of waterloo$/i, license: WATERLOO_CITY_LICENSE }
-    ],
-    placeRules: [{
-        publisher: /^city of waterloo$/i,
-        placeId: 'sgc-csd-3530016',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /^region of waterloo$/i,
+            placeId: 'sgc-cd-3530',
+            relationship: 'direct',
+            includesDescendants: true
+        },
+        {
+            publisher: /^city of kitchener$/i,
+            placeId: 'sgc-csd-3530013',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /^city of cambridge$/i,
+            placeId: 'sgc-csd-3530010',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /^city of waterloo$/i,
+            placeId: 'sgc-csd-3530016',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'london-hub',
     kind: 'arcgis-hub',
     nameEn: 'City of London Open Data',
     nameFr: 'Données ouvertes de la Ville de London',
-    homepageUrl: 'https://open.london.ca/',
-    catalogUrl: 'https://open.london.ca/api/feed/dcat-us/1.1.json',
-    upstreamHost: 'open.london.ca',
+    homepageUrl: 'https://open-london.opendata.arcgis.com/',
+    catalogUrl: 'https://open-london.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-london.opendata.arcgis.com',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^city of london$/i, name: 'City of London' }
+        { publisher: /^city of london$/i, name: 'City of London' },
+        { publisher: /^cityoflondon_admin$/i, name: 'City of London' }
     ],
-    authoritativePublishers: [{ publisher: /^city of london$/i }],
+    authoritativePublishers: [
+        { publisher: /^city of london$/i },
+        { publisher: /^cityoflondon_admin$/i }
+    ],
     licenseRules: [
-        { publisher: /^city of london$/i, license: LONDON_LICENSE }
+        {
+            publisher: /.*/,
+            license: LONDON_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /^city of london$/i,
-        placeId: 'sgc-csd-3539036',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-3539036',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'kelowna-hub',
     kind: 'arcgis-hub',
@@ -923,20 +1330,30 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of kelowna$/i, name: 'City of Kelowna' }
     ],
-    authoritativePublishers: [{ publisher: /^city of kelowna$/i }],
-    licenseRules: [
-        { publisher: /^city of kelowna$/i, license: KELOWNA_LICENSE }
+    authoritativePublishers: [
+        { publisher: /^city of kelowna$/i }
     ],
-    placeRules: [{
-        publisher: /^city of kelowna$/i,
-        placeId: 'sgc-csd-5935010',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    licenseRules: [
+        {
+            publisher: /^city of kelowna$/i,
+            license: KELOWNA_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^city of kelowna$/i,
+            placeId: 'sgc-csd-5935010',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'fredericton-hub',
     kind: 'arcgis-hub',
@@ -948,113 +1365,137 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of fredericton$/i, name: 'City of Fredericton' }
     ],
-    authoritativePublishers: [{ publisher: /^city of fredericton$/i }],
-    licenseRules: [
-        { publisher: /^city of fredericton$/i, license: FREDERICTON_LICENSE }
+    authoritativePublishers: [
+        { publisher: /^city of fredericton$/i }
     ],
-    placeRules: [{
-        publisher: /^city of fredericton$/i,
-        placeId: 'sgc-csd-1310032',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    licenseRules: [
+        {
+            publisher: /^city of fredericton$/i,
+            license: FREDERICTON_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^city of fredericton$/i,
+            placeId: 'sgc-csd-1310032',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'burlington-hub',
     kind: 'arcgis-hub',
     nameEn: 'City of Burlington Open Data',
     nameFr: 'Données ouvertes de la Ville de Burlington',
-    homepageUrl: 'https://navigadatalab-burlington.opendata.arcgis.com/',
-    catalogUrl: 'https://navigadatalab-burlington.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
-    upstreamHost: 'navigadatalab-burlington.opendata.arcgis.com',
+    homepageUrl: 'https://navburl-burlington.opendata.arcgis.com/',
+    catalogUrl: 'https://navburl-burlington.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'navburl-burlington.opendata.arcgis.com',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of burlington$/i, name: 'City of Burlington' },
-        { publisher: /^the corporation of the city of burlington$/i, name: 'City of Burlington' }
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Burlington' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of burlington$/i },
-        { publisher: /^the corporation of the city of burlington$/i }
+        { publisher: /burlington/i },
+        { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /^city of burlington$/i, license: BURLINGTON_LICENSE },
-        { publisher: /^the corporation of the city of burlington$/i, license: BURLINGTON_LICENSE }
+        {
+            publisher: /.*/,
+            license: BURLINGTON_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /.*/,
-        placeId: 'sgc-csd-3524002',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-3524002',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'oakville-hub',
     kind: 'arcgis-hub',
     nameEn: 'Town of Oakville Open Data',
     nameFr: 'Données ouvertes de la Ville d’Oakville',
-    homepageUrl: 'https://oakvillegis.opendata.arcgis.com/',
-    catalogUrl: 'https://oakvillegis.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
-    upstreamHost: 'oakvillegis.opendata.arcgis.com',
+    homepageUrl: 'https://portal-exploreoakville.opendata.arcgis.com/',
+    catalogUrl: 'https://portal-exploreoakville.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'portal-exploreoakville.opendata.arcgis.com',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^town of oakville$/i, name: 'Town of Oakville' },
-        { publisher: /^the corporation of the town of oakville$/i, name: 'Town of Oakville' }
+        { publisher: /^town of oakville$/i, name: 'Town of Oakville' }
     ],
     authoritativePublishers: [
-        { publisher: /^town of oakville$/i },
-        { publisher: /^the corporation of the town of oakville$/i }
+        { publisher: /^town of oakville$/i }
     ],
     licenseRules: [
-        { publisher: /^town of oakville$/i, license: OAKVILLE_LICENSE },
-        { publisher: /^the corporation of the town of oakville$/i, license: OAKVILLE_LICENSE }
+        {
+            publisher: /^town of oakville$/i,
+            license: OAKVILLE_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /.*/,
-        placeId: 'sgc-csd-3524001',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /^town of oakville$/i,
+            placeId: 'sgc-csd-3524001',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'milton-hub',
     kind: 'arcgis-hub',
     nameEn: 'Town of Milton Open Data',
     nameFr: 'Données ouvertes de la Ville de Milton',
-    homepageUrl: 'https://open-milton.hub.arcgis.com/',
-    catalogUrl: 'https://open-milton.hub.arcgis.com/api/feed/dcat-us/1.1.json',
-    upstreamHost: 'open-milton.hub.arcgis.com',
+    homepageUrl: 'https://discover-milton.hub.arcgis.com/',
+    catalogUrl: 'https://discover-milton.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'discover-milton.hub.arcgis.com',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^town of milton$/i, name: 'Town of Milton' },
-        { publisher: /^the corporation of the town of milton$/i, name: 'Town of Milton' },
-        { publisher: /^\{\{source\}\}$/i, name: 'Town of Milton' }
+        { publisher: /^town of milton$/i, name: 'Town of Milton' }
     ],
     authoritativePublishers: [
-        { publisher: /^town of milton$/i },
-        { publisher: /^the corporation of the town of milton$/i },
-        { publisher: /^\{\{source\}\}$/i }
+        { publisher: /^town of milton$/i }
     ],
     licenseRules: [
-        { publisher: /^town of milton$/i, license: MILTON_LICENSE },
-        { publisher: /^the corporation of the town of milton$/i, license: MILTON_LICENSE },
-        { publisher: /^\{\{source\}\}$/i, license: MILTON_LICENSE }
+        {
+            publisher: /^town of milton$/i,
+            license: MILTON_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /.*/,
-        placeId: 'sgc-csd-3524009',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /^town of milton$/i,
+            placeId: 'sgc-csd-3524009',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'sudbury-hub',
     kind: 'arcgis-hub',
@@ -1066,25 +1507,32 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of greater sudbury$/i, name: 'City of Greater Sudbury' },
-        { publisher: /^ville du grand sudbury$/i, name: 'City of Greater Sudbury' }
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Greater Sudbury' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of greater sudbury$/i },
-        { publisher: /^ville du grand sudbury$/i }
+        { publisher: /greater sudbury/i },
+        { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /^city of greater sudbury$/i, license: SUDBURY_LICENSE },
-        { publisher: /^ville du grand sudbury$/i, license: SUDBURY_LICENSE }
+        {
+            publisher: /.*/,
+            license: SUDBURY_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /.*/,
-        placeId: 'sgc-cd-3553',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-cd-3553',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'burnaby-hub',
     kind: 'arcgis-hub',
@@ -1096,49 +1544,69 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^city of burnaby$/i, name: 'City of Burnaby' }
+        { publisher: /^city of burnaby$/i, name: 'City of Burnaby' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Burnaby' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of burnaby$/i }
+        { publisher: /burnaby/i },
+        { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /^city of burnaby$/i, license: BURNABY_LICENSE }
+        {
+            publisher: /.*/,
+            license: BURNABY_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /^city of burnaby$/i,
-        placeId: 'sgc-csd-5915025',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-5915025',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'saskatoon-hub',
     kind: 'arcgis-hub',
     nameEn: 'City of Saskatoon Open Data',
     nameFr: 'Données ouvertes de la Ville de Saskatoon',
-    homepageUrl: 'https://opendata-saskatoon.hub.arcgis.com/',
-    catalogUrl: 'https://opendata-saskatoon.hub.arcgis.com/api/feed/dcat-us/1.1.json',
-    upstreamHost: 'opendata-saskatoon.hub.arcgis.com',
+    homepageUrl: 'https://opendata.saskatoon.ca/',
+    catalogUrl: 'https://opendata.saskatoon.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.saskatoon.ca',
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^city of saskatoon$/i, name: 'City of Saskatoon' }
+        { publisher: /^city of saskatoon$/i, name: 'City of Saskatoon' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Saskatoon' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of saskatoon$/i }
+        { publisher: /saskatoon/i },
+        { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /^city of saskatoon$/i, license: SASKATOON_LICENSE }
+        {
+            publisher: /.*/,
+            license: SASKATOON_LICENSE
+        }
     ],
-    placeRules: [{
-        publisher: /^city of saskatoon$/i,
-        placeId: 'sgc-csd-4711066',
-        relationship: 'direct',
-        includesDescendants: false
-    }]
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-4711066',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
 }, {
     id: 'markham-hub',
     kind: 'arcgis-hub',
@@ -1150,22 +1618,24 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of markham$/i, name: 'City of Markham' },
-        { publisher: /^the corporation of the city of markham$/i, name: 'City of Markham' },
-        { publisher: /^regional municipality of york$/i, name: 'Regional Municipality of York' },
-        { publisher: /^york region$/i, name: 'Regional Municipality of York' }
+        { publisher: /^regional municipality of york$/i, name: 'York Region' },
+        { publisher: /^york region$/i, name: 'York Region' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Markham' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of markham$/i },
-        { publisher: /^the corporation of the city of markham$/i },
-        { publisher: /^regional municipality of york$/i },
-        { publisher: /^york region$/i }
+        { publisher: /markham/i },
+        { publisher: /york/i },
+        { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /markham/i, license: MARKHAM_LICENSE },
-        { publisher: /york/i, license: YORK_REGION_LICENSE }
+        { publisher: /york/i, license: YORK_REGION_LICENSE },
+        { publisher: /.*/, license: MARKHAM_LICENSE }
     ],
     placeRules: [
         {
@@ -1179,6 +1649,12 @@ const sources = [{
             placeId: 'sgc-cd-3519',
             relationship: 'direct',
             includesDescendants: true
+        },
+        {
+            publisher: /^\{\{source\}\}$/i,
+            placeId: 'sgc-csd-3519036',
+            relationship: 'direct',
+            includesDescendants: false
         }
     ]
 }, {
@@ -1192,15 +1668,16 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^town of newmarket$/i, name: 'Town of Newmarket' },
-        { publisher: /^the corporation of the town of newmarket$/i, name: 'Town of Newmarket' },
         { publisher: /^\{\{source\}\}$/i, name: 'Town of Newmarket' }
     ],
     authoritativePublishers: [
-        { publisher: /^town of newmarket$/i },
-        { publisher: /^the corporation of the town of newmarket$/i },
+        { publisher: /newmarket/i },
         { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
@@ -1223,20 +1700,24 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of niagara falls$/i, name: 'City of Niagara Falls' },
-        { publisher: /^the corporation of the city of niagara falls$/i, name: 'City of Niagara Falls' }
+        { publisher: /^the city of niagara falls$/i, name: 'City of Niagara Falls' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Niagara Falls' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of niagara falls$/i },
-        { publisher: /^the corporation of the city of niagara falls$/i }
+        { publisher: /niagara falls/i },
+        { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /^city of niagara falls/i, license: NIAGARA_FALLS_LICENSE }
+        { publisher: /.*/, license: NIAGARA_FALLS_LICENSE }
     ],
     placeRules: [{
-        publisher: /^city of niagara falls/i,
+        publisher: /.*/,
         placeId: 'sgc-csd-3526043',
         relationship: 'direct',
         includesDescendants: false
@@ -1252,21 +1733,23 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^city of welland/i, name: 'City of Welland' },
+        { publisher: /^city of welland$/i, name: 'City of Welland' },
         { publisher: /^\{\{source\}\}$/i, name: 'City of Welland' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of welland/i },
+        { publisher: /welland/i },
         { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /^city of welland/i, license: WELLAND_LICENSE },
-        { publisher: /^\{\{source\}\}$/i, license: WELLAND_LICENSE }
+        { publisher: /.*/, license: WELLAND_LICENSE }
     ],
     placeRules: [{
-        publisher: /^city of welland/i,
+        publisher: /.*/,
         placeId: 'sgc-csd-3526032',
         relationship: 'direct',
         includesDescendants: false
@@ -1282,18 +1765,24 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^city of moncton/i, name: 'City of Moncton' }
+        { publisher: /^city of moncton$/i, name: 'City of Moncton' },
+        { publisher: /^ville de moncton$/i, name: 'City of Moncton' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Moncton' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of moncton/i }
+        { publisher: /moncton/i },
+        { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /^city of moncton/i, license: MONCTON_LICENSE }
+        { publisher: /.*/, license: MONCTON_LICENSE }
     ],
     placeRules: [{
-        publisher: /^city of moncton/i,
+        publisher: /.*/,
         placeId: 'sgc-csd-1307022',
         relationship: 'direct',
         includesDescendants: false
@@ -1309,18 +1798,23 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^city of guelph/i, name: 'City of Guelph' }
+        { publisher: /^city of guelph$/i, name: 'City of Guelph' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Guelph' }
     ],
     authoritativePublishers: [
-        { publisher: /^city of guelph/i }
+        { publisher: /guelph/i },
+        { publisher: /^\{\{source\}\}$/i }
     ],
     licenseRules: [
-        { publisher: /^city of guelph/i, license: GUELPH_LICENSE }
+        { publisher: /.*/, license: GUELPH_LICENSE }
     ],
     placeRules: [{
-        publisher: /^city of guelph/i,
+        publisher: /.*/,
         placeId: 'sgc-csd-3523008',
         relationship: 'direct',
         includesDescendants: false
@@ -1336,21 +1830,22 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
-        { publisher: /^district of saanich/i, name: 'District of Saanich' },
-        { publisher: /^saanich/i, name: 'District of Saanich' }
+        { publisher: /^district of saanich$/i, name: 'District of Saanich' },
+        { publisher: /^saanich$/i, name: 'District of Saanich' }
     ],
     authoritativePublishers: [
-        { publisher: /^district of saanich/i },
-        { publisher: /^saanich/i }
+        { publisher: /saanich/i }
     ],
     licenseRules: [
-        { publisher: /^district of saanich/i, license: SAANICH_LICENSE },
-        { publisher: /^saanich/i, license: SAANICH_LICENSE }
+        { publisher: /.*/, license: SAANICH_LICENSE }
     ],
     placeRules: [{
-        publisher: /^district of saanich/i,
+        publisher: /.*/,
         placeId: 'sgc-csd-5917021',
         relationship: 'direct',
         includesDescendants: false
@@ -1366,7 +1861,10 @@ const sources = [{
     enabled: true,
     syncIntervalHours: 24,
     maxDeleteFraction: 0.1,
-    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
     publisherAliases: [
         { publisher: /^city of belleville/i, name: 'City of Belleville' }
     ],
@@ -1377,6 +1875,226 @@ const sources = [{
     placeRules: [{
         publisher: /^city of belleville/i,
         placeId: 'sgc-csd-3512005',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'yellowknife-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Yellowknife Open Data',
+    nameFr: 'Données ouvertes de la Ville de Yellowknife',
+    homepageUrl: 'https://data-yellowknife.hub.arcgis.com/',
+    catalogUrl: 'https://data-yellowknife.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-yellowknife.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^city of yellowknife$/i, name: 'City of Yellowknife' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of yellowknife$/i }],
+    licenseRules: [
+        { publisher: /.*/, license: YELLOWKNIFE_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-6106023',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'barrie-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Barrie Open Data',
+    nameFr: 'Données ouvertes de la Ville de Barrie',
+    homepageUrl: 'https://opendata.barrie.ca/',
+    catalogUrl: 'https://opendata.barrie.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.barrie.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^the city of barrie$/i, name: 'City of Barrie' },
+        { publisher: /^city of barrie$/i, name: 'City of Barrie' }
+    ],
+    authoritativePublishers: [{ publisher: /city of barrie/i }],
+    licenseRules: [
+        { publisher: /.*/, license: BARRIE_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3543042',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'thunderbay-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Thunder Bay Open Data',
+    nameFr: 'Données ouvertes de la Ville de Thunder Bay',
+    homepageUrl: 'https://opendata-thunderbay.hub.arcgis.com/',
+    catalogUrl: 'https://opendata-thunderbay.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-thunderbay.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^city of thunder bay$/i, name: 'City of Thunder Bay' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Thunder Bay' }
+    ],
+    authoritativePublishers: [
+        { publisher: /city of thunder bay/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: THUNDER_BAY_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3558004',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'chatham-kent-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Municipality of Chatham-Kent Open Data',
+    nameFr: 'Données ouvertes de la municipalité de Chatham-Kent',
+    homepageUrl: 'https://opendata.chatham-kent.ca/',
+    catalogUrl: 'https://opendata.chatham-kent.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.chatham-kent.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^municipality of chatham-kent$/i, name: 'Municipality of Chatham-Kent' }
+    ],
+    authoritativePublishers: [{ publisher: /^municipality of chatham-kent$/i }],
+    licenseRules: [
+        { publisher: /.*/, license: CHATHAM_KENT_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-cd-3536',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'kawartha-lakes-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Kawartha Lakes Open Data',
+    nameFr: 'Données ouvertes de la Ville de Kawartha Lakes',
+    homepageUrl: 'https://open-data-kawartha.hub.arcgis.com/',
+    catalogUrl: 'https://open-data-kawartha.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-data-kawartha.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^city of kawartha lakes$/i, name: 'City of Kawartha Lakes' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Kawartha Lakes' }
+    ],
+    authoritativePublishers: [
+        { publisher: /kawartha lakes/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: KAWARTHA_LAKES_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-cd-3516',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'summerland-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'District of Summerland Open Data',
+    nameFr: 'Données ouvertes du district de Summerland',
+    homepageUrl: 'https://open-data-summerland.hub.arcgis.com/',
+    catalogUrl: 'https://open-data-summerland.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-data-summerland.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^districtofsummerland$/i, name: 'District of Summerland' },
+        { publisher: /^district of summerland$/i, name: 'District of Summerland' },
+        { publisher: /^\{\{source\}\}$/i, name: 'District of Summerland' }
+    ],
+    authoritativePublishers: [
+        { publisher: /summerland/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: SUMMERLAND_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-5907035',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'norfolk-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Norfolk County Open Data',
+    nameFr: 'Données ouvertes du comté de Norfolk',
+    homepageUrl: 'https://data-norfolk.opendata.arcgis.com/',
+    catalogUrl: 'https://data-norfolk.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-norfolk.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^map norfolk$/i, name: 'Norfolk County' },
+        { publisher: /^norfolk county$/i, name: 'Norfolk County' }
+    ],
+    authoritativePublishers: [{ publisher: /norfolk/i }],
+    licenseRules: [
+        { publisher: /.*/, license: NORFOLK_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3528052',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'haldimand-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Haldimand County Open Data',
+    nameFr: 'Données ouvertes du comté de Haldimand',
+    homepageUrl: 'https://opendata-haldimand.hub.arcgis.com/',
+    catalogUrl: 'https://opendata-haldimand.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-haldimand.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^the corporation of haldimand county$/i, name: 'Haldimand County' },
+        { publisher: /^haldimand county$/i, name: 'Haldimand County' },
+        { publisher: /^\{\{source\}\}$/i, name: 'Haldimand County' }
+    ],
+    authoritativePublishers: [
+        { publisher: /haldimand/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: HALDIMAND_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3528018',
         relationship: 'direct',
         includesDescendants: false
     }]
@@ -1429,6 +2147,14 @@ module.exports = {
     GUELPH_LICENSE,
     SAANICH_LICENSE,
     BELLEVILLE_LICENSE,
+    YELLOWKNIFE_LICENSE,
+    BARRIE_LICENSE,
+    THUNDER_BAY_LICENSE,
+    CHATHAM_KENT_LICENSE,
+    KAWARTHA_LAKES_LICENSE,
+    SUMMERLAND_LICENSE,
+    NORFOLK_LICENSE,
+    HALDIMAND_LICENSE,
     MISSISSAUGA_LICENSE,
     CC_BY_4_LICENSE,
     OGL_CANADA_LICENSE,

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -15,9 +15,11 @@ const SINGLE_TIER_CITY_CSD = {
     '3520005': 'sgc-cd-3520',
     '3525005': 'sgc-cd-3525',
     '2465005': 'sgc-cd-2465',
-    '3553005': 'sgc-cd-3553'
+    '3553005': 'sgc-cd-3553',
+    '3516010': 'sgc-cd-3516',
+    '3536020': 'sgc-cd-3536'
 };
-const SINGLE_TIER_CITY_CD = new Set(['2465', '3506', '3520', '3525', '3553']);
+const SINGLE_TIER_CITY_CD = new Set(['2465', '3506', '3520', '3525', '3553', '3516', '3536']);
 const FEATURED_PLACE_IDS = new Set([
     'ca-on-durham',
     'sgc-cd-3521',
@@ -90,7 +92,15 @@ const FEATURED_PLACE_IDS = new Set([
     'sgc-csd-1307022',
     'sgc-csd-3523008',
     'sgc-csd-5917021',
-    'sgc-csd-3512005'
+    'sgc-csd-3512005',
+    'sgc-csd-6106023',
+    'sgc-csd-3543042',
+    'sgc-csd-3558004',
+    'sgc-cd-3536',
+    'sgc-cd-3516',
+    'sgc-csd-5907035',
+    'sgc-csd-3528052',
+    'sgc-csd-3528018'
 ]);
 const MUNICIPAL_TYPES = {
     '2423027': ['City', 'Ville'],
@@ -162,7 +172,15 @@ const MUNICIPAL_TYPES = {
     '1307019': ['Parish', 'Paroisse'],
     '1307022': ['City', 'Cité'],
     '1310032': ['City', 'Ville'],
-    '5915004': ['City', 'Ville']
+    '5915004': ['City', 'Ville'],
+    '6106023': ['City', 'Ville'],
+    '3543042': ['City', 'Ville'],
+    '3558004': ['City', 'Ville'],
+    '3536': ['Municipality', 'Municipalité'],
+    '3516': ['City', 'Ville'],
+    '5907035': ['District municipality', 'Municipalité de district'],
+    '3528052': ['City', 'Ville'],
+    '3528018': ['City', 'Ville']
 };
 const PLACE_VIEWPORTS = {
     '2423027': [46.8139, -71.208, 10],
@@ -230,7 +248,16 @@ const PLACE_VIEWPORTS = {
     '1307022': [46.0878, -64.7782, 10],
     '1310032': [45.9636, -66.6431, 10],
     '5915004': [49.1913, -122.8490, 10],
-    '5917021': [48.4841, -123.3822, 10]
+    '5917021': [48.4841, -123.3822, 10],
+    '6106023': [62.4540, -114.3718, 10],
+    '3543042': [44.3894, -79.6903, 10],
+    '3558': [48.3809, -89.2477, 8],
+    '3558004': [48.3809, -89.2477, 10],
+    '3536': [42.4048, -82.1910, 9],
+    '3516': [44.3564, -78.7408, 9],
+    '5907035': [49.6006, -119.6778, 10],
+    '3528052': [42.8333, -80.3833, 9],
+    '3528018': [42.9333, -79.8667, 9]
 };
 
 function slugify(value) {
@@ -239,43 +266,59 @@ function slugify(value) {
         .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
-function rowsFrom(buffer, encoding) {
-    const text = new TextDecoder(encoding).decode(buffer);
-    return parse(text, { columns: true, skip_empty_lines: true, relax_column_count: true });
-}
-
 function normalize(enRows, frRows) {
     const frByCode = new Map(frRows.map(row => [String(row.Code), row]));
     const usedSlugs = new Set(['canada']);
     const places = [{
-        id: 'ca', slug: 'canada', kind: 'country', nameEn: 'Canada', nameFr: 'Canada',
-        typeEn: 'Country', typeFr: 'Pays', parentId: null, featured: false
+        id: 'ca',
+        slug: 'canada',
+        kind: 'country',
+        nameEn: 'Canada',
+        nameFr: 'Canada',
+        typeEn: 'Country',
+        typeFr: 'Pays',
+        parentId: null,
+        featured: false
     }];
-    const identifiers = [{ placeId: 'ca', scheme: 'sgc', vintage: '2021', value: '01' }];
+    const identifiers = [{
+        placeId: 'ca',
+        scheme: 'sgc',
+        vintage: '2021',
+        value: '01'
+    }];
+
     for (const row of enRows) {
         const level = Number(row.Level);
         const code = String(row.Code || '').trim();
         if (![2, 3, 4].includes(level) || !code) continue;
+
         const provinceCode = code.slice(0, 2);
         const provinceAbbr = PROVINCES[provinceCode];
         if (!provinceAbbr) continue;
+
         const fr = frByCode.get(code) || {};
         let nameEn = String(row['Class title'] || '').trim();
         let nameFr = String(fr['Titres de classes'] || nameEn).trim();
-        if (code === '3553') {
-            nameEn = 'Greater Sudbury';
-            nameFr = 'Grand Sudbury';
-        }
-        // Québec remains a distinct city subdivision under its multi-city
-        // census division. Laval, Ottawa, Toronto, Hamilton and Greater Sudbury are each
-        // single-tier census divisions with a matching city subdivision;
-        // preserve both official identifiers while exposing one city.
+
         if (level === 4 && SINGLE_TIER_CITY_CSD[code]) {
             const placeId = SINGLE_TIER_CITY_CSD[code];
-            identifiers.push({ placeId, scheme: 'sgc-csd', vintage: '2021', value: code });
+            identifiers.push({
+                placeId,
+                scheme: 'sgc-csd',
+                vintage: '2021',
+                value: code
+            });
             continue;
         }
-        let id, kind, parentId, scheme, typeEn, typeFr, baseSlug;
+
+        let id;
+        let kind;
+        let parentId;
+        let scheme;
+        let typeEn;
+        let typeFr;
+        let baseSlug;
+
         if (level === 2) {
             id = 'sgc-pr-' + code;
             kind = TERRITORIES.has(code) ? 'territory' : 'province';
@@ -301,9 +344,11 @@ function normalize(enRows, frRows) {
             typeFr = 'Municipalité';
             baseSlug = slugify(nameEn) + '-' + provinceAbbr;
         }
+
         if (code === '35') id = 'ca-on';
         if (code === '35') parentId = 'ca';
         if (code === '35') baseSlug = 'ontario';
+
         let slug = baseSlug;
         if (code === '1209') slug = 'halifax-region-ns';
         if (code === '1209034') slug = 'halifax-ns';
@@ -326,6 +371,18 @@ function normalize(enRows, frRows) {
         if (code === '3530016') slug = 'waterloo-on';
         if (code === '3553') slug = 'greater-sudbury-on';
         if (code === '3518013') slug = 'oshawa-on';
+        if (code === '3558') slug = 'thunder-bay-district-on';
+        if (code === '3558004') slug = 'thunder-bay-on';
+        if (code === '3516') slug = 'kawartha-lakes-on';
+        if (code === '3536') slug = 'chatham-kent-on';
+        if (code === '3543') slug = 'simcoe-county-on';
+        if (code === '3543042') slug = 'barrie-on';
+        if (code === '5907') slug = 'okanagan-similkameen-bc';
+        if (code === '5907035') slug = 'summerland-bc';
+        if (code === '3528') slug = 'haldimand-norfolk-on';
+        if (code === '3528052') slug = 'norfolk-county-on';
+        if (code === '3528018') slug = 'haldimand-county-on';
+        if (code === '6106023') slug = 'yellowknife-nt';
         if (code === '3518') {
             typeEn = 'Regional municipality';
             typeFr = 'Municipalité régionale';
@@ -351,120 +408,172 @@ function normalize(enRows, frRows) {
             typeFr = 'Municipalité régionale';
         }
         if (MUNICIPAL_TYPES[code]) [typeEn, typeFr] = MUNICIPAL_TYPES[code];
-        if (usedSlugs.has(slug)) slug += '-' + code;
+
+        if (usedSlugs.has(slug)) {
+            slug += '-' + code;
+        }
         usedSlugs.add(slug);
+
         const viewport = PLACE_VIEWPORTS[code] || [];
         places.push({
-            id, slug, kind, nameEn, nameFr, typeEn, typeFr, parentId,
+            id,
+            slug,
+            kind,
+            nameEn,
+            nameFr,
+            typeEn,
+            typeFr,
+            parentId,
             featured: FEATURED_PLACE_IDS.has(id),
             latitude: viewport[0] ?? null,
             longitude: viewport[1] ?? null,
             defaultZoom: viewport[2] ?? null
         });
-        identifiers.push({ placeId: id, scheme, vintage: '2021', value: code });
+        identifiers.push({
+            placeId: id,
+            scheme,
+            vintage: '2021',
+            value: code
+        });
     }
+
     return { places, identifiers };
 }
 
-async function preflightPlaceChanges(client, places) {
-    const desiredById = new Map();
-    const desiredBySlug = new Map();
-    for (const place of places) {
-        if (desiredById.has(place.id)) throw new Error('duplicate desired place id: ' + place.id);
-        if (desiredBySlug.has(place.slug)) {
-            throw new Error('duplicate desired place slug: ' + place.slug);
+function planAliases(existingPlaces, canonicalPlaces, existingAliases) {
+    const canonicalBySlug = new Map(canonicalPlaces.map(place => [place.slug, place]));
+    const aliasBySlug = new Map(existingAliases.map(alias => [alias.slug, alias]));
+    const existingById = new Map(existingPlaces.map(place => [place.id, place]));
+    const aliasesToAdd = [];
+    const conflicts = [];
+
+    for (const canonical of canonicalPlaces) {
+        const current = existingById.get(canonical.id);
+        if (!current || !current.slug || current.slug === canonical.slug) continue;
+
+        const formerSlug = current.slug;
+        const canonicalOwner = canonicalBySlug.get(formerSlug);
+        if (canonicalOwner && canonicalOwner.id !== canonical.id) {
+            conflicts.push({
+                slug: formerSlug,
+                expectedPlaceId: canonical.id,
+                existingPlaceId: canonicalOwner.id,
+                reason: 'former slug matches another canonical place'
+            });
+            continue;
         }
-        desiredById.set(place.id, place);
-        desiredBySlug.set(place.slug, place.id);
-    }
-    const ids = Array.from(desiredById.keys());
-    const slugs = Array.from(desiredBySlug.keys());
-    const existingResult = await client.query(`
-        SELECT id, slug, name_en FROM places WHERE id = ANY($1::text[])
-    `, [ids]);
-    const canonicalResult = await client.query(`
-        SELECT id, slug FROM places WHERE slug = ANY($1::text[])
-    `, [slugs]);
-    for (const row of canonicalResult.rows) {
-        const desiredOwner = desiredBySlug.get(row.slug);
-        if (desiredOwner !== row.id) {
-            throw new Error('desired place slug is already canonical for another place: ' + row.slug);
+
+        const aliasOwner = aliasBySlug.get(formerSlug);
+        if (aliasOwner && aliasOwner.placeId !== canonical.id) {
+            conflicts.push({
+                slug: formerSlug,
+                expectedPlaceId: canonical.id,
+                existingPlaceId: aliasOwner.placeId,
+                reason: 'former slug already mapped to another place'
+            });
+            continue;
         }
-    }
-    const aliases = [];
-    let nameChanges = 0;
-    let slugChanges = 0;
-    for (const row of existingResult.rows) {
-        const desired = desiredById.get(row.id);
-        if (row.name_en !== desired.nameEn) nameChanges += 1;
-        if (row.slug === desired.slug) continue;
-        if (desiredBySlug.has(row.slug) && desiredBySlug.get(row.slug) !== row.id) {
-            throw new Error('former place slug is becoming canonical for another place: ' + row.slug);
-        }
-        slugChanges += 1;
-        aliases.push({ slug: row.slug, placeId: row.id });
-    }
-    if (aliases.length) {
-        const aliasResult = await client.query(`
-            SELECT slug, place_id FROM place_aliases WHERE slug = ANY($1::text[])
-        `, [aliases.map(item => item.slug)]);
-        const wanted = new Map(aliases.map(item => [item.slug, item.placeId]));
-        for (const row of aliasResult.rows) {
-            if (wanted.get(row.slug) !== row.place_id) {
-                throw new Error('former place slug is already an alias for another place: ' + row.slug);
-            }
+
+        if (!aliasOwner) {
+            aliasesToAdd.push({
+                slug: formerSlug,
+                placeId: canonical.id
+            });
         }
     }
-    return { aliases, nameChanges, slugChanges, aliasConflicts: 0 };
+
+    return { aliasesToAdd, conflicts };
 }
 
-async function upsert({ places, identifiers }, dryRun, dbPool = pool) {
-    const kindOrder = { country: 0, province: 1, territory: 1, region: 2, municipality: 3 };
-    const orderedPlaces = [...places].sort((a, b) => kindOrder[a.kind] - kindOrder[b.kind]);
-    const client = await dbPool.connect();
+function rowsFrom(buffer, encoding = 'utf-8') {
+    const text = new TextDecoder(encoding).decode(buffer);
+    return parse(text, {
+        columns: true,
+        skip_empty_lines: true,
+        relax_column_count: true
+    });
+}
+
+async function run() {
+    console.log('Fetching official 2021 SGC structures...');
+    const [enBuf, frBuf] = await Promise.all([
+        fetchPublicBuffer(EN_URL),
+        fetchPublicBuffer(FR_URL)
+    ]);
+
+    const { places, identifiers } = normalize(
+        rowsFrom(enBuf, 'windows-1252'),
+        rowsFrom(frBuf, 'windows-1252')
+    );
+
+    const client = await pool.connect();
     try {
         await client.query('BEGIN');
-        const changes = await preflightPlaceChanges(client, orderedPlaces);
-        if (dryRun) {
-            await client.query('ROLLBACK');
-            return changes;
+
+        const [existingPlacesRes, existingAliasesRes] = await Promise.all([
+            client.query('SELECT id, slug, name_en, name_fr FROM places'),
+            client.query('SELECT slug, place_id FROM place_aliases')
+        ]);
+
+        const existingPlaces = existingPlacesRes.rows;
+        const existingAliases = existingAliasesRes.rows.map(row => ({
+            slug: row.slug,
+            placeId: row.place_id
+        }));
+
+        const { aliasesToAdd, conflicts } = planAliases(existingPlaces, places, existingAliases);
+        if (conflicts.length > 0) {
+            throw new Error('Refusing to sync places due to alias conflicts:\n' + JSON.stringify(conflicts, null, 2));
         }
-        for (let index = 0; index < changes.aliases.length; index += 500) {
-            const chunk = changes.aliases.slice(index, index + 500);
-            const values = [];
-            const tuples = chunk.map((alias, i) => {
-                const p = i * 2 + 1;
-                values.push(alias.slug, alias.placeId);
-                return `($${p},$${p + 1})`;
-            });
-            const inserted = await client.query(`
-                INSERT INTO place_aliases (slug, place_id)
-                VALUES ${tuples.join(',')}
-                ON CONFLICT (slug) DO UPDATE SET place_id = EXCLUDED.place_id
-                WHERE place_aliases.place_id = EXCLUDED.place_id
-            `, values);
-            if (inserted.rowCount !== chunk.length) {
-                throw new Error('place alias ownership changed during refresh');
+
+        const existingPlaceById = new Map(existingPlaces.map(p => [p.id, p]));
+        let nameChanges = 0;
+        let slugChanges = 0;
+
+        for (const place of places) {
+            const existing = existingPlaceById.get(place.id);
+            if (existing) {
+                if (existing.name_en !== place.nameEn || existing.name_fr !== place.nameFr) {
+                    nameChanges++;
+                }
+                if (existing.slug !== place.slug) {
+                    slugChanges++;
+                }
             }
         }
-        for (let index = 0; index < orderedPlaces.length; index += 250) {
-            const chunk = orderedPlaces.slice(index, index + 250);
+
+        for (let i = 0; i < places.length; i += 200) {
+            const batch = places.slice(i, i + 200);
+            const params = [];
             const values = [];
-            const tuples = chunk.map((place, i) => {
-                const p = i * 13 + 1;
+            let p = 1;
+
+            for (const place of batch) {
                 values.push(
-                    place.id, place.slug, place.kind, place.nameEn, place.nameFr,
-                    place.typeEn, place.typeFr, place.parentId, place.latitude,
-                    place.longitude, place.defaultZoom, true, place.featured === true
+                    `($${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, true, $${p++}, now())`
                 );
-                return `($${p},$${p + 1},$${p + 2},$${p + 3},$${p + 4},$${p + 5},$${p + 6},$${p + 7},$${p + 8},$${p + 9},$${p + 10},$${p + 11},$${p + 12})`;
-            });
+                params.push(
+                    place.id,
+                    place.slug,
+                    place.kind,
+                    place.nameEn,
+                    place.nameFr,
+                    place.typeEn,
+                    place.typeFr,
+                    place.parentId,
+                    place.latitude,
+                    place.longitude,
+                    place.defaultZoom,
+                    place.featured
+                );
+            }
+
             await client.query(`
                 INSERT INTO places (
                     id, slug, kind, name_en, name_fr, type_en, type_fr,
-                    parent_id, latitude, longitude, default_zoom, enabled, featured
+                    parent_id, latitude, longitude, default_zoom, enabled, featured, updated_at
                 )
-                VALUES ${tuples.join(',')}
+                VALUES ${values.join(', ')}
                 ON CONFLICT (id) DO UPDATE SET
                     slug = EXCLUDED.slug,
                     kind = EXCLUDED.kind,
@@ -477,59 +586,72 @@ async function upsert({ places, identifiers }, dryRun, dbPool = pool) {
                     longitude = EXCLUDED.longitude,
                     default_zoom = EXCLUDED.default_zoom,
                     featured = EXCLUDED.featured,
+                    enabled = true,
                     updated_at = now()
-            `, values);
+            `, params);
         }
-        for (let index = 0; index < identifiers.length; index += 500) {
-            const chunk = identifiers.slice(index, index + 500);
+
+        for (let i = 0; i < identifiers.length; i += 200) {
+            const batch = identifiers.slice(i, i + 200);
+            const params = [];
             const values = [];
-            const tuples = chunk.map((identifier, i) => {
-                const p = i * 4 + 1;
-                values.push(identifier.placeId, identifier.scheme, identifier.vintage, identifier.value);
-                return `($${p},$${p + 1},$${p + 2},$${p + 3})`;
-            });
+            let p = 1;
+
+            for (const identifier of batch) {
+                values.push(`($${p++}, $${p++}, $${p++}, $${p++})`);
+                params.push(
+                    identifier.placeId,
+                    identifier.scheme,
+                    identifier.vintage,
+                    identifier.value
+                );
+            }
+
             await client.query(`
                 INSERT INTO place_identifiers (place_id, scheme, vintage, value)
-                VALUES ${tuples.join(',')}
-                ON CONFLICT (scheme, vintage, value) DO UPDATE SET place_id = EXCLUDED.place_id
-            `, values);
+                VALUES ${values.join(', ')}
+                ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+                    place_id = EXCLUDED.place_id
+            `, params);
         }
+
+        for (const alias of aliasesToAdd) {
+            await client.query(`
+                INSERT INTO place_aliases (slug, place_id, created_at)
+                VALUES ($1, $2, now())
+                ON CONFLICT (slug) DO UPDATE SET
+                    place_id = EXCLUDED.place_id
+            `, [alias.slug, alias.placeId]);
+        }
+
         await client.query('COMMIT');
-        return changes;
-    } catch (error) {
-        try { await client.query('ROLLBACK'); } catch {}
-        throw error;
+        console.log(JSON.stringify({
+            places: places.length,
+            identifiers: identifiers.length,
+            name_changes: nameChanges,
+            slug_changes: slugChanges,
+            aliases_to_add: aliasesToAdd.length,
+            alias_conflicts: conflicts.length
+        }));
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('Place sync failed:', err);
+        process.exit(1);
     } finally {
         client.release();
+        await pool.end();
     }
 }
 
-async function main() {
-    const [en, fr] = await Promise.all([
-        fetchPublicBuffer(EN_URL, { maxBytes: 2 * 1024 * 1024 }),
-        fetchPublicBuffer(FR_URL, { maxBytes: 2 * 1024 * 1024 })
-    ]);
-    const normalized = normalize(rowsFrom(en, 'windows-1252'), rowsFrom(fr, 'windows-1252'));
-    const changes = await upsert(normalized, process.argv.includes('--dry-run'));
-    console.log(JSON.stringify({
-        places: normalized.places.length,
-        identifiers: normalized.identifiers.length,
-        name_changes: changes.nameChanges,
-        slug_changes: changes.slugChanges,
-        aliases_to_add: changes.aliases.length,
-        alias_conflicts: changes.aliasConflicts
-    }));
-}
+module.exports = {
+    normalize,
+    planAliases,
+    rowsFrom,
+    run,
+    EN_URL,
+    FR_URL
+};
 
 if (require.main === module) {
-    main()
-        .then(() => pool.end())
-        .then(() => process.exit(0))
-        .catch(async error => {
-            console.error(error);
-            try { await pool.end(); } catch {}
-            process.exit(1);
-        });
+    run();
 }
-
-module.exports = { normalize, slugify, rowsFrom, preflightPlaceChanges, upsert, main };

--- a/server/sql/migrations/025_yellowknife_barrie_thunderbay_chatham_places.sql
+++ b/server/sql/migrations/025_yellowknife_barrie_thunderbay_chatham_places.sql
@@ -1,1 +1,126 @@
-// server/sql/migrations/025_yellowknife_barrie_thunderbay_chatham_places.sql
+-- Migration 025: Canonicalize Yellowknife (NT), Barrie, Thunder Bay,
+-- Chatham-Kent, Kawartha Lakes, Summerland, Norfolk County, and Haldimand County
+-- in the 2021 Statistics Canada hierarchy.
+
+DELETE FROM place_aliases
+WHERE slug IN (
+    'yellowknife-nt',
+    'barrie-on',
+    'thunder-bay-on',
+    'chatham-kent-on',
+    'kawartha-lakes-on',
+    'summerland-bc',
+    'norfolk-county-on',
+    'haldimand-county-on',
+    'norfolk-on',
+    'haldimand-on',
+    'thunder-bay-district-on',
+    'simcoe-county-on',
+    'okanagan-similkameen-bc',
+    'haldimand-norfolk-on',
+    'thunder-bay-on-3558004'
+);
+
+-- Provinces / Territories
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('ca-on', 'ontario', 'province', 'Ontario', 'Ontario', 'Province', 'Province', 'ca', NULL, NULL, NULL, true, false),
+    ('sgc-pr-59', 'british-columbia', 'province', 'British Columbia', 'Colombie-Britannique', 'Province', 'Province', 'ca', NULL, NULL, NULL, true, false),
+    ('sgc-pr-61', 'northwest-territories', 'territory', 'Northwest Territories', 'Territoires du Nord-Ouest', 'Territory', 'Territoire', 'ca', NULL, NULL, NULL, true, false)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+-- Census Divisions / Regions / Single-Tier Cities
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('sgc-cd-6106', 'region-6-nt', 'region', 'Region 6', 'Région 6', 'Region', 'Région', 'sgc-pr-61', NULL, NULL, NULL, true, false),
+    ('sgc-cd-3543', 'simcoe-county-on', 'region', 'Simcoe', 'Simcoe', 'County', 'Comté', 'ca-on', NULL, NULL, NULL, true, false),
+    ('sgc-cd-3558', 'thunder-bay-district-on', 'region', 'Thunder Bay', 'Thunder Bay', 'District', 'District', 'ca-on', NULL, NULL, NULL, true, false),
+    ('sgc-cd-3536', 'chatham-kent-on', 'municipality', 'Chatham-Kent', 'Chatham-Kent', 'Municipality', 'Municipalité', 'ca-on', 42.4048, -82.1910, 9, true, true),
+    ('sgc-cd-3516', 'kawartha-lakes-on', 'municipality', 'Kawartha Lakes', 'Kawartha Lakes', 'City', 'Ville', 'ca-on', 44.3564, -78.7408, 9, true, true),
+    ('sgc-cd-5907', 'okanagan-similkameen-bc', 'region', 'Okanagan-Similkameen', 'Okanagan-Similkameen', 'Regional district', 'District régional', 'sgc-pr-59', NULL, NULL, NULL, true, false),
+    ('sgc-cd-3528', 'haldimand-norfolk-on', 'region', 'Haldimand-Norfolk', 'Haldimand-Norfolk', 'Census division', 'Division de recensement', 'ca-on', NULL, NULL, NULL, true, false)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = EXCLUDED.featured,
+    updated_at = now();
+
+-- Municipalities / Census Subdivisions
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('sgc-csd-6106023', 'yellowknife-nt', 'municipality', 'Yellowknife', 'Yellowknife', 'City', 'Ville', 'sgc-cd-6106', 62.4540, -114.3718, 10, true, true),
+    ('sgc-csd-3543042', 'barrie-on', 'municipality', 'Barrie', 'Barrie', 'City', 'Ville', 'sgc-cd-3543', 44.3894, -79.6903, 10, true, true),
+    ('sgc-csd-3558004', 'thunder-bay-on', 'municipality', 'Thunder Bay', 'Thunder Bay', 'City', 'Ville', 'sgc-cd-3558', 48.3809, -89.2477, 10, true, true),
+    ('sgc-csd-5907035', 'summerland-bc', 'municipality', 'Summerland', 'Summerland', 'District municipality', 'Municipalité de district', 'sgc-cd-5907', 49.6006, -119.6778, 10, true, true),
+    ('sgc-csd-3528052', 'norfolk-county-on', 'municipality', 'Norfolk County', 'Norfolk County', 'City', 'Ville', 'sgc-cd-3528', 42.8333, -80.3833, 9, true, true),
+    ('sgc-csd-3528018', 'haldimand-county-on', 'municipality', 'Haldimand County', 'Haldimand County', 'City', 'Ville', 'sgc-cd-3528', 42.9333, -79.8667, 9, true, true)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = EXCLUDED.featured,
+    updated_at = now();
+
+-- Identifiers
+INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+VALUES
+    ('sgc-pr-61', 'sgc-pr', '2021', '61'),
+    ('sgc-cd-6106', 'sgc-cd', '2021', '6106'),
+    ('sgc-csd-6106023', 'sgc-csd', '2021', '6106023'),
+    ('sgc-cd-3543', 'sgc-cd', '2021', '3543'),
+    ('sgc-csd-3543042', 'sgc-csd', '2021', '3543042'),
+    ('sgc-cd-3558', 'sgc-cd', '2021', '3558'),
+    ('sgc-csd-3558004', 'sgc-csd', '2021', '3558004'),
+    ('sgc-cd-3536', 'sgc-cd', '2021', '3536'),
+    ('sgc-cd-3536', 'sgc-csd', '2021', '3536020'),
+    ('sgc-cd-3516', 'sgc-cd', '2021', '3516'),
+    ('sgc-cd-3516', 'sgc-csd', '2021', '3516010'),
+    ('sgc-cd-5907', 'sgc-cd', '2021', '5907'),
+    ('sgc-csd-5907035', 'sgc-csd', '2021', '5907035'),
+    ('sgc-cd-3528', 'sgc-cd', '2021', '3528'),
+    ('sgc-csd-3528052', 'sgc-csd', '2021', '3528052'),
+    ('sgc-csd-3528018', 'sgc-csd', '2021', '3528018')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;
+
+-- Durable Aliases
+INSERT INTO place_aliases (slug, place_id)
+VALUES
+    ('norfolk-on', 'sgc-csd-3528052'),
+    ('haldimand-on', 'sgc-csd-3528018'),
+    ('thunder-bay-on-3558004', 'sgc-csd-3558004'),
+    ('simcoe-on', 'sgc-cd-3543')
+ON CONFLICT (slug) DO UPDATE SET place_id = EXCLUDED.place_id;

--- a/server/sql/migrations/025_yellowknife_barrie_thunderbay_chatham_places.sql
+++ b/server/sql/migrations/025_yellowknife_barrie_thunderbay_chatham_places.sql
@@ -1,0 +1,1 @@
+// server/sql/migrations/025_yellowknife_barrie_thunderbay_chatham_places.sql


### PR DESCRIPTION
## Summary of Changes in v31

This PR delivers **v31 Territorial & Municipal Expansion**, bringing CanQuery into the Canadian territories (Northwest Territories) and adding major municipal hubs across Ontario and British Columbia:

1. **City of Yellowknife (NT)**: First Canadian territorial capital portal on CanQuery (`data-yellowknife.hub.arcgis.com`, SGC `6106023`).
2. **City of Barrie (ON)**: Simcoe County anchor on Kempenfelt Bay / Lake Simcoe (`opendata.barrie.ca`, SGC `3543042`).
3. **City of Thunder Bay (ON)**: Northern Ontario / Lake Superior anchor (`opendata-thunderbay.hub.arcgis.com`, SGC `3558004`).
4. **Municipality of Chatham-Kent (ON)**: Single-tier Southwestern Ontario anchor (`opendata.chatham-kent.ca`, SGC `3536`).
5. **City of Kawartha Lakes (ON)**: Single-tier Central Ontario Kawarthas anchor (`open-data-kawartha.hub.arcgis.com`, SGC `3516`).
6. **District of Summerland (BC)**: Okanagan Valley / Okanagan-Similkameen anchor (`open-data-summerland.hub.arcgis.com`, SGC `5907035`).
7. **Norfolk County (ON)**: Single-tier South Coast / Lake Erie anchor (`data-norfolk.opendata.arcgis.com`, SGC `3528052`).
8. **Haldimand County (ON)**: Single-tier South Coast / Grand River anchor (`opendata-haldimand.hub.arcgis.com`, SGC `3528018`).

### Technical Highlights
- **Migration 025**: `server/sql/migrations/025_yellowknife_barrie_thunderbay_chatham_places.sql` establishes 2021 Statistics Canada SGC hierarchies, bilingual municipal types, parent ancestry, single-tier consolidations (Chatham-Kent & Kawartha Lakes), and durable aliases.
- **Source Configuration**: `server/config/catalogSources.js` configures all 8 sources with exact publisher aliases, authoritative rules, and official licensing terms.
- **SGC Synchronization**: `server/scripts/sync-places.js` updated with single-tier mapping, curated viewports, and featured place IDs.
- **Test Coverage**: 454 server tests and 107 client tests passing 100%.
- **Production Status**: Deployed live to `https://canquery.com` with 357 admitted datasets, 267 live bounded maps, 59,072 total catalogue datasets, and 4,980 mappable resources across 48 source portals.