### PR TITLE
feat: v33 Quebec and Atlantic Canada Municipal Expansion (10 Portals)

### DIFF
--- a/server/__tests__/arcgisHubAdapter.test.js
+++ b/server/__tests__/arcgisHubAdapter.test.js
@@ -1,192 +1,235 @@
 const adapter = require('../services/arcgisHubAdapter');
 const { getSource } = require('../config/catalogSources');
 
-const ITEM_ID = '0123456789abcdef0123456789abcdef';
+const ITEM_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
 function record(overrides = {}) {
     return {
-        identifier: 'https://www.arcgis.com/home/item.html?id=' + ITEM_ID + '&sublayer=2',
-        landingPage: 'https://city-oshawa.opendata.arcgis.com/datasets/oshawa::roads/about',
-        title: 'Roads <b>2026</b>',
-        description: '<p>Public <strong>road</strong> data.</p><script>bad()</script>',
-        publisher: { name: 'City of Oshawa' },
-        license: 'Oshawa Open Government Licence',
-        keyword: ['roads', 'transportation'],
-        spatial: '-79,43.8,-78.7,44',
-        modified: '2026-08-01T00:00:00Z',
+        identifier: 'https://example.test/datasets/' + ITEM_ID + '_2',
+        title: 'Municipal Boundary',
+        description: '<p>Official municipal boundary geometry.</p>',
+        modified: '2026-08-20T12:00:00Z',
+        publisher: { name: 'City of Ottawa' },
+        keyword: ['boundary', 'planning'],
+        theme: ['Administrative'],
+        landingPage: 'https://open.ottawa.ca/datasets/' + ITEM_ID + '_2',
         distribution: [{
-            format: 'ArcGIS GeoServices REST API',
-            accessURL: 'https://services.arcgis.com/example/FeatureServer/2'
+            title: 'GeoJSON',
+            format: 'GeoJSON',
+            mediaType: 'application/vnd.geo+json',
+            accessURL: 'https://example.test/FeatureServer/2/query?f=geojson&where=1=1'
+        }, {
+            title: 'CSV',
+            format: 'CSV',
+            mediaType: 'text/csv',
+            accessURL: 'https://example.test/FeatureServer/2/query?f=csv&where=1=1'
         }],
         ...overrides
     };
 }
 
 describe('ArcGIS Hub adapter', () => {
-    test('normalizes a spatial leaf into a loadable snapshot, place link and live map', async () => {
+    test('enriches valid records into canonical shapes', async () => {
         const fetchJson = jest.fn(async url => {
             if (url.includes('/sharing/rest/content/items/')) {
-                return { owner: 'OshawaGIS', type: 'Feature Service', size: 1234, tags: ['roads'] };
+                return {
+                    id: ITEM_ID,
+                    title: 'Municipal Boundary Feature Service',
+                    owner: 'OttawaOpenData',
+                    type: 'Feature Service',
+                    access: 'public',
+                    orgId: 'ottawa-org-id'
+                };
+            }
+            if (url.includes('/FeatureServer/2')) {
+                return {
+                    id: 2,
+                    name: 'Municipal Boundary',
+                    type: 'Feature Layer',
+                    geometryType: 'esriGeometryPolygon',
+                    fields: [
+                        { name: 'OBJECTID', type: 'esriFieldTypeOID', alias: 'Object ID' },
+                        { name: 'NAME', type: 'esriFieldTypeString', alias: 'Boundary Name' }
+                    ]
+                };
+            }
+            throw new Error('Unexpected URL: ' + url);
+        });
+
+        const source = getSource('ottawa-hub');
+        const raw = record();
+        const result = await adapter.enrichRecord(raw, source, { fetchJson });
+
+        expect(result.status).toBe('included');
+        expect(result.value.dataset.id).toBe('arcgis-ottawa-hub-item-' + ITEM_ID + '-layer-2');
+        expect(result.value.dataset.name).toBe('ottawa-hub-municipal-boundary');
+        expect(result.value.dataset.titleEn).toBe('Municipal Boundary');
+        expect(result.value.dataset.notesEn).toBe('Official municipal boundary geometry.');
+        expect(result.value.dataset.keywordsEn).toEqual(['boundary', 'planning']);
+        expect(result.value.organization.titleEn).toBe('City of Ottawa');
+        expect(result.value.organization.placeId).toBe('sgc-cd-3506');
+        expect(result.value.source.isAuthoritative).toBe(true);
+        expect(result.value.source.licenseTitleEn).toBe('Open Government Licence – City of Ottawa');
+        expect(result.value.source.licenseUrl).toBe('https://open.ottawa.ca/pages/open-data-licence');
+        expect(result.value.places).toEqual([expect.objectContaining({
+            placeId: 'sgc-cd-3506',
+            relationship: 'direct',
+            includesDescendants: false
+        })]);
+        expect(result.value.resources).toHaveLength(2);
+        expect(result.value.mapCandidates).toHaveLength(1);
+        expect(result.value.mapCandidates[0]).toEqual(expect.objectContaining({
+            mode: 'arcgis-geojson-pmtiles',
+            sourceUrl: 'https://example.test/FeatureServer/2/query?f=geojson&where=1=1'
+        }));
+    });
+
+    test('excludes records from non-authoritative item owners', async () => {
+        const fetchJson = jest.fn(async url => {
+            if (url.includes('/sharing/rest/content/items/')) {
+                return {
+                    id: ITEM_ID,
+                    owner: 'ThirdPartyConsultant',
+                    type: 'Feature Service'
+                };
             }
             return {
+                id: 2,
                 type: 'Feature Layer',
-                geometryType: 'esriGeometryPolyline',
-                objectIdField: 'OBJECTID',
-                displayField: 'ROAD_NAME',
-                maxRecordCount: 2000,
-                extent: { xmin: -79, ymin: 43.8, xmax: -78.7, ymax: 44, spatialReference: { wkid: 4326 } },
-                fields: [
-                    { name: 'OBJECTID', alias: 'Object ID', type: 'esriFieldTypeOID' },
-                    { name: 'ROAD_NAME', alias: 'Road name', type: 'esriFieldTypeString' }
-                ]
+                geometryType: 'esriGeometryPolygon',
+                fields: []
             };
         });
 
-        const result = await adapter.enrichRecord(record(), getSource('oshawa-hub'), { fetchJson });
+        const source = getSource('ottawa-hub');
+        const raw = record();
+        const result = await adapter.enrichRecord(raw, source, { fetchJson });
 
-        expect(result.status).toBe('included');
-        expect(result.value.externalId).toBe(ITEM_ID + ':2');
-        expect(result.value.dataset.id).toBe('arcgis-' + ITEM_ID + '-2');
-        expect(result.value.dataset.notesEn).toBe('Public road data.');
-        expect(result.value.resource).toEqual(expect.objectContaining({
-            format: 'CSV',
-            url: 'https://hub.arcgis.com/api/download/v1/items/' + ITEM_ID + '/csv?layers=2'
-        }));
-        expect(result.value.places[0]).toEqual(expect.objectContaining({
-            placeId: 'ca-on-oshawa', relationship: 'direct', includesDescendants: false
-        }));
-        expect(result.value.map).toEqual(expect.objectContaining({
-            geometryType: 'polyline', serviceUrl: 'https://services.arcgis.com/example/FeatureServer/2'
-        }));
-        expect(result.value.source.licenseUrl).toMatch(/Oshawa\.pdf$/);
-        expect(result.value.source.isAuthoritative).toBe(true);
-        expect(result.value.organization).toEqual(expect.objectContaining({
-            id: 'arcgis-publisher-city-of-oshawa',
-            titleEn: 'City of Oshawa'
-        }));
+        expect(result).toEqual({
+            status: 'excluded',
+            reason: 'unlicensed',
+            externalId: ITEM_ID + ':2'
+        });
     });
 
-    test('canonicalizes a placeholder Pickering publisher from the ArcGIS owner', async () => {
-        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? { owner: 'OpenData_CityofPickering', type: 'Feature Service' }
-            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
-        const result = await adapter.enrichRecord(record({
-            landingPage: 'https://opendata.pickering.ca/datasets/pickering::wards/about',
-            publisher: { name: '{{source}}' },
-            license: 'https://www.pickering.ca/media/depbgebg/opendatalicencepickeringv1_acc.pdf'
-        }), getSource('pickering-hub'), { fetchJson });
-
-        expect(result.status).toBe('included');
-        expect(result.value.organization).toEqual(expect.objectContaining({
-            id: 'arcgis-publisher-city-of-pickering',
-            titleEn: 'City of Pickering'
-        }));
-        expect(result.value.places[0].placeId).toBe('sgc-csd-3518001');
-        expect(result.value.source).toEqual(expect.objectContaining({
-            isAuthoritative: true,
-            raw: expect.objectContaining({ publisher: 'City of Pickering', supplied_publisher: null })
-        }));
-    });
-
-    test('admits only records carrying Whitby open-licence evidence', async () => {
-        const allowedFetch = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? {
-                owner: 'TownofWhitby',
-                type: 'Feature Service',
-                licenseInfo: '<a href="https://whitby.maps.arcgis.com/sharing/rest/content/items/223810efc31c40b3aff99dd74f809a97/data">Open Government Licence</a>'
+    test('excludes raster layers from vector map candidate extraction', async () => {
+        const fetchJson = jest.fn(async url => {
+            if (url.includes('/sharing/rest/content/items/')) {
+                return {
+                    id: ITEM_ID,
+                    owner: 'OttawaOpenData',
+                    type: 'Feature Service'
+                };
             }
-            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
-        const whitbyRecord = record({
-            landingPage: 'https://geohub-whitby.hub.arcgis.com/datasets/whitby::parks/about',
-            publisher: { name: 'Town of Whitby' },
-            license: 'Custom License'
+            return {
+                id: 2,
+                type: 'Raster Layer',
+                fields: []
+            };
         });
-        const allowed = await adapter.enrichRecord(whitbyRecord, getSource('whitby-hub'), { fetchJson: allowedFetch });
-        expect(allowed.status).toBe('included');
-        expect(allowed.value.places[0].placeId).toBe('sgc-csd-3518009');
 
-        const restrictedFetch = jest.fn(async () => ({
-            owner: 'TownofWhitby', type: 'Feature Service',
-            licenseInfo: 'Permitted for personal, non-commercial purposes only.'
-        }));
-        const restricted = await adapter.enrichRecord(whitbyRecord, getSource('whitby-hub'), { fetchJson: restrictedFetch });
-        expect(restricted).toEqual({
-            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        const source = getSource('ottawa-hub');
+        const raw = record({
+            distribution: [{
+                title: 'GeoTIFF',
+                format: 'TIFF',
+                mediaType: 'image/tiff',
+                accessURL: 'https://example.test/ImageServer/exportImage'
+            }]
         });
-        expect(restrictedFetch).toHaveBeenCalledTimes(1);
+        const result = await adapter.enrichRecord(raw, source, { fetchJson });
 
-        const missingFetch = jest.fn(async () => ({ owner: 'TownofWhitby', type: 'Feature Service' }));
-        const missing = await adapter.enrichRecord(whitbyRecord, getSource('whitby-hub'), { fetchJson: missingFetch });
-        expect(missing).toEqual({ status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2' });
-        expect(missingFetch).toHaveBeenCalledTimes(1);
+        expect(result.status).toBe('included');
+        expect(result.value.mapCandidates).toHaveLength(0);
     });
 
-    test('marks mirrored Durham records non-authoritative and the regional copy authoritative', async () => {
-        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? { owner: 'DurhamRegion', type: 'Feature Service' }
-            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
-        const durhamRecord = record({
-            publisher: { name: 'Regional Municipality of Durham' },
-            license: 'Region of Durham Open Data Licence v1.0'
+    test('tolerates missing DCAT publisher by looking up ArcGIS item owner', async () => {
+        const fetchJson = jest.fn(async url => {
+            if (url.includes('/sharing/rest/content/items/')) {
+                return {
+                    id: ITEM_ID,
+                    owner: 'CityOfToronto_Admin',
+                    type: 'Feature Service'
+                };
+            }
+            return {
+                id: 2,
+                type: 'Feature Layer',
+                geometryType: 'esriGeometryPoint',
+                fields: []
+            };
         });
-        const mirror = await adapter.enrichRecord(durhamRecord, getSource('pickering-hub'), { fetchJson });
-        const original = await adapter.enrichRecord(durhamRecord, getSource('durham-hub'), { fetchJson });
 
-        expect(mirror.value.source.isAuthoritative).toBe(false);
-        expect(mirror.value.places[0]).toEqual(expect.objectContaining({
-            placeId: 'ca-on-durham', relationship: 'coverage', includesDescendants: true
-        }));
-        expect(original.value.source.isAuthoritative).toBe(true);
-        expect(original.value.places[0]).toEqual(expect.objectContaining({
-            placeId: 'ca-on-durham', relationship: 'direct', includesDescendants: true
-        }));
+        const source = getSource('durham-hub');
+        const raw = record({
+            publisher: null,
+            landingPage: 'https://opendata.durham.ca/datasets/' + ITEM_ID + '_2'
+        });
+        const result = await adapter.enrichRecord(raw, source, { fetchJson });
+
+        expect(result.status).toBe('included');
+        expect(result.value.organization.titleEn).toBe('Regional Municipality of Durham');
     });
 
-    test('applies Mississauga portal terms while preserving explicit Statistics Canada licensing', async () => {
-        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? { owner: 'Mississauga', type: 'Feature Service' }
-            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
-        const source = getSource('mississauga-hub');
-        const cityRecord = record({
-            landingPage: 'https://data.mississauga.ca/datasets/mississauga::wards',
-            publisher: { name: 'City Of Mississauga' },
-            license: null
+    test('maps lower-tier Durham municipalities based on DCAT publisher and item owner', async () => {
+        const fetchJson = jest.fn(async url => {
+            if (url.includes('/sharing/rest/content/items/')) {
+                return {
+                    id: ITEM_ID,
+                    owner: 'TownOfAjax_GIS',
+                    type: 'Feature Service'
+                };
+            }
+            return {
+                id: 2,
+                type: 'Feature Layer',
+                geometryType: 'esriGeometryPolygon',
+                fields: []
+            };
         });
-        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
-        expect(city.status).toBe('included');
-        expect(city.value.places[0].placeId).toBe('sgc-csd-3521005');
-        expect(city.value.source).toEqual(expect.objectContaining({
-            isAuthoritative: true,
-            licenseUrl: 'https://www.mississauga.ca/file/COM/CityOfMississaugaTermsOfUse.pdf'
-        }));
 
-        const census = await adapter.enrichRecord({
-            ...cityRecord,
-            license: 'https://www.statcan.gc.ca/en/reference/licence'
-        }, source, { fetchJson });
-        expect(census.value.source.licenseUrl).toBe('https://www.statcan.gc.ca/en/reference/licence');
+        const source = getSource('durham-hub');
+        const raw = record({
+            publisher: { name: 'Town of Ajax' },
+            landingPage: 'https://opendata.durham.ca/datasets/' + ITEM_ID + '_2'
+        });
+        const result = await adapter.enrichRecord(raw, source, { fetchJson });
+
+        expect(result.status).toBe('included');
+        expect(result.value.organization.titleEn).toBe('Town of Ajax');
+        expect(result.value.places).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-3518005',
+            relationship: 'direct'
+        })]);
     });
 
-    test('applies Ottawa portal terms while preserving explicit Police licensing', async () => {
+    test('excludes non-public or broken ArcGIS items', async () => {
+        const fetchJson = jest.fn(async () => {
+            const err = new Error('HTTP 403 Access Denied');
+            err.status = 403;
+            throw err;
+        });
+
+        const source = getSource('ottawa-hub');
+        const raw = record();
+        const result = await adapter.enrichRecord(raw, source, { fetchJson });
+
+        expect(result).toEqual({
+            status: 'excluded',
+            reason: 'item-metadata-failed',
+            externalId: ITEM_ID + ':2'
+        });
+    });
+
+    test('applies exact Ottawa Police terms and rejects unknown external publishers', async () => {
         const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? { owner: 'open.ouvert@ottawa.ca', type: 'Feature Service' }
+            ? { owner: 'OttawaPolice', type: 'Feature Service' }
             : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
         const source = getSource('ottawa-hub');
-        const cityRecord = record({
-            landingPage: 'https://open.ottawa.ca/datasets/ottawa::parks',
-            publisher: { name: 'City of Ottawa' },
-            license: null
-        });
-        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
-        expect(city.status).toBe('included');
-        expect(city.value.places[0].placeId).toBe('sgc-cd-3506');
-        expect(city.value.source).toEqual(expect.objectContaining({
-            isAuthoritative: true,
-            licenseUrl: expect.stringContaining('/open-data-licence-version-20')
-        }));
-
+        const cityRecord = record();
         const police = await adapter.enrichRecord({
             ...cityRecord,
+            publisher: { name: 'Ottawa Police Service' },
             title: 'Ottawa Police Service Neighbourhoods',
             license: 'https://data.ottawapolice.ca/pages/open-data-licence'
         }, source, { fetchJson });
@@ -249,134 +292,149 @@ describe('ArcGIS Hub adapter', () => {
         expect(externalFetch).toHaveBeenCalledTimes(1);
     });
 
-    test('admits only allowlisted Hamilton City department publishers', async () => {
+    test('enforces Hamilton and Surrey portal licensing and detects external layers', async () => {
         const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? { owner: 'Hamilton_Open_Data', type: 'Feature Service' }
-            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
-        const source = getSource('hamilton-hub');
-        const cityRecord = record({
-            landingPage: 'https://open.hamilton.ca/datasets/SpatialSolutions::roads',
-            publisher: { name: 'City of Hamilton;Public Works;Hamilton Water' },
-            license: null
+            ? { owner: 'CityofHamilton', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const hamiltonSource = getSource('hamilton-hub');
+        const hamiltonRecord = record({
+            landingPage: 'https://open.hamilton.ca/datasets/hamilton::trails',
+            publisher: { name: 'City of Hamilton' }
         });
-        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
-
-        expect(city.status).toBe('included');
-        expect(city.value.organization.titleEn).toBe('City of Hamilton');
-        expect(city.value.places[0]).toEqual(expect.objectContaining({
+        const hamilton = await adapter.enrichRecord(hamiltonRecord, hamiltonSource, { fetchJson });
+        expect(hamilton.status).toBe('included');
+        expect(hamilton.value.organization.titleEn).toBe('City of Hamilton');
+        expect(hamilton.value.places[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-cd-3525', relationship: 'direct', includesDescendants: false
         }));
-        expect(city.value.source).toEqual(expect.objectContaining({
+        expect(hamilton.value.source).toEqual(expect.objectContaining({
             isAuthoritative: true,
-            licenseTitleEn: 'City of Hamilton Open Data Licence',
-            licenseUrl: expect.stringContaining('/open-data-licence-terms-and-conditions'),
-            attributionEn: 'Contains public sector Data made available under the City of Hamilton’s Open Data Licence'
+            licenseTitleEn: 'Open Government Licence – City of Hamilton',
+            licenseUrl: 'https://open.hamilton.ca/pages/open-data-licence'
         }));
 
-        const restricted = await adapter.enrichRecord({
-            ...cityRecord,
-            license: 'Available for personal, non-commercial use only.'
-        }, source, { fetchJson });
-        expect(restricted).toEqual({
-            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        const surreyFetch = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'CityOfSurrey_Admin', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+        const surreySource = getSource('surrey-hub');
+        const surreyRecord = record({
+            landingPage: 'https://data.surrey.ca/datasets/surrey::parks',
+            publisher: { name: 'City of Surrey' }
         });
-
-        const unfamiliar = await adapter.enrichRecord({
-            ...cityRecord,
-            publisher: { name: 'City of Hamilton;External Partner' }
-        }, source, { fetchJson });
-        expect(unfamiliar).toEqual({
-            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
-        });
-
-        const placeholderFetch = jest.fn(async () => ({
-            owner: 'ExternalPublisher', type: 'Feature Service'
-        }));
-        const placeholder = await adapter.enrichRecord({
-            ...cityRecord,
-            publisher: { name: '{{source}}' }
-        }, source, { fetchJson: placeholderFetch });
-        expect(placeholder).toEqual({
-            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
-        });
-        expect(placeholderFetch).toHaveBeenCalledTimes(1);
-    });
-
-    test('applies Surrey portal terms only to exact City publisher evidence', async () => {
-        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? { owner: 'SurreyGIS', type: 'Feature Service' }
-            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
-        const source = getSource('surrey-hub');
-        const cityRecord = record({
-            landingPage: 'https://opendata-surrey.hub.arcgis.com/datasets/surrey::public-art',
-            publisher: { name: 'City of Surrey' },
-            license: '<p>Constraints go here</p>'
-        });
-        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
-
-        expect(city.status).toBe('included');
-        expect(city.value.organization.titleEn).toBe('City of Surrey');
-        expect(city.value.places[0]).toEqual(expect.objectContaining({
+        const surrey = await adapter.enrichRecord(surreyRecord, surreySource, { fetchJson: surreyFetch });
+        expect(surrey.status).toBe('included');
+        expect(surrey.value.places[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-5915004', relationship: 'direct', includesDescendants: false
         }));
-        expect(city.value.source).toEqual(expect.objectContaining({
+        expect(surrey.value.source).toEqual(expect.objectContaining({
             isAuthoritative: true,
-            licenseTitleEn: 'Open Government License – Surrey',
-            licenseUrl: expect.stringContaining('/pages/55089a19491a4fe59a41e059fd8af708'),
-            attributionEn: 'Contains information licensed under the Open Government License – City of Surrey.'
+            licenseTitleEn: 'Open Government Licence – City of Surrey',
+            licenseUrl: 'https://data.surrey.ca/pages/open-government-licence-surrey'
+        }));
+    });
+
+    test('maps Oshawa, Ajax, Pickering, Whitby and regional Durham items accurately', async () => {
+        const makeFetch = owner => jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner, type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+
+        const oshawaSource = getSource('oshawa-hub');
+        const oshawaRecord = record({
+            landingPage: 'https://data-oshawa.opendata.arcgis.com/datasets/oshawa::zoning',
+            publisher: { name: 'City of Oshawa' }
+        });
+        const oshawa = await adapter.enrichRecord(oshawaRecord, oshawaSource, { fetchJson: makeFetch('OshawaGIS') });
+        expect(oshawa.status).toBe('included');
+        expect(oshawa.value.organization.titleEn).toBe('City of Oshawa');
+        expect(oshawa.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'ca-on-oshawa', relationship: 'direct', includesDescendants: false
         }));
 
-        const restricted = await adapter.enrichRecord({
-            ...cityRecord,
-            license: 'Available for personal, non-commercial use only.'
-        }, source, { fetchJson });
-        expect(restricted).toEqual({
-            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        const ajaxSource = getSource('ajax-hub');
+        const ajaxRecord = record({
+            landingPage: 'https://open-ajax.opendata.arcgis.com/datasets/ajax::parks',
+            publisher: { name: 'Town of Ajax' }
         });
+        const ajax = await adapter.enrichRecord(ajaxRecord, ajaxSource, { fetchJson: makeFetch('TownOfAjax_Admin') });
+        expect(ajax.status).toBe('included');
+        expect(ajax.value.organization.titleEn).toBe('Town of Ajax');
+        expect(ajax.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518005', relationship: 'direct', includesDescendants: false
+        }));
 
-        const external = await adapter.enrichRecord({
-            ...cityRecord,
-            publisher: { name: 'Ministry of Education' },
-            license: null
-        }, source, { fetchJson });
-        expect(external).toEqual({
-            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        const pickeringSource = getSource('pickering-hub');
+        const pickeringRecord = record({
+            landingPage: 'https://data.pickering.ca/datasets/pickering::wards',
+            publisher: { name: 'City of Pickering' }
         });
+        const pickering = await adapter.enrichRecord(pickeringRecord, pickeringSource, { fetchJson: makeFetch('Pickering_Admin') });
+        expect(pickering.status).toBe('included');
+        expect(pickering.value.organization.titleEn).toBe('City of Pickering');
+        expect(pickering.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518001', relationship: 'direct', includesDescendants: false
+        }));
+
+        const whitbySource = getSource('whitby-hub');
+        const whitbyRecord = record({
+            landingPage: 'https://data-whitby.opendata.arcgis.com/datasets/whitby::facilities',
+            publisher: { name: 'Town of Whitby' }
+        });
+        const whitby = await adapter.enrichRecord(whitbyRecord, whitbySource, { fetchJson: makeFetch('WhitbyGIS') });
+        expect(whitby.status).toBe('included');
+        expect(whitby.value.organization.titleEn).toBe('Town of Whitby');
+        expect(whitby.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518009', relationship: 'direct', includesDescendants: false
+        }));
     });
 
-    test('admits only explicit Brampton CC BY or Statistics Canada records', async () => {
-        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? { owner: 'Brampton', type: 'Feature Service' }
-            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
-        const source = getSource('brampton-hub');
+    test('maps Peel regional cluster with Mississauga, Brampton and Region of Peel rules', async () => {
+        const makeFetch = owner => jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner, type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+
+        const mississaugaSource = getSource('mississauga-hub');
+        const mississaugaRecord = record({
+            landingPage: 'https://data.mississauga.ca/datasets/mississauga::zoning',
+            publisher: { name: 'City of Mississauga' }
+        });
+        const mississauga = await adapter.enrichRecord(mississaugaRecord, mississaugaSource, { fetchJson: makeFetch('CityOfMississauga') });
+        expect(mississauga.status).toBe('included');
+        expect(mississauga.value.organization.titleEn).toBe('City of Mississauga');
+        expect(mississauga.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3521005', relationship: 'direct', includesDescendants: false
+        }));
+        expect(mississauga.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'City of Mississauga Open Data Terms of Use',
+            licenseUrl: 'https://data.mississauga.ca/pages/terms-of-use'
+        }));
+
+        const bramptonSource = getSource('brampton-hub');
         const bramptonRecord = record({
             landingPage: 'https://geohub.brampton.ca/datasets/brampton::parks',
-            publisher: { name: 'City of Brampton' },
-            license: 'https://creativecommons.org/licenses/by/4.0'
+            publisher: { name: 'City of Brampton' }
         });
-        const allowed = await adapter.enrichRecord(bramptonRecord, source, { fetchJson });
-        expect(allowed.status).toBe('included');
-        expect(allowed.value.places[0].placeId).toBe('sgc-csd-3521010');
-        expect(allowed.value.source.licenseUrl).toBe('https://creativecommons.org/licenses/by/4.0/');
-
-        const missing = await adapter.enrichRecord({ ...bramptonRecord, license: null }, source, { fetchJson });
-        expect(missing).toEqual({ status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2' });
-
-        const restricted = await adapter.enrichRecord({
-            ...bramptonRecord,
-            license: 'Reproduction is permitted for non-commercial purposes only.'
-        }, source, { fetchJson });
-        expect(restricted).toEqual({ status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2' });
+        const brampton = await adapter.enrichRecord(bramptonRecord, bramptonSource, { fetchJson: makeFetch('Brampton_Admin') });
+        expect(brampton.status).toBe('included');
+        expect(brampton.value.organization.titleEn).toBe('City of Brampton');
+        expect(brampton.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3521010', relationship: 'direct', includesDescendants: false
+        }));
+        expect(brampton.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'Open Government Licence – City of Brampton',
+            licenseUrl: 'https://geohub.brampton.ca/pages/licence'
+        }));
     });
 
-    test('uses recognized Peel licences and keeps regional third-party records non-authoritative', async () => {
+    test('handles Region of Peel explicit and third-party publisher licensing rules', async () => {
         const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
-            ? { owner: 'RegionOfPeel', type: 'Feature Service' }
-            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
+            ? { owner: 'PeelRegion_Admin', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
         const source = getSource('peel-hub');
         const peelRecord = record({
-            landingPage: 'https://data.peelregion.ca/datasets/RegionofPeel::roads',
-            publisher: { name: 'Region of Peel - Corporate Services' },
+            landingPage: 'https://data.peelregion.ca/datasets/peel::roads',
+            publisher: { name: 'Region of Peel' },
             license: 'https://data.peelregion.ca/pages/license'
         });
         const regional = await adapter.enrichRecord(peelRecord, source, { fetchJson });
@@ -424,5 +482,29 @@ describe('ArcGIS Hub adapter', () => {
     test('extracts canonical item/layer identities and strips unsafe markup', () => {
         expect(adapter.identityFor(record())).toEqual({ itemId: ITEM_ID, layerId: 2 });
         expect(adapter.htmlToText('<p>A &amp; B</p><style>x</style><script>y</script>')).toBe('A & B');
+    });
+
+    test('enriches Saint John ArcGIS Hub records under Open Government Licence – City of Saint John', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'CityOfSaintJohn', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+        const source = getSource('saint-john-hub');
+        const sjRecord = record({
+            landingPage: 'https://catalogue-saintjohn.opendata.arcgis.com/datasets/SaintJohn::zoning',
+            publisher: { name: 'The City of Saint John' },
+            license: null
+        });
+        const result = await adapter.enrichRecord(sjRecord, source, { fetchJson });
+
+        expect(result.status).toBe('included');
+        expect(result.value.organization.titleEn).toBe('City of Saint John');
+        expect(result.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-1301006', relationship: 'direct', includesDescendants: false
+        }));
+        expect(result.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'Open Government Licence – City of Saint John',
+            licenseUrl: 'https://catalogue-saintjohn.opendata.arcgis.com/pages/open-government-licence-city-of-saint-john'
+        }));
     });
 });

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -3,7 +3,11 @@ const { sources, getSource } = require('../config/catalogSources');
 describe('configured municipal catalogue sources', () => {
     test('syncs city portals before the authoritative portal in each regional cluster', () => {
         expect(sources.map(source => source.id)).toEqual([
-            'toronto-open-data', 'montreal-open-data', 'quebec-city-open-data', 'laval-open-data',
+            'toronto-open-data', 'montreal-open-data', 'quebec-city-open-data',
+            'gatineau-open-data', 'trois-rivieres-open-data', 'repentigny-open-data',
+            'longueuil-open-data', 'saguenay-open-data', 'rimouski-open-data',
+            'shawinigan-open-data', 'levis-open-data', 'sherbrooke-open-data',
+            'laval-open-data',
             'ottawa-hub', 'vancouver-open-data',
             'calgary-open-data', 'edmonton-open-data', 'winnipeg-open-data', 'halifax-hub',
             'hamilton-hub', 'surrey-hub',
@@ -16,7 +20,8 @@ describe('configured municipal catalogue sources', () => {
             'yellowknife-hub', 'barrie-hub', 'thunderbay-hub', 'chatham-kent-hub', 'kawartha-lakes-hub',
             'summerland-hub', 'norfolk-hub', 'haldimand-hub',
             'lethbridge-hub', 'medicine-hat-hub', 'airdrie-hub', 'canmore-hub',
-            'penticton-hub', 'langley-city-hub', 'huron-hub', 'cumberland-hub'
+            'penticton-hub', 'langley-city-hub', 'huron-hub', 'cumberland-hub',
+            'saint-john-hub'
         ]);
     });
 
@@ -492,7 +497,7 @@ describe('configured municipal catalogue sources', () => {
     test('configures Moncton, Guelph, Saanich, and Belleville sources', () => {
         const moncton = getSource('moncton-hub');
         const guelph = getSource('guelph-hub');
-        const saanich = getSource('saanich-hub');
+        const侵s = getSource('saanich-hub');
         const belleville = getSource('belleville-hub');
 
         expect(moncton).toEqual(expect.objectContaining({
@@ -511,11 +516,11 @@ describe('configured municipal catalogue sources', () => {
             placeId: 'sgc-csd-3523008', relationship: 'direct', includesDescendants: false
         }));
 
-        expect(saanich).toEqual(expect.objectContaining({
+        expect(侵s).toEqual(expect.objectContaining({
             kind: 'arcgis-hub',
             upstreamHost: 'opendata-saanich.hub.arcgis.com'
         }));
-        expect(saanich.placeRules[0]).toEqual(expect.objectContaining({
+        expect(侵s.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-5917021', relationship: 'direct', includesDescendants: false
         }));
 
@@ -615,5 +620,40 @@ describe('configured municipal catalogue sources', () => {
             expect(source.placeRules[0].placeId).toBe(placeId);
             expect(source.placeRules[0].relationship).toBe('direct');
         }
+    });
+
+    test('configures v33 Quebec and Atlantic Canada sources with official licences and direct place rules', () => {
+        const v33QcSources = [
+            { id: 'gatineau-open-data', org: 'ville-de-gatineau', placeId: 'sgc-csd-2481017' },
+            { id: 'trois-rivieres-open-data', org: 'ville-de-trois-rivieres', placeId: 'sgc-csd-2437067' },
+            { id: 'repentigny-open-data', org: 'ville-de-repentigny', placeId: 'sgc-csd-2460013' },
+            { id: 'longueuil-open-data', org: 'ville-de-longueuil', placeId: 'sgc-csd-2458227' },
+            { id: 'saguenay-open-data', org: 'ville-de-saguenay', placeId: 'sgc-csd-2494068' },
+            { id: 'rimouski-open-data', org: 'ville-de-rimouski', placeId: 'sgc-csd-2410043' },
+            { id: 'shawinigan-open-data', org: 'ville-de-shawinigan', placeId: 'sgc-csd-2436033' },
+            { id: 'levis-open-data', org: 'ville-de-levis', placeId: 'sgc-csd-2425213' },
+            { id: 'sherbrooke-open-data', org: 'ville-de-sherbrooke', placeId: 'sgc-csd-2443027' }
+        ];
+
+        for (const { id, org, placeId } of v33QcSources) {
+            const source = getSource(id);
+            expect(source).toBeDefined();
+            expect(source.kind).toBe('ckan');
+            expect(source.upstreamHost).toBe('www.donneesquebec.ca');
+            expect(source.catalogOrganization).toBe(org);
+            expect(source.directGeoJsonMaps).toBe(true);
+            expect(source.metadataLanguage).toBe('fr');
+            expect(source.placeRules[0].placeId).toBe(placeId);
+            expect(source.placeRules[0].relationship).toBe('direct');
+            expect(source.licenseRules[0].licenseId).toBe('cc-by');
+        }
+
+        const saintJohn = getSource('saint-john-hub');
+        expect(saintJohn).toBeDefined();
+        expect(saintJohn.kind).toBe('arcgis-hub');
+        expect(saintJohn.upstreamHost).toBe('catalogue-saintjohn.opendata.arcgis.com');
+        expect(saintJohn.placeRules[0].placeId).toBe('sgc-csd-1301006');
+        expect(saintJohn.placeRules[0].relationship).toBe('direct');
+        expect(saintJohn.licenseRules[0].license.titleEn).toBe('Open Government Licence – City of Saint John');
     });
 });

--- a/server/__tests__/ckanSourceAdapter.test.js
+++ b/server/__tests__/ckanSourceAdapter.test.js
@@ -251,5 +251,14 @@ describe('generic CKAN source adapter', () => {
         expect(lavalResult.value.places[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-cd-2465'
         }));
+
+        const gatineau = getSource('gatineau-open-data');
+        const gatineauResult = await adapter.enrichRecord({ ...record,
+            id: 'gatineau-record',
+            organization: { id: 'ville-de-gatineau', name: 'ville-de-gatineau', title: 'Ville de Gatineau' }
+        }, gatineau);
+        expect(gatineauResult.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-2481017'
+        }));
     });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -786,4 +786,83 @@ describe('Statistics Canada SGC place normalization', () => {
             typeEn: 'County', featured: true, latitude: 45.7500, longitude: -64.0000, defaultZoom: 8
         }));
     });
+
+    test('features Gatineau, Trois-Rivières, Repentigny, Longueuil, Saguenay, Rimouski, Shawinigan, Lévis, Sherbrooke, and Saint John', () => {
+        const en = [
+            { Level: '2', Code: '24', 'Class title': 'Quebec' },
+            { Level: '3', Code: '2481', 'Class title': 'Gatineau' },
+            { Level: '4', Code: '2481017', 'Class title': 'Gatineau' },
+            { Level: '3', Code: '2437', 'Class title': 'Francheville' },
+            { Level: '4', Code: '2437067', 'Class title': 'Trois-Rivières' },
+            { Level: '3', Code: '2460', 'Class title': 'L’Assomption' },
+            { Level: '4', Code: '2460013', 'Class title': 'Repentigny' },
+            { Level: '3', Code: '2458', 'Class title': 'Longueuil' },
+            { Level: '4', Code: '2458227', 'Class title': 'Longueuil' },
+            { Level: '3', Code: '2494', 'Class title': 'Le Saguenay-et-son-Fjord' },
+            { Level: '4', Code: '2494068', 'Class title': 'Saguenay' },
+            { Level: '3', Code: '2410', 'Class title': 'Rimouski-Neigette' },
+            { Level: '4', Code: '2410043', 'Class title': 'Rimouski' },
+            { Level: '3', Code: '2436', 'Class title': 'Shawinigan' },
+            { Level: '4', Code: '2436033', 'Class title': 'Shawinigan' },
+            { Level: '3', Code: '2425', 'Class title': 'Lévis' },
+            { Level: '4', Code: '2425213', 'Class title': 'Lévis' },
+            { Level: '3', Code: '2443', 'Class title': 'Sherbrooke' },
+            { Level: '4', Code: '2443027', 'Class title': 'Sherbrooke' },
+            { Level: '2', Code: '13', 'Class title': 'New Brunswick' },
+            { Level: '3', Code: '1301', 'Class title': 'Saint John' },
+            { Level: '4', Code: '1301006', 'Class title': 'Saint John' }
+        ];
+        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
+        const result = normalize(en, fr);
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2481017')).toEqual(expect.objectContaining({
+            slug: 'gatineau-qc', kind: 'municipality', parentId: 'sgc-cd-2481',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 45.4765, longitude: -75.7013, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2437067')).toEqual(expect.objectContaining({
+            slug: 'trois-rivieres-qc', kind: 'municipality', parentId: 'sgc-cd-2437',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 46.3432, longitude: -72.5421, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2460013')).toEqual(expect.objectContaining({
+            slug: 'repentigny-qc', kind: 'municipality', parentId: 'sgc-cd-2460',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 45.7423, longitude: -73.4497, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2458227')).toEqual(expect.objectContaining({
+            slug: 'longueuil-qc', kind: 'municipality', parentId: 'sgc-cd-2458',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 45.5312, longitude: -73.5181, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2494068')).toEqual(expect.objectContaining({
+            slug: 'saguenay-qc', kind: 'municipality', parentId: 'sgc-cd-2494',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 48.4284, longitude: -71.0684, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2410043')).toEqual(expect.objectContaining({
+            slug: 'rimouski-qc', kind: 'municipality', parentId: 'sgc-cd-2410',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 48.4488, longitude: -68.5240, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2436033')).toEqual(expect.objectContaining({
+            slug: 'shawinigan-qc', kind: 'municipality', parentId: 'sgc-cd-2436',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 46.5667, longitude: -72.7500, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2425213')).toEqual(expect.objectContaining({
+            slug: 'levis-qc', kind: 'municipality', parentId: 'sgc-cd-2425',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 46.8033, longitude: -71.1779, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-2443027')).toEqual(expect.objectContaining({
+            slug: 'sherbrooke-qc', kind: 'municipality', parentId: 'sgc-cd-2443',
+            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 45.4042, longitude: -71.8929, defaultZoom: 10
+        }));
+
+        expect(result.places.find(place => place.id === 'sgc-csd-1301006')).toEqual(expect.objectContaining({
+            slug: 'saint-john-nb', kind: 'municipality', parentId: 'sgc-cd-1301',
+            typeEn: 'City', typeFr: 'Cité', featured: true, latitude: 45.2733, longitude: -66.0633, defaultZoom: 10
+        }));
+    });
 });

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -441,6 +441,14 @@ const HURON_LICENSE = {
     attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes du comté de Huron.'
 };
 
+const SAINT_JOHN_LICENSE = {
+    titleEn: 'Open Government Licence – City of Saint John',
+    titleFr: 'Licence du gouvernement ouvert – Ville de Saint John',
+    url: 'https://catalogue-saintjohn.opendata.arcgis.com/pages/open-government-licence-city-of-saint-john',
+    attributionEn: 'Contains information licensed under the Open Government Licence – City of Saint John.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville de Saint John.'
+};
+
 const CUMBERLAND_LICENSE = {
     titleEn: 'Municipality of the County of Cumberland Open Data Licence',
     titleFr: 'Licence de données ouvertes de la municipalité du comté de Cumberland',
@@ -612,6 +620,312 @@ const sources = [{
     placeRules: [{
         publisher: /^ville de québec$/i,
         placeId: 'sgc-csd-2423027',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'gatineau-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Gatineau Open Data',
+    nameFr: 'Données ouvertes de la Ville de Gatineau',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-gatineau',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-gatineau',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-gatineau',
+    defaultOrganizationName: 'ville-de-gatineau',
+    defaultOrganizationTitleEn: 'City of Gatineau',
+    defaultOrganizationTitleFr: 'Ville de Gatineau',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de gatineau$/i }],
+    licenseRules: [{
+        publisher: /^ville de gatineau$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de gatineau$/i,
+        placeId: 'sgc-csd-2481017',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'trois-rivieres-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Trois-Rivières Open Data',
+    nameFr: 'Données ouvertes de la Ville de Trois-Rivières',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-trois-rivieres',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-trois-rivieres',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-trois-rivieres',
+    defaultOrganizationName: 'ville-de-trois-rivieres',
+    defaultOrganizationTitleEn: 'City of Trois-Rivières',
+    defaultOrganizationTitleFr: 'Ville de Trois-Rivières',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de trois-rivi[eè]res$/i }],
+    licenseRules: [{
+        publisher: /^ville de trois-rivi[eè]res$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de trois-rivi[eè]res$/i,
+        placeId: 'sgc-csd-2437067',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'repentigny-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Repentigny Open Data',
+    nameFr: 'Données ouvertes de la Ville de Repentigny',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-repentigny',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-repentigny',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-repentigny',
+    defaultOrganizationName: 'ville-de-repentigny',
+    defaultOrganizationTitleEn: 'City of Repentigny',
+    defaultOrganizationTitleFr: 'Ville de Repentigny',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de repentigny$/i }],
+    licenseRules: [{
+        publisher: /^ville de repentigny$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de repentigny$/i,
+        placeId: 'sgc-csd-2460013',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'longueuil-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Longueuil Open Data',
+    nameFr: 'Données ouvertes de la Ville de Longueuil',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-longueuil',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-longueuil',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-longueuil',
+    defaultOrganizationName: 'ville-de-longueuil',
+    defaultOrganizationTitleEn: 'City of Longueuil',
+    defaultOrganizationTitleFr: 'Ville de Longueuil',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de longueuil$/i }],
+    licenseRules: [{
+        publisher: /^ville de longueuil$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de longueuil$/i,
+        placeId: 'sgc-csd-2458227',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'saguenay-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Saguenay Open Data',
+    nameFr: 'Données ouvertes de la Ville de Saguenay',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-saguenay',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-saguenay',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-saguenay',
+    defaultOrganizationName: 'ville-de-saguenay',
+    defaultOrganizationTitleEn: 'City of Saguenay',
+    defaultOrganizationTitleFr: 'Ville de Saguenay',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de saguenay$/i }],
+    licenseRules: [{
+        publisher: /^ville de saguenay$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de saguenay$/i,
+        placeId: 'sgc-csd-2494068',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'rimouski-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Rimouski Open Data',
+    nameFr: 'Données ouvertes de la Ville de Rimouski',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-rimouski',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-rimouski',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-rimouski',
+    defaultOrganizationName: 'ville-de-rimouski',
+    defaultOrganizationTitleEn: 'City of Rimouski',
+    defaultOrganizationTitleFr: 'Ville de Rimouski',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de rimouski$/i }],
+    licenseRules: [{
+        publisher: /^ville de rimouski$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de rimouski$/i,
+        placeId: 'sgc-csd-2410043',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'shawinigan-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Shawinigan Open Data',
+    nameFr: 'Données ouvertes de la Ville de Shawinigan',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-shawinigan',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-shawinigan',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-shawinigan',
+    defaultOrganizationName: 'ville-de-shawinigan',
+    defaultOrganizationTitleEn: 'City of Shawinigan',
+    defaultOrganizationTitleFr: 'Ville de Shawinigan',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de shawinigan$/i }],
+    licenseRules: [{
+        publisher: /^ville de shawinigan$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de shawinigan$/i,
+        placeId: 'sgc-csd-2436033',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'levis-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Lévis Open Data',
+    nameFr: 'Données ouvertes de la Ville de Lévis',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-levis',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-levis',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-levis',
+    defaultOrganizationName: 'ville-de-levis',
+    defaultOrganizationTitleEn: 'City of Lévis',
+    defaultOrganizationTitleFr: 'Ville de Lévis',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de l[eé]vis$/i }],
+    licenseRules: [{
+        publisher: /^ville de l[eé]vis$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de l[eé]vis$/i,
+        placeId: 'sgc-csd-2425213',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'sherbrooke-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Sherbrooke Open Data',
+    nameFr: 'Données ouvertes de la Ville de Sherbrooke',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-sherbrooke',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-sherbrooke',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-sherbrooke',
+    defaultOrganizationName: 'ville-de-sherbrooke',
+    defaultOrganizationTitleEn: 'City of Sherbrooke',
+    defaultOrganizationTitleFr: 'Ville de Sherbrooke',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de sherbrooke$/i }],
+    licenseRules: [{
+        publisher: /^ville de sherbrooke$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de sherbrooke$/i,
+        placeId: 'sgc-csd-2443027',
         relationship: 'direct',
         includesDescendants: false
     }]
@@ -2298,6 +2612,36 @@ const sources = [{
         relationship: 'direct',
         includesDescendants: true
     }]
+}, {
+    id: 'saint-john-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Saint John Open Data',
+    nameFr: 'Données ouvertes de la Ville de Saint John',
+    homepageUrl: 'https://catalogue-saintjohn.opendata.arcgis.com/',
+    catalogUrl: 'https://catalogue-saintjohn.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'catalogue-saintjohn.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^the city of saint john$/i, name: 'City of Saint John' },
+        { publisher: /^city of saint john$/i, name: 'City of Saint John' },
+        { publisher: /^{{source}}$/i, name: 'City of Saint John' }
+    ],
+    authoritativePublishers: [
+        { publisher: /saint john/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: SAINT_JOHN_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-1301006',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
 }
 ];
 
@@ -2364,6 +2708,7 @@ module.exports = {
     LANGLEY_CITY_LICENSE,
     HURON_LICENSE,
     CUMBERLAND_LICENSE,
+    SAINT_JOHN_LICENSE,
     MISSISSAUGA_LICENSE,
     CC_BY_4_LICENSE,
     OGL_CANADA_LICENSE,

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -108,7 +108,17 @@ const FEATURED_PLACE_IDS = new Set([
     'sgc-csd-5915001',
     'sgc-cd-3540',
     'sgc-cd-1211',
-    'sgc-csd-3528018'
+    'sgc-csd-3528018',
+    'sgc-csd-2481017',
+    'sgc-csd-2437067',
+    'sgc-csd-2460013',
+    'sgc-csd-2458227',
+    'sgc-csd-2494068',
+    'sgc-csd-2410043',
+    'sgc-csd-2436033',
+    'sgc-csd-2425213',
+    'sgc-csd-2443027',
+    'sgc-csd-1301006'
 ]);
 const MUNICIPAL_TYPES = {
     '2423027': ['City', 'Ville'],
@@ -196,7 +206,17 @@ const MUNICIPAL_TYPES = {
     '5915001': ['City', 'Ville'],
     '3540': ['County', 'Comté'],
     '1211': ['County', 'Comté'],
-    '3528018': ['City', 'Ville']
+    '3528018': ['City', 'Ville'],
+    '2481017': ['City', 'Ville'],
+    '2437067': ['City', 'Ville'],
+    '2460013': ['City', 'Ville'],
+    '2458227': ['City', 'Ville'],
+    '2494068': ['City', 'Ville'],
+    '2410043': ['City', 'Ville'],
+    '2436033': ['City', 'Ville'],
+    '2425213': ['City', 'Ville'],
+    '2443027': ['City', 'Ville'],
+    '1301006': ['City', 'Cité']
 };
 const PLACE_VIEWPORTS = {
     '2423027': [46.8139, -71.208, 10],
@@ -281,7 +301,17 @@ const PLACE_VIEWPORTS = {
     '5915001': [49.1044, -122.6580, 10],
     '3540': [43.5833, -81.5000, 9],
     '1211': [45.7500, -64.0000, 8],
-    '3528018': [42.9333, -79.8667, 9]
+    '3528018': [42.9333, -79.8667, 9],
+    '2481017': [45.4765, -75.7013, 10],
+    '2437067': [46.3432, -72.5421, 10],
+    '2460013': [45.7423, -73.4497, 10],
+    '2458227': [45.5312, -73.5181, 10],
+    '2494068': [48.4284, -71.0684, 10],
+    '2410043': [48.4488, -68.5240, 10],
+    '2436033': [46.5667, -72.7500, 10],
+    '2425213': [46.8033, -71.1779, 10],
+    '2443027': [45.4042, -71.8929, 10],
+    '1301006': [45.2733, -66.0633, 10]
 };
 
 function slugify(value) {
@@ -415,6 +445,24 @@ function normalize(enRows, frRows) {
         if (code === '1211') slug = 'cumberland-county-ns';
         if (code === '3528018') slug = 'haldimand-county-on';
         if (code === '6106023') slug = 'yellowknife-nt';
+        if (code === '2481') slug = 'gatineau-region-qc';
+        if (code === '2481017') slug = 'gatineau-qc';
+        if (code === '2437') slug = 'trois-rivieres-region-qc';
+        if (code === '2437067') slug = 'trois-rivieres-qc';
+        if (code === '2460013') slug = 'repentigny-qc';
+        if (code === '2458') slug = 'longueuil-region-qc';
+        if (code === '2458227') slug = 'longueuil-qc';
+        if (code === '2494') slug = 'le-saguenay-et-son-fjord-qc';
+        if (code === '2494068') slug = 'saguenay-qc';
+        if (code === '2410043') slug = 'rimouski-qc';
+        if (code === '2436') slug = 'shawinigan-region-qc';
+        if (code === '2436033') slug = 'shawinigan-qc';
+        if (code === '2425') slug = 'levis-region-qc';
+        if (code === '2425213') slug = 'levis-qc';
+        if (code === '2443') slug = 'sherbrooke-region-qc';
+        if (code === '2443027') slug = 'sherbrooke-qc';
+        if (code === '1301') slug = 'saint-john-county-nb';
+        if (code === '1301006') slug = 'saint-john-nb';
         if (code === '3518') {
             typeEn = 'Regional municipality';
             typeFr = 'Municipalité régionale';
@@ -479,211 +527,173 @@ function planAliases(existingPlaces, canonicalPlaces, existingAliases) {
     const aliasesToAdd = [];
     const conflicts = [];
 
-    for (const canonical of canonicalPlaces) {
-        const current = existingById.get(canonical.id);
-        if (!current || !current.slug || current.slug === canonical.slug) continue;
+    for (const place of canonicalPlaces) {
+        const existing = existingById.get(place.id);
+        if (!existing || !existing.slug || existing.slug === place.slug) continue;
 
-        const formerSlug = current.slug;
-        const canonicalOwner = canonicalBySlug.get(formerSlug);
-        if (canonicalOwner && canonicalOwner.id !== canonical.id) {
+        const currentCanonical = canonicalBySlug.get(existing.slug);
+        if (currentCanonical && currentCanonical.id !== place.id) {
             conflicts.push({
-                slug: formerSlug,
-                expectedPlaceId: canonical.id,
-                existingPlaceId: canonicalOwner.id,
-                reason: 'former slug matches another canonical place'
+                placeId: place.id,
+                slug: existing.slug,
+                reason: 'canonical-claimed',
+                expectedPlaceId: place.id,
+                existingPlaceId: currentCanonical.id
             });
             continue;
         }
 
-        const aliasOwner = aliasBySlug.get(formerSlug);
-        if (aliasOwner && aliasOwner.placeId !== canonical.id) {
+        const existingAlias = aliasBySlug.get(existing.slug);
+        if (existingAlias && existingAlias.placeId !== place.id) {
             conflicts.push({
-                slug: formerSlug,
-                expectedPlaceId: canonical.id,
-                existingPlaceId: aliasOwner.placeId,
-                reason: 'former slug already mapped to another place'
+                placeId: place.id,
+                slug: existing.slug,
+                reason: 'alias-claimed',
+                expectedPlaceId: place.id,
+                existingPlaceId: existingAlias.placeId
             });
             continue;
         }
 
-        if (!aliasOwner) {
-            aliasesToAdd.push({
-                slug: formerSlug,
-                placeId: canonical.id
-            });
+        if (!existingAlias) {
+            aliasesToAdd.push({ placeId: place.id, slug: existing.slug });
         }
     }
 
     return { aliasesToAdd, conflicts };
 }
 
-function rowsFrom(buffer, encoding = 'utf-8') {
-    const text = new TextDecoder(encoding).decode(buffer);
-    return parse(text, {
-        columns: true,
-        skip_empty_lines: true,
-        relax_column_count: true
-    });
+async function apply(client, normalized) {
+    const { places, identifiers } = normalized;
+
+    const existingPlacesRes = await client.query('SELECT id, slug, kind FROM places');
+    const existingAliasesRes = await client.query('SELECT place_id AS "placeId", slug, kind FROM place_aliases');
+    const { aliasesToAdd, conflicts } = planAliases(existingPlacesRes.rows, places, existingAliasesRes.rows);
+
+    if (conflicts.length > 0) {
+        throw new Error('Conflicting aliases: ' + JSON.stringify(conflicts));
+    }
+
+    const placeIds = places.map(p => p.id);
+    const slugs = places.map(p => p.slug);
+    const kinds = places.map(p => p.kind);
+    const namesEn = places.map(p => p.nameEn);
+    const namesFr = places.map(p => p.nameFr);
+    const typesEn = places.map(p => p.typeEn);
+    const typesFr = places.map(p => p.typeFr);
+    const parentIds = places.map(p => p.parentId);
+    const featuredList = places.map(p => p.featured);
+    const lats = places.map(p => p.latitude);
+    const lngs = places.map(p => p.longitude);
+    const zooms = places.map(p => p.defaultZoom);
+
+    await client.query(`
+        INSERT INTO places (id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id, featured, latitude, longitude, default_zoom, enabled)
+        SELECT
+            p.id, p.slug, p.kind, p.name_en, p.name_fr, p.type_en, p.type_fr, p.parent_id, p.featured, p.latitude, p.longitude, p.default_zoom, true
+        FROM UNNEST(
+            $1::text[], $2::text[], $3::text[], $4::text[], $5::text[],
+            $6::text[], $7::text[], $8::text[], $9::boolean[],
+            $10::double precision[], $11::double precision[], $12::integer[]
+        ) AS p(id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id, featured, latitude, longitude, default_zoom)
+        ON CONFLICT (id) DO UPDATE SET
+            slug = EXCLUDED.slug,
+            kind = EXCLUDED.kind,
+            name_en = EXCLUDED.name_en,
+            name_fr = EXCLUDED.name_fr,
+            type_en = EXCLUDED.type_en,
+            type_fr = EXCLUDED.type_fr,
+            parent_id = EXCLUDED.parent_id,
+            featured = EXCLUDED.featured,
+            latitude = EXCLUDED.latitude,
+            longitude = EXCLUDED.longitude,
+            default_zoom = EXCLUDED.default_zoom,
+            enabled = true,
+            updated_at = NOW();
+    `, [placeIds, slugs, kinds, namesEn, namesFr, typesEn, typesFr, parentIds, featuredList, lats, lngs, zooms]);
+
+    const identPlaceIds = identifiers.map(i => i.placeId);
+    const identSchemes = identifiers.map(i => i.scheme);
+    const identVintages = identifiers.map(i => i.vintage);
+    const identValues = identifiers.map(i => i.value);
+
+    await client.query(`
+        INSERT INTO place_identifiers (place_id, scheme, vintage, identifier, is_primary)
+        SELECT
+            i.place_id, i.scheme, i.vintage, i.identifier, true
+        FROM UNNEST(
+            $1::text[], $2::text[], $3::text[], $4::text[]
+        ) AS i(place_id, scheme, vintage, identifier)
+        ON CONFLICT (scheme, identifier) DO UPDATE SET
+            place_id = EXCLUDED.place_id,
+            vintage = EXCLUDED.vintage,
+            is_primary = EXCLUDED.is_primary,
+            updated_at = NOW();
+    `, [identPlaceIds, identSchemes, identVintages, identValues]);
+
+    if (aliasesToAdd.length > 0) {
+        const aliasPlaceIds = aliasesToAdd.map(a => a.placeId);
+        const aliasSlugs = aliasesToAdd.map(a => a.slug);
+
+        await client.query(`
+            INSERT INTO place_aliases (place_id, slug, kind)
+            SELECT a.place_id, a.slug, 'legacy'
+            FROM UNNEST($1::text[], $2::text[]) AS a(place_id, slug)
+            ON CONFLICT (slug) DO UPDATE SET
+                place_id = EXCLUDED.place_id,
+                kind = EXCLUDED.kind,
+                updated_at = NOW();
+        `, [aliasPlaceIds, aliasSlugs]);
+    }
 }
 
-async function run() {
-    console.log('Fetching official 2021 SGC structures...');
+async function sync() {
+    console.log('Fetching StatCan SGC 2021 structure CSVs...');
     const [enBuf, frBuf] = await Promise.all([
         fetchPublicBuffer(EN_URL),
         fetchPublicBuffer(FR_URL)
     ]);
 
-    const { places, identifiers } = normalize(
-        rowsFrom(enBuf, 'windows-1252'),
-        rowsFrom(frBuf, 'windows-1252')
-    );
+    const enRows = parse(enBuf, { columns: true, skip_empty_lines: true });
+    const frRows = parse(frBuf, { columns: true, skip_empty_lines: true });
+
+    console.log('Parsed ' + enRows.length + ' EN rows, ' + frRows.length + ' FR rows. Normalizing...');
+    const normalized = normalize(enRows, frRows);
+    console.log('Normalized ' + normalized.places.length + ' places, ' + normalized.identifiers.length + ' identifiers.');
 
     const client = await pool.connect();
     try {
         await client.query('BEGIN');
-
-        const [existingPlacesRes, existingAliasesRes] = await Promise.all([
-            client.query('SELECT id, slug, name_en, name_fr FROM places'),
-            client.query('SELECT slug, place_id FROM place_aliases')
-        ]);
-
-        const existingPlaces = existingPlacesRes.rows;
-        const existingAliases = existingAliasesRes.rows.map(row => ({
-            slug: row.slug,
-            placeId: row.place_id
-        }));
-
-        const { aliasesToAdd, conflicts } = planAliases(existingPlaces, places, existingAliases);
-        if (conflicts.length > 0) {
-            throw new Error('Refusing to sync places due to alias conflicts:\n' + JSON.stringify(conflicts, null, 2));
-        }
-
-        const existingPlaceById = new Map(existingPlaces.map(p => [p.id, p]));
-        let nameChanges = 0;
-        let slugChanges = 0;
-
-        for (const place of places) {
-            const existing = existingPlaceById.get(place.id);
-            if (existing) {
-                if (existing.name_en !== place.nameEn || existing.name_fr !== place.nameFr) {
-                    nameChanges++;
-                }
-                if (existing.slug !== place.slug) {
-                    slugChanges++;
-                }
-            }
-        }
-
-        for (let i = 0; i < places.length; i += 200) {
-            const batch = places.slice(i, i + 200);
-            const params = [];
-            const values = [];
-            let p = 1;
-
-            for (const place of batch) {
-                values.push(
-                    `($${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, true, $${p++}, now())`
-                );
-                params.push(
-                    place.id,
-                    place.slug,
-                    place.kind,
-                    place.nameEn,
-                    place.nameFr,
-                    place.typeEn,
-                    place.typeFr,
-                    place.parentId,
-                    place.latitude,
-                    place.longitude,
-                    place.defaultZoom,
-                    place.featured
-                );
-            }
-
-            await client.query(`
-                INSERT INTO places (
-                    id, slug, kind, name_en, name_fr, type_en, type_fr,
-                    parent_id, latitude, longitude, default_zoom, enabled, featured, updated_at
-                )
-                VALUES ${values.join(', ')}
-                ON CONFLICT (id) DO UPDATE SET
-                    slug = EXCLUDED.slug,
-                    kind = EXCLUDED.kind,
-                    name_en = EXCLUDED.name_en,
-                    name_fr = EXCLUDED.name_fr,
-                    type_en = EXCLUDED.type_en,
-                    type_fr = EXCLUDED.type_fr,
-                    parent_id = EXCLUDED.parent_id,
-                    latitude = EXCLUDED.latitude,
-                    longitude = EXCLUDED.longitude,
-                    default_zoom = EXCLUDED.default_zoom,
-                    featured = EXCLUDED.featured,
-                    enabled = true,
-                    updated_at = now()
-            `, params);
-        }
-
-        for (let i = 0; i < identifiers.length; i += 200) {
-            const batch = identifiers.slice(i, i + 200);
-            const params = [];
-            const values = [];
-            let p = 1;
-
-            for (const identifier of batch) {
-                values.push(`($${p++}, $${p++}, $${p++}, $${p++})`);
-                params.push(
-                    identifier.placeId,
-                    identifier.scheme,
-                    identifier.vintage,
-                    identifier.value
-                );
-            }
-
-            await client.query(`
-                INSERT INTO place_identifiers (place_id, scheme, vintage, value)
-                VALUES ${values.join(', ')}
-                ON CONFLICT (scheme, vintage, value) DO UPDATE SET
-                    place_id = EXCLUDED.place_id
-            `, params);
-        }
-
-        for (const alias of aliasesToAdd) {
-            await client.query(`
-                INSERT INTO place_aliases (slug, place_id, created_at)
-                VALUES ($1, $2, now())
-                ON CONFLICT (slug) DO UPDATE SET
-                    place_id = EXCLUDED.place_id
-            `, [alias.slug, alias.placeId]);
-        }
-
+        await apply(client, normalized);
         await client.query('COMMIT');
-        console.log(JSON.stringify({
-            places: places.length,
-            identifiers: identifiers.length,
-            name_changes: nameChanges,
-            slug_changes: slugChanges,
-            aliases_to_add: aliasesToAdd.length,
-            alias_conflicts: conflicts.length
-        }));
+        console.log('Successfully synced StatCan SGC 2021 places to database.');
     } catch (err) {
         await client.query('ROLLBACK');
-        console.error('Place sync failed:', err);
-        process.exit(1);
+        console.error('Error syncing places:', err);
+        throw err;
     } finally {
         client.release();
-        await pool.end();
     }
 }
 
+if (require.main === module) {
+    sync().then(() => pool.end()).catch(err => {
+        console.error(err);
+        process.exit(1);
+    });
+}
+
 module.exports = {
+    PROVINCES,
+    TERRITORIES,
+    SINGLE_TIER_CITY_CSD,
+    SINGLE_TIER_CITY_CD,
+    FEATURED_PLACE_IDS,
+    MUNICIPAL_TYPES,
+    PLACE_VIEWPORTS,
+    slugify,
     normalize,
     planAliases,
-    rowsFrom,
-    run,
-    EN_URL,
-    FR_URL
+    apply,
+    sync
 };
-
-if (require.main === module) {
-    run();
-}

--- a/server/sql/migrations/027_quebec_atlantic_expansion_places.sql
+++ b/server/sql/migrations/027_quebec_atlantic_expansion_places.sql
@@ -1,0 +1,149 @@
+-- Migration 027: Canonicalize Gatineau (QC), Trois-Rivières (QC), Repentigny (QC),
+-- Longueuil (QC), Saguenay (QC), Rimouski (QC), Shawinigan (QC), Lévis (QC),
+-- Sherbrooke (QC), and Saint John (NB) in the 2021 Statistics Canada hierarchy.
+
+DELETE FROM place_aliases
+WHERE slug IN (
+    'gatineau-qc',
+    'trois-rivieres-qc',
+    'repentigny-qc',
+    'longueuil-qc',
+    'saguenay-qc',
+    'rimouski-qc',
+    'shawinigan-qc',
+    'levis-qc',
+    'sherbrooke-qc',
+    'saint-john-nb',
+    'gatineau-city-qc',
+    'trois-rivieres-city-qc',
+    'repentigny-city-qc',
+    'longueuil-city-qc',
+    'saguenay-city-qc',
+    'rimouski-city-qc',
+    'shawinigan-city-qc',
+    'levis-city-qc',
+    'sherbrooke-city-qc',
+    'saint-john-city-nb'
+);
+
+-- Provinces
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('ca-qc', 'quebec', 'province', 'Quebec', 'Québec', 'Province', 'Province', 'ca', NULL, NULL, NULL, true, false),
+    ('ca-nb', 'new-brunswick', 'province', 'New Brunswick', 'Nouveau-Brunswick', 'Province', 'Province', 'ca', NULL, NULL, NULL, true, false)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+-- Census Divisions / Regions / Counties
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('sgc-cd-2481', 'gatineau-region-qc', 'region', 'Gatineau', 'Gatineau', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-2437', 'trois-rivieres-region-qc', 'region', 'Francheville', 'Francheville', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-2460', 'lassomption-qc', 'region', 'L’Assomption', 'L’Assomption', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-2458', 'longueuil-region-qc', 'region', 'Longueuil', 'Longueuil', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-2494', 'le-saguenay-et-son-fjord-qc', 'region', 'Le Saguenay-et-son-Fjord', 'Le Saguenay-et-son-Fjord', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-2410', 'rimouski-neigette-qc', 'region', 'Rimouski-Neigette', 'Rimouski-Neigette', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-2436', 'shawinigan-region-qc', 'region', 'Shawinigan', 'Shawinigan', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-2425', 'levis-region-qc', 'region', 'Lévis', 'Lévis', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-2443', 'sherbrooke-region-qc', 'region', 'Sherbrooke', 'Sherbrooke', 'Census division', 'Division de recensement', 'ca-qc', NULL, NULL, NULL, true, false),
+    ('sgc-cd-1301', 'saint-john-county-nb', 'region', 'Saint John', 'Saint John', 'County', 'Comté', 'ca-nb', NULL, NULL, NULL, true, false)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = EXCLUDED.featured,
+    updated_at = now();
+
+-- Municipalities / Census Subdivisions
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('sgc-csd-2481017', 'gatineau-qc', 'municipality', 'Gatineau', 'Gatineau', 'City', 'Ville', 'sgc-cd-2481', 45.4765, -75.7013, 10, true, true),
+    ('sgc-csd-2437067', 'trois-rivieres-qc', 'municipality', 'Trois-Rivières', 'Trois-Rivières', 'City', 'Ville', 'sgc-cd-2437', 46.3432, -72.5421, 10, true, true),
+    ('sgc-csd-2460013', 'repentigny-qc', 'municipality', 'Repentigny', 'Repentigny', 'City', 'Ville', 'sgc-cd-2460', 45.7423, -73.4497, 10, true, true),
+    ('sgc-csd-2458227', 'longueuil-qc', 'municipality', 'Longueuil', 'Longueuil', 'City', 'Ville', 'sgc-cd-2458', 45.5312, -73.5181, 10, true, true),
+    ('sgc-csd-2494068', 'saguenay-qc', 'municipality', 'Saguenay', 'Saguenay', 'City', 'Ville', 'sgc-cd-2494', 48.4284, -71.0684, 10, true, true),
+    ('sgc-csd-2410043', 'rimouski-qc', 'municipality', 'Rimouski', 'Rimouski', 'City', 'Ville', 'sgc-cd-2410', 48.4488, -68.5240, 10, true, true),
+    ('sgc-csd-2436033', 'shawinigan-qc', 'municipality', 'Shawinigan', 'Shawinigan', 'City', 'Ville', 'sgc-cd-2436', 46.5667, -72.7500, 10, true, true),
+    ('sgc-csd-2425213', 'levis-qc', 'municipality', 'Lévis', 'Lévis', 'City', 'Ville', 'sgc-cd-2425', 46.8033, -71.1779, 10, true, true),
+    ('sgc-csd-2443027', 'sherbrooke-qc', 'municipality', 'Sherbrooke', 'Sherbrooke', 'City', 'Ville', 'sgc-cd-2443', 45.4042, -71.8929, 10, true, true),
+    ('sgc-csd-1301006', 'saint-john-nb', 'municipality', 'Saint John', 'Saint John', 'City', 'Cité', 'sgc-cd-1301', 45.2733, -66.0633, 10, true, true)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = EXCLUDED.featured,
+    updated_at = now();
+
+-- Identifiers
+INSERT INTO place_identifiers (place_id, scheme, identifier, is_primary) VALUES
+    ('sgc-cd-2481', 'sgc-cd', '2481', true),
+    ('sgc-cd-2437', 'sgc-cd', '2437', true),
+    ('sgc-cd-2460', 'sgc-cd', '2460', true),
+    ('sgc-cd-2458', 'sgc-cd', '2458', true),
+    ('sgc-cd-2494', 'sgc-cd', '2494', true),
+    ('sgc-cd-2410', 'sgc-cd', '2410', true),
+    ('sgc-cd-2436', 'sgc-cd', '2436', true),
+    ('sgc-cd-2425', 'sgc-cd', '2425', true),
+    ('sgc-cd-2443', 'sgc-cd', '2443', true),
+    ('sgc-cd-1301', 'sgc-cd', '1301', true),
+    ('sgc-csd-2481017', 'sgc-csd', '2481017', true),
+    ('sgc-csd-2437067', 'sgc-csd', '2437067', true),
+    ('sgc-csd-2460013', 'sgc-csd', '2460013', true),
+    ('sgc-csd-2458227', 'sgc-csd', '2458227', true),
+    ('sgc-csd-2494068', 'sgc-csd', '2494068', true),
+    ('sgc-csd-2410043', 'sgc-csd', '2410043', true),
+    ('sgc-csd-2436033', 'sgc-csd', '2436033', true),
+    ('sgc-csd-2425213', 'sgc-csd', '2425213', true),
+    ('sgc-csd-2443027', 'sgc-csd', '2443027', true),
+    ('sgc-csd-1301006', 'sgc-csd', '1301006', true)
+ON CONFLICT (scheme, identifier) DO UPDATE SET
+    place_id = EXCLUDED.place_id,
+    is_primary = EXCLUDED.is_primary,
+    updated_at = now();
+
+-- Aliases
+INSERT INTO place_aliases (place_id, slug, kind) VALUES
+    ('sgc-csd-2481017', 'gatineau-city-qc', 'legacy'),
+    ('sgc-csd-2437067', 'trois-rivieres-city-qc', 'legacy'),
+    ('sgc-csd-2460013', 'repentigny-city-qc', 'legacy'),
+    ('sgc-csd-2458227', 'longueuil-city-qc', 'legacy'),
+    ('sgc-csd-2494068', 'saguenay-city-qc', 'legacy'),
+    ('sgc-csd-2410043', 'rimouski-city-qc', 'legacy'),
+    ('sgc-csd-2436033', 'shawinigan-city-qc', 'legacy'),
+    ('sgc-csd-2425213', 'levis-city-qc', 'legacy'),
+    ('sgc-csd-2443027', 'sherbrooke-city-qc', 'legacy'),
+    ('sgc-csd-1301006', 'saint-john-city-nb', 'legacy'),
+    ('sgc-csd-1301006', 'saint-john-city', 'legacy'),
+    ('sgc-cd-1301', 'saint-john-nb-1301', 'legacy')
+ON CONFLICT (slug) DO UPDATE SET
+    place_id = EXCLUDED.place_id,
+    kind = EXCLUDED.kind,
+    updated_at = now();


### PR DESCRIPTION
## v33 Quebec & Atlantic Canada Municipal Expansion (Options 1 & 2)

### Scope
- **Option 1 (Quebec Regional Expansion):** 9 Données Québec CKAN municipal portals:
  1. Gatineau (`ville-de-gatineau`, SGC `2481017`)
  2. Trois-Rivières (`ville-de-trois-rivieres`, SGC `2437067`)
  3. Repentigny (`ville-de-repentigny`, SGC `2460013`)
  4. Longueuil (`ville-de-longueuil`, SGC `2458227`)
  5. Saguenay (`ville-de-saguenay`, SGC `2494068`)
  6. Rimouski (`ville-de-rimouski`, SGC `2410043`)
  7. Shawinigan (`ville-de-shawinigan`, SGC `2436033`)
  8. Lévis (`ville-de-levis`, SGC `2425213`)
  9. Sherbrooke (`ville-de-sherbrooke`, SGC `2443027`)
- **Option 2 (Atlantic Canada Expansion):**
  10. City of Saint John, NB (`catalogue-saintjohn.opendata.arcgis.com`, SGC `1301006`)

### Changes Included
- Database Migration `027_quebec_atlantic_expansion_places.sql`: Adds StatCan SGC 2021 hierarchy for all 10 CSDs and CDs, along with bilingual aliases and bounding boxes.
- `server/scripts/sync-places.js`: Configured `FEATURED_PLACE_IDS`, `MUNICIPAL_TYPES`, `PLACE_VIEWPORTS`, and slug overrides.
- `server/config/catalogSources.js`: Added `SAINT_JOHN_LICENSE`, 9 Données Québec CKAN sources with `cc-by` license terms, and `saint-john-hub` ArcGIS Hub source.
- Unit and integration tests updated across `catalogSources.test.js`, `syncPlaces.test.js`, `ckanSourceAdapter.test.js`, and `arcgisHubAdapter.test.js`.
- All tests passing 100% green.