### PR TITLE
feat(v35): recover expansion sources and add high-volume portals

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,20 @@ upstream APIs (such as CKAN's DataStore or Socrata), while most are published as
 | 2 - load | tabular file <= 50 MB | streams into local PostgreSQL on demand; same `/query` response shape |
 | 3 - honest fallback | anything else | metadata + the download link, labeled `file-only` (422 on `/query`) |
 
-The catalogue combines the federal CKAN portal with source adapters for local
-publishers across sixty-five municipal and regional portals (sixty-six total catalogue sources)
-spanning all ten Canadian provinces and the Northwest Territories. Dataset provenance and
-licensing stay attached per source. A versioned Statistics Canada SGC hierarchy powers
-place-first discovery across seventy-three canonical featured jurisdictions, and
-spatial resources can be explored through bounded maps before their CSV snapshot
-is loaded.
+The catalogue combines the federal CKAN portal with a fail-closed registry of 85
+municipal, regional, provincial, and territorial source definitions. Eighty-two
+local sources are currently enabled, for 83 active catalogue sources including
+the federal mirror. Dataset provenance and licensing stay attached per source.
+A versioned Statistics Canada SGC hierarchy powers place-first discovery across
+116 configured featured browse destinations, and spatial resources can be
+explored through bounded maps before their CSV snapshot is loaded.
 
 Technology adapters preserve per-portal provenance and licensing:
-- **Shared & Municipal CKAN**: Toronto, Montréal, and the centralized Données Québec CKAN
+- **Shared & Municipal CKAN**: Toronto, Montréal, Regina, the Government of the Northwest
+  Territories, and the centralized Données Québec CKAN
   engine serving Québec City, Laval, Gatineau, Trois-Rivières, Repentigny, Longueuil,
-  Saguenay, Rimouski, Shawinigan, Lévis, and Sherbrooke with French-first metadata and
-  record-explicit CC BY 4.0 terms.
+  Saguenay, Rimouski, Shawinigan, Lévis, Sherbrooke, Sherbrooke geomatics, and
+  Saint-Hyacinthe with French-first metadata and record-explicit CC BY 4.0 terms.
 - **Opendatasoft**: City of Vancouver with English-first metadata, record-explicit Open
   Government Licence – Vancouver terms, and validated GeoJSON exports in the local PostGIS index.
 - **Socrata**: Calgary, Edmonton, and Winnipeg with config-driven publisher/licence admission
@@ -37,11 +38,18 @@ Technology adapters preserve per-portal provenance and licensing:
   Greater Sudbury, Burnaby, Saskatoon, Moncton, Guelph, Saanich, Belleville, Yellowknife (NT),
   Barrie, Thunder Bay, Chatham-Kent, Kawartha Lakes, Summerland, Norfolk County, Haldimand County,
   Lethbridge, Medicine Hat, Airdrie, Canmore, Penticton, Langley City, Huron County, Cumberland County,
-  Saint John (NB), and the Durham, Peel, Halton, York, Niagara, and Waterloo regional clusters
+  Saint John (NB), Windsor, Kingston, Kamloops, Nanaimo, Abbotsford, Coquitlam, Prince George,
+  New Westminster, Port Moody, Squamish, Maple Ridge, Port Coquitlam, and the Durham, Peel,
+  Halton, York, Niagara, and Waterloo regional clusters
   with bounded live ArcGIS map viewports and strict publisher-scoped open licences.
+- **Municipal JSON catalogue**: Red Deer, normalized through its official dataset API and
+  portal-wide Open Government Licence.
 
 Each portal is gated to its recognized open licences, so generic website terms, blank licence
 records where no portal-wide grant applies, and non-commercial data stay excluded.
+The Whitehorse, St. John's, and Charlottetown source identities remain configured but disabled:
+their previously documented ArcGIS feeds are unavailable and no equivalent machine-readable
+catalogue with verified open-data terms is currently admissible.
 
 ## Layout
 
@@ -65,13 +73,13 @@ psql canquery -c "CREATE EXTENSION IF NOT EXISTS unaccent;"
 cd server
 npm install
 cp .env.example .env              # set DATABASE_URL (and optional S3_* for PMTiles)
-npm run migrate                   # apply migrations (runs 001..028)
+npm run migrate                   # apply migrations (runs 001..029)
 npm run sync:places               # populate the 2021 SGC hierarchy
 
 # sync the federal catalogue (batched harvest, chunks of 50)
-npm run sync                      # full harvest (~50k datasets)
+node scripts/catalog-sync.js      # full harvest (~50k datasets)
 # or test against a small sample:
-npm run sync -- --limit=100
+node scripts/catalog-sync.js --limit=100
 
 # or harvest a standalone municipal/regional source (dry-run or real)
 npm run sync:source -- --source=toronto-open-data --dry-run
@@ -217,7 +225,7 @@ remain in PostGIS.
 ## Web UI
 
 The SPA (`client/`) starts with a search plus an optional remembered place
-(All Canada remains the default). Its grouped selector shows seventy-three canonical
+(All Canada remains the default). Its grouped selector shows 116 configured canonical
 featured jurisdictions, including standalone cities (Calgary, Edmonton, Fredericton, Gatineau,
 Greater Sudbury, Guelph, Halifax, Hamilton, Kelowna, Laval, Lévis, London, Longueuil, Moncton,
 Montréal, Ottawa, Québec City, Repentigny, Rimouski, Saanich, Saguenay, Saint John, Saskatoon,
@@ -241,8 +249,7 @@ sparklines. English/French throughout.
 ## Tests & lint
 
 ```bash
-cd server && npm test && npm run lint
-cd client && npm test && npm run lint && npm run build
+npm --prefix server run verify
 ```
 
 Coverage includes CKAN, ArcGIS Hub, Opendatasoft and Socrata source adapters, place hierarchy and APIs, streaming direct
@@ -253,7 +260,7 @@ concurrent job-lease heartbeats, store/map-budget eviction, and client UI routin
 ## Deployment
 
 Dedicated VPS `canquery-prod-01` at Little Creek Hosting (IPv4 `38.45.71.90`).
-Deployed through `git pull` on `main` under user `canquery`; managed as systemd
-services `canquery-api.service`, `canquery-worker.service`, and `canquery-map-worker.service`
-behind a Caddy reverse proxy that terminates TLS with automatic Let's Encrypt certificates.
-See `deploy/DEPLOY.md` for runbooks.
+Production retains the legacy systemd names `opencanada-api`, `opencanada-worker`,
+and `opencanada-map-worker` behind a Caddy reverse proxy. The generic deployment
+templates use `canquery-*` names for new installations. See `deploy/DEPLOY.md` and
+`deploy/RELEASE_RUNBOOK_v35.md` for runbooks.

--- a/client/src/api/catalog.js
+++ b/client/src/api/catalog.js
@@ -36,6 +36,27 @@ export function fetchPlaces({ q, kind, parent, featured, limit, cursor } = {}) {
   return getJSON('/api/v1/places', { q, kind, parent, featured, limit, cursor });
 }
 
+export async function fetchFeaturedPlaces() {
+  const data = [];
+  const seenCursors = new Set();
+  let cursor;
+  let meta = {};
+
+  do {
+    const env = await fetchPlaces({ featured: true, limit: 100, cursor });
+    data.push(...(env.data || []));
+    meta = env.meta || meta;
+    const nextCursor = env.pagination?.nextCursor || null;
+    if (nextCursor && seenCursors.has(nextCursor)) {
+      throw new Error('Featured place pagination returned a repeated cursor');
+    }
+    if (nextCursor) seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  } while (cursor);
+
+  return { data, pagination: { nextCursor: null }, meta };
+}
+
 export function fetchPlace(idOrSlug) {
   return getJSON('/api/v1/places/' + encodeURIComponent(idOrSlug));
 }

--- a/client/src/api/catalog.test.js
+++ b/client/src/api/catalog.test.js
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('./client.js', () => ({ getJSON: vi.fn(), postJSON: vi.fn() }));
+
+import { getJSON } from './client.js';
+import { fetchFeaturedPlaces } from './catalog.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('catalog API helpers', () => {
+  test('collects every featured-place page', async () => {
+    getJSON
+      .mockResolvedValueOnce({
+        data: [{ id: 'place-1' }],
+        pagination: { nextCursor: '100' },
+        meta: { request: 1 }
+      })
+      .mockResolvedValueOnce({
+        data: [{ id: 'place-2' }],
+        pagination: { nextCursor: null },
+        meta: { request: 2 }
+      });
+
+    await expect(fetchFeaturedPlaces()).resolves.toEqual({
+      data: [{ id: 'place-1' }, { id: 'place-2' }],
+      pagination: { nextCursor: null },
+      meta: { request: 2 }
+    });
+    expect(getJSON).toHaveBeenNthCalledWith(1, '/api/v1/places', {
+      q: undefined, kind: undefined, parent: undefined,
+      featured: true, limit: 100, cursor: undefined
+    });
+    expect(getJSON).toHaveBeenNthCalledWith(2, '/api/v1/places', {
+      q: undefined, kind: undefined, parent: undefined,
+      featured: true, limit: 100, cursor: '100'
+    });
+  });
+
+  test('rejects a repeated cursor instead of looping forever', async () => {
+    getJSON
+      .mockResolvedValueOnce({ data: [], pagination: { nextCursor: '100' } })
+      .mockResolvedValueOnce({ data: [], pagination: { nextCursor: '100' } });
+
+    await expect(fetchFeaturedPlaces()).rejects.toThrow('repeated cursor');
+    expect(getJSON).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import { searchDatasets, fetchOrganizations, fetchStats, fetchFeatured, fetchPlaces, fetchSources } from '../api/catalog.js';
+import { searchDatasets, fetchOrganizations, fetchStats, fetchFeatured, fetchFeaturedPlaces, fetchSources } from '../api/catalog.js';
 import useDebouncedValue from '../hooks/useDebouncedValue.js';
 import usePaginatedCollection from '../hooks/usePaginatedCollection.js';
 import useCountUp from '../hooks/useCountUp.js';
@@ -145,7 +145,7 @@ export default function HomePage() {
 
   useEffect(() => {
     let cancelled = false;
-    fetchPlaces({ featured: true, limit: 100 })
+    fetchFeaturedPlaces()
       .then(env => { if (!cancelled) setPlaces(env.data || []); })
       .catch(() => {});
     return () => { cancelled = true; };

--- a/client/src/pages/PlacesPage.jsx
+++ b/client/src/pages/PlacesPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { fetchPlaces } from '../api/catalog.js';
+import { fetchFeaturedPlaces, fetchPlaces } from '../api/catalog.js';
 import { useLang } from '../i18n.jsx';
 import { MapPinIcon, ArrowRightIcon, MapIcon, SearchIcon } from '../components/Icons.jsx';
 import LoadingSpinner from '../components/LoadingSpinner.jsx';
@@ -22,11 +22,10 @@ export default function PlacesPage() {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
-    fetchPlaces({
-      q: debouncedQuery || undefined,
-      featured: debouncedQuery ? undefined : true,
-      limit: 100
-    })
+    const request = debouncedQuery
+      ? fetchPlaces({ q: debouncedQuery, limit: 100 })
+      : fetchFeaturedPlaces();
+    request
       .then(env => {
         if (!cancelled) {
           setPlaces(env.data || []);

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -3,12 +3,12 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import PlacesPage from './PlacesPage.jsx';
 
-vi.mock('../api/catalog.js', () => ({ fetchPlaces: vi.fn() }));
-import { fetchPlaces } from '../api/catalog.js';
+vi.mock('../api/catalog.js', () => ({ fetchFeaturedPlaces: vi.fn(), fetchPlaces: vi.fn() }));
+import { fetchFeaturedPlaces, fetchPlaces } from '../api/catalog.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
-  fetchPlaces.mockResolvedValue({ data: [
+  const response = { data: [
     {
       id: 'ca-on-durham', slug: 'durham-on', kind: 'region',
       name: { en: 'Durham' }, type: { en: 'Regional municipality' },
@@ -110,7 +110,9 @@ beforeEach(() => {
       parent: { id: 'sgc-cd-5915', name: { en: 'Greater Vancouver', fr: 'Greater Vancouver' } },
       dataset_count: 216, direct_dataset_count: 216, mappable_resource_count: 180
     }
-  ] });
+  ] };
+  fetchFeaturedPlaces.mockResolvedValue(response);
+  fetchPlaces.mockResolvedValue(response);
 });
 
 describe('PlacesPage', () => {
@@ -137,15 +139,12 @@ describe('PlacesPage', () => {
     expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Caledon/ })).toBeInTheDocument();
     expect(screen.getAllByText('Broader-area coverage')).toHaveLength(2);
-    await waitFor(() => expect(fetchPlaces).toHaveBeenCalledWith({
-      q: undefined, featured: true, limit: 100
-    }));
+    await waitFor(() => expect(fetchFeaturedPlaces).toHaveBeenCalledTimes(1));
+    expect(fetchPlaces).not.toHaveBeenCalled();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Find a city, region or province...' }), {
       target: { value: 'Toronto' }
     });
-    await waitFor(() => expect(fetchPlaces).toHaveBeenCalledWith({
-      q: 'Toronto', featured: undefined, limit: 100
-    }));
+    await waitFor(() => expect(fetchPlaces).toHaveBeenCalledWith({ q: 'Toronto', limit: 100 }));
   });
 });

--- a/deploy/RELEASE_RUNBOOK_v33.md
+++ b/deploy/RELEASE_RUNBOOK_v33.md
@@ -1,5 +1,9 @@
 # CanQuery v33 Production Deployment Runbook
 
+> Superseded by `RELEASE_RUNBOOK_v35.md`. Retained only as a historical v33
+> source list; do not use its credentials, paths, counts, or deployment sequence
+> for the current release.
+
 **Target Server:** `canquery-prod-01` (dedicated VPS at Little Creek Hosting)  
 **Host IP:** `38.45.71.90`  
 **User:** `canquery` / `root`  

--- a/deploy/RELEASE_RUNBOOK_v35.md
+++ b/deploy/RELEASE_RUNBOOK_v35.md
@@ -1,0 +1,396 @@
+# CanQuery v35 recovery and high-volume source runbook
+
+Status: release candidate validated locally on August 30, 2026. This document
+does not claim that v35 has been deployed to production.
+
+This release repairs the incomplete v34 implementation, activates the live v33
+and v34 catalogues that can still be verified, adds ten v35 sources, and applies
+migration `029_recovery_and_high_volume_places.sql`. The source registry contains
+85 local definitions: 82 enabled and three retained but disabled fail-closed.
+Including the federal mirror, the application exposes 83 active catalogue
+sources. `/api/v1/ops` registers 82 `source:*` jobs; the federal mirror is
+tracked through its separate full and incremental jobs.
+
+## 1. Validated release snapshot
+
+The following are live upstream dry-run observations, not permanent count
+assertions. Repeat the dry-runs immediately before deployment because upstream
+catalogues can change.
+
+| Wave | Active sources | Discovered | Admitted | Excluded | Mappable | Failed |
+|---|---:|---:|---:|---:|---:|---:|
+| v33 Quebec and Saint John | 10 | 869 | 647 | 222 | 532 | 0 |
+| v34 currently available catalogues | 7 | 2,566 | 2,438 | 128 | 841 | 0 |
+| v35 NWT, BC, and Quebec | 10 | 1,420 | 1,276 | 144 | 707 | 0 |
+| Total | 27 | 4,855 | 4,361 | 494 | 2,080 | 0 |
+
+The v35 source-level snapshot is:
+
+| Source id | Discovered | Admitted | Excluded | Mappable |
+|---|---:|---:|---:|---:|
+| `northwest-territories-open-data` | 341 | 340 | 1 | 0 |
+| `coquitlam-hub` | 259 | 240 | 19 | 162 |
+| `prince-george-hub` | 185 | 181 | 4 | 159 |
+| `new-westminster-hub` | 169 | 109 | 60 | 81 |
+| `port-moody-hub` | 160 | 118 | 42 | 83 |
+| `squamish-hub` | 120 | 108 | 12 | 77 |
+| `maple-ridge-hub` | 67 | 64 | 3 | 48 |
+| `port-coquitlam-hub` | 62 | 59 | 3 | 41 |
+| `sherbrooke-geomatics-open-data` | 30 | 30 | 0 | 30 |
+| `saint-hyacinthe-open-data` | 27 | 27 | 0 | 26 |
+
+`whitehorse-hub`, `st-johns-hub`, and `charlottetown-hub` are intentionally
+disabled. Their documented ArcGIS feeds are unavailable, and no equivalent
+machine-readable municipal catalogue with verified open-data terms was found.
+Do not enable them merely to make the configured count match an older release
+document.
+
+Abbotsford intentionally excludes 28 records whose advertised service URLs are
+under the inaccessible `maps.abbotsford.ca/arcgis/rest/services/GeocortexExt/`
+family and one record with restricted third-party terms. Its validated result is
+186 discovered, 157 admitted, 29 excluded, 148 mappable, and zero failures.
+
+## 2. Local release gate
+
+Run from a clean release checkout with the lockfiles installed:
+
+```bash
+git status --short
+npm ci --prefix server
+npm ci --prefix client
+npm --prefix server run verify
+git diff --check
+```
+
+The August 30 release candidate passed 58 server suites (472 tests), 27 client
+suites (109 tests), both ESLint passes, and the Vite production build. The normal
+Jest run skips the PostGIS integration suite unless a database is supplied, so
+also validate all migrations against a disposable PostgreSQL 16/PostGIS 3.5
+database:
+
+```bash
+CANQUERY_DATABASE_URL=<disposable-postgis-url> npm --prefix server run migrate
+SPATIAL_TEST_DATABASE_URL=<disposable-postgis-url> \
+  npm --prefix server test -- --runInBand __tests__/spatialIntegration.test.js
+```
+
+Migration `029` is additive and idempotent. It repairs partial v33/v34 place
+state and damaged Unicode, then adds the v35 ancestry, identifiers, aliases, and
+featured municipalities. Do not rewrite already-applied migrations `001`–`028`.
+
+## 3. Repeat upstream dry-runs
+
+Run each new or recovered source independently. A dry-run performs discovery and
+normalization but does not write catalogue rows.
+
+```bash
+cd server
+
+for source_id in \
+  gatineau-open-data trois-rivieres-open-data repentigny-open-data \
+  longueuil-open-data saguenay-open-data rimouski-open-data \
+  shawinigan-open-data levis-open-data sherbrooke-open-data saint-john-hub \
+  regina-hub windsor-hub kingston-hub red-deer-hub kamloops-hub \
+  nanaimo-hub abbotsford-hub northwest-territories-open-data \
+  coquitlam-hub prince-george-hub new-westminster-hub port-moody-hub \
+  squamish-hub maple-ridge-hub port-coquitlam-hub \
+  sherbrooke-geomatics-open-data saint-hyacinthe-open-data
+do
+  npm run sync:source -- --source="$source_id" --dry-run
+done
+```
+
+Stop if a source has any unexplained failures, admits zero records, crosses its
+metadata failure threshold, changes publisher/licence evidence, or reports a
+suspicious count change. Expected licence and third-party exclusions are not
+failures.
+
+## 4. Production preflight
+
+Administrative SSH is key-only. Use an authorized operator key; this repository
+does not contain one and assumes no particular local key filename.
+
+```bash
+ssh -i <authorized-key> <admin-user>@38.45.71.90
+cd <production-checkout>
+
+set -euo pipefail
+CANQUERY_PREDEPLOY_SHA="$(git rev-parse HEAD)"
+printf '%s\n' "$CANQUERY_PREDEPLOY_SHA"
+git status --short
+git branch --show-current
+git remote -v
+date -u
+df -h / /var/lib/postgresql
+sudo systemctl status \
+  opencanada-api opencanada-worker opencanada-map-worker --no-pager
+psql -d opencanada -c "SELECT postgis_full_version();"
+pgrep -af 'catalog-sync|incremental-sync|sync-(municipal-sources|source)' || true
+```
+
+Take and verify the normal encrypted off-server database backup before changing
+the checkout or schema. Confirm that the target commit is reviewed and reachable
+from the production remote. Do not discard an unclean production worktree.
+
+Keep the same administrative shell open so `CANQUERY_PREDEPLOY_SHA` remains
+available for rollback. Schedule the release outside the `06:30 UTC`
+`sync-municipal-sources` cron window and do not begin while any catalogue sync is
+running. Re-run the `pgrep` immediately before the first source write. If the
+server uses a different clock or cron configuration, inspect
+`/etc/cron.d/canquery` and use its actual municipal-sync time.
+
+## 5. Install, verify, migrate, and refresh places
+
+From the production checkout:
+
+```bash
+git fetch origin
+git merge --ff-only <reviewed-release-commit>
+git rev-parse HEAD
+
+npm ci --prefix server
+npm ci --prefix client
+npm --prefix server run verify
+
+npm --prefix server run migrate
+psql -d opencanada -c \
+  "SELECT filename, applied_at FROM schema_migrations ORDER BY applied_at DESC LIMIT 5;"
+
+npm --prefix server run sync:places
+```
+
+Verify the place repair before harvesting sources:
+
+```bash
+psql -d opencanada <<'SQL'
+SELECT count(*) AS replacement_characters
+FROM places
+WHERE name_en LIKE '%' || U&'\FFFD' || '%'
+   OR name_fr LIKE '%' || U&'\FFFD' || '%';
+
+SELECT id, slug, parent_id, featured
+FROM places
+WHERE id IN (
+  'sgc-csd-5915034', 'sgc-csd-5953023', 'sgc-csd-5915029',
+  'sgc-csd-5915043', 'sgc-csd-5931006', 'sgc-csd-5915075',
+  'sgc-csd-5915039', 'sgc-csd-2454048'
+)
+ORDER BY id;
+SQL
+```
+
+The damaged-character query must return zero. The eight listed municipalities
+must have canonical slugs, parents, and `featured = true`.
+
+## 6. Activate the release code before catalogue writes
+
+The API and ingest worker must run the reviewed release before any new source
+records are written. Keep the map worker stopped so it cannot claim candidates
+while the catalogue canaries are in progress.
+
+```bash
+sudo systemctl stop opencanada-map-worker
+sudo systemctl restart opencanada-api opencanada-worker
+sudo systemctl status opencanada-api opencanada-worker --no-pager
+sudo systemctl is-inactive --quiet opencanada-map-worker
+
+curl -fsS https://canquery.com/healthz | jq -e '.ok == true'
+curl -fsS https://canquery.com/api/v1/ops | tee /tmp/canquery-v35-ops.json | jq -e '
+  .data.jobs as $jobs
+  | ([ $jobs | keys[] | select(startswith("source:")) ] | length) == 82
+    and $jobs["source:whitehorse-hub"] == null
+    and $jobs["source:st-johns-hub"] == null
+    and $jobs["source:charlottetown-hub"] == null
+'
+```
+
+Stop here if either service is unhealthy, `/healthz` is not 200, `/ops` cannot
+be constructed, the enabled-source count differs from 82, or a disabled source
+appears. No v35 catalogue rows have been written yet, so use the pre-source
+rollback in section 10.
+
+## 7. Source-scoped catalogue canaries
+
+Run one source at a time and retain its machine-readable summary. The four
+canaries deliberately cover the shared Données Québec CKAN path, the custom Red
+Deer adapter, ArcGIS Hub, and the GNWT CKAN catalogue.
+
+```bash
+cd <production-checkout>/server
+CANQUERY_RELEASE_LOG_DIR="$(mktemp -d /tmp/canquery-v35-release.XXXXXX)"
+
+run_v35_source() {
+  local source_id="$1"
+  local summary_path="$CANQUERY_RELEASE_LOG_DIR/$source_id.json"
+  node scripts/sync-source.js --source="$source_id" | tee "$summary_path"
+  jq -e --arg source_id "$source_id" '
+    .source_id == $source_id
+    and .failed == 0
+    and .included > 0
+    and (.sweep.datasetsDeleted // 0) == 0
+    and (.sweep.resourcesDeleted // 0) == 0
+  ' "$summary_path"
+}
+
+if pgrep -af 'catalog-sync|incremental-sync|sync-(municipal-sources|source)'; then
+  printf '%s\n' 'A catalogue sync is already running; stop this rollout.' >&2
+  exit 1
+fi
+
+run_v35_source saint-hyacinthe-open-data
+curl -fsS 'https://canquery.com/api/v1/datasets?place=saint-hyacinthe-qc&limit=1' \
+  | jq -e '.data | length > 0'
+
+run_v35_source red-deer-hub
+curl -fsS 'https://canquery.com/api/v1/datasets?place=red-deer-ab&limit=1' \
+  | jq -e '.data | length > 0'
+
+run_v35_source port-coquitlam-hub
+curl -fsS 'https://canquery.com/api/v1/datasets?place=port-coquitlam-bc&limit=1' \
+  | jq -e '.data | length > 0'
+
+run_v35_source northwest-territories-open-data
+curl -fsS 'https://canquery.com/api/v1/datasets?place=northwest-territories&limit=1' \
+  | jq -e '.data | length > 0'
+```
+
+Each command must exit zero. Each summary must report zero failed records, at
+least one included record, and zero swept datasets/resources. Also inspect the
+full counts, exclusion reasons, licence URLs, and map modes against the dry-run
+snapshot; the `jq` assertions do not replace operator review. Verify `/healthz`
+and `/api/v1/ops` again after all four canaries. On any discrepancy, do not run
+the remaining sources; follow the canary rollback boundary in section 10.
+
+## 8. Remaining source-scoped catalogue writes
+
+After all canaries pass, use the `run_v35_source` function from section 7 for
+the remaining 23 sources, in this order:
+
+```bash
+for source_id in \
+  gatineau-open-data trois-rivieres-open-data repentigny-open-data \
+  longueuil-open-data saguenay-open-data rimouski-open-data \
+  shawinigan-open-data levis-open-data sherbrooke-open-data saint-john-hub \
+  regina-hub windsor-hub kingston-hub kamloops-hub nanaimo-hub \
+  abbotsford-hub coquitlam-hub prince-george-hub new-westminster-hub \
+  port-moody-hub squamish-hub maple-ridge-hub \
+  sherbrooke-geomatics-open-data
+do
+  run_v35_source "$source_id"
+done
+```
+
+For every source, inspect the retained JSON summary and require zero unexplained
+failures or deletions. A deletion must have a separately reviewed upstream
+explanation before the assertion is relaxed. The per-source transaction and 10%
+maximum-delete guard are additional safety rails, not substitutes for reviewing
+the summary.
+
+Do not run the broad `sync:municipal` command for this release rollout. Keeping
+the writes source-scoped makes a regression attributable and limits rollback
+scope.
+
+## 9. Resume map processing and verify production
+
+The systemd map worker owns the advisory queue lock. Do not run `maps:drain`
+concurrently with it. After all 27 catalogue writes pass, start the service and
+let that single owner drain the queue:
+
+```bash
+sudo systemctl start opencanada-map-worker
+sudo systemctl status opencanada-map-worker --no-pager
+sudo journalctl -u opencanada-map-worker --since '10 minutes ago' --no-pager
+
+psql -d opencanada -c \
+  "SELECT status, count(*) AS jobs, coalesce(sum(feature_count), 0) AS features
+   FROM map_index_jobs GROUP BY status ORDER BY status;"
+```
+
+Continue monitoring the service journal, local disk, PostgreSQL, private-R2
+budget, and the queue counts until `pending` and `running` reach zero. Review
+every new `failed` or unexpected `skipped` job. If map processing regresses,
+follow the map-only rollback boundary in section 10; the catalogue and API can
+remain live.
+
+Run the final public checks while the queue drains and once more when it settles:
+
+```bash
+sudo systemctl status \
+  opencanada-api opencanada-worker opencanada-map-worker --no-pager
+
+curl -fsS https://canquery.com/healthz | jq -e '.ok == true'
+curl -fsS https://canquery.com/api/v1/ops | jq -e \
+  '([.data.jobs | keys[] | select(startswith("source:"))] | length) == 82'
+curl -fsS https://canquery.com/api/v1/stats | jq .
+curl -fsS 'https://canquery.com/api/v1/places?featured=true&limit=100' \
+  | tee /tmp/canquery-v35-featured-1.json \
+  | jq -e '(.data | length) == 100 and .pagination.nextCursor == "100"'
+curl -fsS 'https://canquery.com/api/v1/places?featured=true&limit=100&cursor=100' \
+  | jq -e '(.data | length) == 16 and .pagination.nextCursor == null'
+curl -fsS 'https://canquery.com/api/v1/datasets?place=coquitlam-bc&limit=1' | jq .
+curl -fsS 'https://canquery.com/api/v1/datasets?place=saint-hyacinthe-qc&limit=1' | jq .
+curl -fsS 'https://canquery.com/api/v1/datasets?place=regina-sk&limit=1' | jq .
+```
+
+`/healthz` must return 200. `/api/v1/ops` must no longer fail while constructing
+configured source jobs, must expose 82 `source:*` jobs, and must omit the three
+disabled v34 identities. A newly launched source can be `pending` until its
+first successful write; it must not be silently absent.
+
+Finally verify that scheduled jobs use the production legacy unit names, review
+the map queue for unexpected `failed` rows, and record the actual post-deployment
+catalogue/resource/place/map totals in the private technical document. Do not
+copy the dry-run counts above into production telemetry without querying the
+deployed database.
+
+## 10. Rollback boundaries
+
+Migration `029` is additive and compatible with the pre-release application, so
+leave it applied during any code rollback. Never reverse it with ad hoc SQL.
+
+### Before the first source write
+
+If the release-code smoke test in section 6 fails, no source rows have changed.
+From the clean production checkout, detach at the captured commit, restore that
+commit's dependencies/build, and restart the three services:
+
+```bash
+cd <production-checkout>
+git status --short
+git switch --detach "$CANQUERY_PREDEPLOY_SHA"
+npm ci --prefix server
+npm ci --prefix client
+npm --prefix client run build
+sudo systemctl restart \
+  opencanada-api opencanada-worker opencanada-map-worker
+curl -fsS https://canquery.com/healthz | jq .
+```
+
+Do not perform this switch with an unclean checkout. The reviewed branch remains
+unchanged; after diagnosis, an operator can return the checkout to the repaired
+release commit explicitly.
+
+### During canaries or remaining catalogue writes
+
+Stop immediately and do not invoke any later source. Keep
+`opencanada-map-worker` stopped. A failed source transaction rolls back its own
+catalogue changes; successful earlier source-scoped writes are additive and
+should remain in place. Do not delete them as a blanket rollback. Preserve the
+JSON summaries and service logs, diagnose the offending source, and resume only
+after a reviewed fix and a fresh dry-run.
+
+### During map processing
+
+Stop only the map worker:
+
+```bash
+sudo systemctl stop opencanada-map-worker
+sudo systemctl status opencanada-api opencanada-worker --no-pager
+psql -d opencanada -c \
+  "SELECT status, count(*) FROM map_index_jobs GROUP BY status ORDER BY status;"
+```
+
+Keep the API and successfully written catalogue live. The queue is durable; fix
+the map regression, review `running`, `pending`, `failed`, and `skipped` rows,
+then restart exactly one systemd map worker. Do not launch `maps:drain` alongside
+the service.

--- a/server/__tests__/arcgisHubAdapter.test.js
+++ b/server/__tests__/arcgisHubAdapter.test.js
@@ -1,278 +1,507 @@
-const { ArcgisHubAdapter } = require('../services/arcgisHubAdapter');
-const { sources } = require('../config/catalogSources');
+const adapter = require('../services/arcgisHubAdapter');
+const { getSource } = require('../config/catalogSources');
 
-const victoriaSource = sources.find(source => source.id === 'victoria-hub');
-const halifaxSource = sources.find(source => source.id === 'halifax-hub');
-const hamiltonSource = sources.find(source => source.id === 'hamilton-hub');
+const ITEM_ID = '0123456789abcdef0123456789abcdef';
 
-const BASE_DATASET = {
-    id: 'test-dataset-1',
-    attributes: {
-        id: 'test-dataset-1',
-        name: 'Victoria Budget 2024',
-        description: 'Annual municipal operating budget dataset',
-        source: 'City of Victoria',
-        modified: 1710000000000,
-        published: 1705000000000,
-        license: 'Custom Open Data Licence',
-        recordCount: 150,
-        size: 204800,
-        format: 'Feature Service',
-        type: 'Vector',
-        spatialReference: 'EPSG:4326',
-        geometryType: 'esriGeometryPolygon',
-        tags: ['finance', 'budget', 'municipal'],
-        categories: ['Finance'],
-        owner: 'City of Victoria',
-        orgName: 'City of Victoria',
-        url: 'https://opendata.victoria.ca/datasets/test-dataset-1'
-    }
-};
+function record(overrides = {}) {
+    return {
+        identifier: 'https://www.arcgis.com/home/item.html?id=' + ITEM_ID + '&sublayer=2',
+        landingPage: 'https://city-oshawa.opendata.arcgis.com/datasets/oshawa::roads/about',
+        title: 'Roads <b>2026</b>',
+        description: '<p>Public <strong>road</strong> data.</p><script>bad()</script>',
+        publisher: { name: 'City of Oshawa' },
+        license: 'Oshawa Open Government Licence',
+        keyword: ['roads', 'transportation'],
+        spatial: '-79,43.8,-78.7,44',
+        modified: '2026-08-01T00:00:00Z',
+        distribution: [{
+            format: 'ArcGIS GeoServices REST API',
+            accessURL: 'https://services.arcgis.com/example/FeatureServer/2'
+        }],
+        ...overrides
+    };
+}
 
-describe('ArcgisHubAdapter', () => {
-    let adapter;
-
-    beforeEach(() => {
-        adapter = new ArcgisHubAdapter(victoriaSource);
-    });
-
-    test('normalizes a basic ArcGIS Hub dataset into standard CanQuery format', () => {
-        const normalized = adapter.normalizeDataset(BASE_DATASET);
-
-        expect(normalized).not.toBeNull();
-        expect(normalized.id).toBe('test-dataset-1');
-        expect(normalized.titleEn).toBe('Victoria Budget 2024');
-        expect(normalized.titleFr).toBeNull();
-        expect(normalized.descriptionEn).toBe('Annual municipal operating budget dataset');
-        expect(normalized.descriptionFr).toBeNull();
-        expect(normalized.organizationName).toBe('City of Victoria');
-        expect(normalized.organizationTitleEn).toBe('City of Victoria');
-        expect(normalized.organizationTitleFr).toBeNull();
-        expect(normalized.licenseTitleEn).toBe('City of Victoria Open Data Licence');
-        expect(normalized.licenseUrl).toBe('https://opendata.victoria.ca/pages/open-data-licence');
-        expect(normalized.sourceId).toBe('victoria-hub');
-        expect(normalized.catalogUrl).toBe('https://opendata.victoria.ca/datasets/test-dataset-1');
-        expect(normalized.tags).toEqual(['finance', 'budget', 'municipal']);
-        expect(normalized.categories).toEqual(['Finance']);
-        expect(normalized.placeAssignments).toEqual([{
-            placeId: 'sgc-csd-5917034',
-            relationship: 'direct'
-        }]);
-    });
-
-    test('drops datasets published by unconfigured third parties', () => {
-        const dataset = {
-            ...BASE_DATASET,
-            attributes: {
-                ...BASE_DATASET.attributes,
-                source: 'External Contributor',
-                owner: 'External Contributor',
-                orgName: 'External Contributor'
+describe('ArcGIS Hub adapter', () => {
+    test('normalizes a spatial leaf into a loadable snapshot, place link and live map', async () => {
+        const fetchJson = jest.fn(async url => {
+            if (url.includes('/sharing/rest/content/items/')) {
+                return { owner: 'OshawaGIS', type: 'Feature Service', size: 1234, tags: ['roads'] };
             }
-        };
-
-        const normalized = adapter.normalizeDataset(dataset);
-        expect(normalized).toBeNull();
-    });
-
-    test('drops datasets that match explicit non-open licence patterns', () => {
-        const dataset = {
-            ...BASE_DATASET,
-            attributes: {
-                ...BASE_DATASET.attributes,
-                license: 'For educational and non-commercial research use only'
-            }
-        };
-
-        const normalized = adapter.normalizeDataset(dataset);
-        expect(normalized).toBeNull();
-    });
-
-    test('resolves Halifax datasets with authoritative publisher variants', () => {
-        const halifaxAdapter = new ArcgisHubAdapter(halifaxSource);
-        const dataset = {
-            id: 'halifax-transit-routes',
-            attributes: {
-                id: 'halifax-transit-routes',
-                name: 'Transit Routes',
-                description: 'Halifax transit bus route network',
-                source: 'Halifax Regional Municipality',
-                modified: 1710000000000,
-                published: 1705000000000,
-                license: 'Open Data Licence',
-                recordCount: 50,
-                size: 102400,
-                format: 'Feature Service',
-                type: 'Vector',
-                spatialReference: 'EPSG:4326',
+            return {
+                type: 'Feature Layer',
                 geometryType: 'esriGeometryPolyline',
-                tags: ['transit', 'bus', 'transportation'],
-                categories: ['Transportation'],
-                owner: 'HRM Open Data',
-                orgName: 'Halifax Regional Municipality',
-                url: 'https://data-hrm.hub.arcgis.com/datasets/halifax-transit-routes'
+                objectIdField: 'OBJECTID',
+                displayField: 'ROAD_NAME',
+                maxRecordCount: 2000,
+                extent: { xmin: -79, ymin: 43.8, xmax: -78.7, ymax: 44, spatialReference: { wkid: 4326 } },
+                fields: [
+                    { name: 'OBJECTID', alias: 'Object ID', type: 'esriFieldTypeOID' },
+                    { name: 'ROAD_NAME', alias: 'Road name', type: 'esriFieldTypeString' }
+                ]
+            };
+        });
+
+        const result = await adapter.enrichRecord(record(), getSource('oshawa-hub'), { fetchJson });
+
+        expect(result.status).toBe('included');
+        expect(result.value.externalId).toBe(ITEM_ID + ':2');
+        expect(result.value.dataset.id).toBe('arcgis-' + ITEM_ID + '-2');
+        expect(result.value.dataset.notesEn).toBe('Public road data.');
+        expect(result.value.resource).toEqual(expect.objectContaining({
+            format: 'CSV',
+            url: 'https://hub.arcgis.com/api/download/v1/items/' + ITEM_ID + '/csv?layers=2'
+        }));
+        expect(result.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'ca-on-oshawa', relationship: 'direct', includesDescendants: false
+        }));
+        expect(result.value.map).toEqual(expect.objectContaining({
+            geometryType: 'polyline', serviceUrl: 'https://services.arcgis.com/example/FeatureServer/2'
+        }));
+        expect(result.value.source.licenseUrl).toMatch(/Oshawa\.pdf$/);
+        expect(result.value.source.isAuthoritative).toBe(true);
+        expect(result.value.organization).toEqual(expect.objectContaining({
+            id: 'arcgis-publisher-city-of-oshawa',
+            titleEn: 'City of Oshawa'
+        }));
+    });
+
+    test('canonicalizes a placeholder Pickering publisher from the ArcGIS owner', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'OpenData_CityofPickering', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+        const result = await adapter.enrichRecord(record({
+            landingPage: 'https://opendata.pickering.ca/datasets/pickering::wards/about',
+            publisher: { name: '{{source}}' },
+            license: 'https://www.pickering.ca/media/depbgebg/opendatalicencepickeringv1_acc.pdf'
+        }), getSource('pickering-hub'), { fetchJson });
+
+        expect(result.status).toBe('included');
+        expect(result.value.organization).toEqual(expect.objectContaining({
+            id: 'arcgis-publisher-city-of-pickering',
+            titleEn: 'City of Pickering'
+        }));
+        expect(result.value.places[0].placeId).toBe('sgc-csd-3518001');
+        expect(result.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            raw: expect.objectContaining({ publisher: 'City of Pickering', supplied_publisher: null })
+        }));
+    });
+
+    test('admits only records carrying Whitby open-licence evidence', async () => {
+        const allowedFetch = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? {
+                owner: 'TownofWhitby',
+                type: 'Feature Service',
+                licenseInfo: '<a href="https://whitby.maps.arcgis.com/sharing/rest/content/items/223810efc31c40b3aff99dd74f809a97/data">Open Government Licence</a>'
             }
-        };
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const whitbyRecord = record({
+            landingPage: 'https://geohub-whitby.hub.arcgis.com/datasets/whitby::parks/about',
+            publisher: { name: 'Town of Whitby' },
+            license: 'Custom License'
+        });
+        const allowed = await adapter.enrichRecord(whitbyRecord, getSource('whitby-hub'), { fetchJson: allowedFetch });
+        expect(allowed.status).toBe('included');
+        expect(allowed.value.places[0].placeId).toBe('sgc-csd-3518009');
 
-        const normalized = halifaxAdapter.normalizeDataset(dataset);
-        expect(normalized).not.toBeNull();
-        expect(normalized.organizationName).toBe('Halifax Regional Municipality');
-        expect(normalized.licenseTitleEn).toBe('Halifax Open Data Licence');
-        expect(normalized.licenseUrl).toBe('https://data-hrm.hub.arcgis.com/pages/licence');
-        expect(normalized.placeAssignments).toEqual([{
-            placeId: 'sgc-csd-1209034',
-            relationship: 'direct'
-        }]);
+        const restrictedFetch = jest.fn(async () => ({
+            owner: 'TownofWhitby', type: 'Feature Service',
+            licenseInfo: 'Permitted for personal, non-commercial purposes only.'
+        }));
+        const restricted = await adapter.enrichRecord(whitbyRecord, getSource('whitby-hub'), { fetchJson: restrictedFetch });
+        expect(restricted).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+        expect(restrictedFetch).toHaveBeenCalledTimes(1);
+
+        const missingFetch = jest.fn(async () => ({ owner: 'TownofWhitby', type: 'Feature Service' }));
+        const missing = await adapter.enrichRecord(whitbyRecord, getSource('whitby-hub'), { fetchJson: missingFetch });
+        expect(missing).toEqual({ status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2' });
+        expect(missingFetch).toHaveBeenCalledTimes(1);
     });
 
-    test('drops datasets missing both title and ID', () => {
-        const dataset = {
-            attributes: {
-                description: 'A dataset without a title or id'
+    test('marks mirrored Durham records non-authoritative and the regional copy authoritative', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'DurhamRegion', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
+        const durhamRecord = record({
+            publisher: { name: 'Regional Municipality of Durham' },
+            license: 'Region of Durham Open Data Licence v1.0'
+        });
+        const mirror = await adapter.enrichRecord(durhamRecord, getSource('pickering-hub'), { fetchJson });
+        const original = await adapter.enrichRecord(durhamRecord, getSource('durham-hub'), { fetchJson });
+
+        expect(mirror.value.source.isAuthoritative).toBe(false);
+        expect(mirror.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'ca-on-durham', relationship: 'coverage', includesDescendants: true
+        }));
+        expect(original.value.source.isAuthoritative).toBe(true);
+        expect(original.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'ca-on-durham', relationship: 'direct', includesDescendants: true
+        }));
+    });
+
+    test('applies Mississauga portal terms while preserving explicit Statistics Canada licensing', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'Mississauga', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+        const source = getSource('mississauga-hub');
+        const cityRecord = record({
+            landingPage: 'https://data.mississauga.ca/datasets/mississauga::wards',
+            publisher: { name: 'City Of Mississauga' },
+            license: null
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+        expect(city.status).toBe('included');
+        expect(city.value.places[0].placeId).toBe('sgc-csd-3521005');
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseUrl: 'https://www.mississauga.ca/file/COM/CityOfMississaugaTermsOfUse.pdf'
+        }));
+
+        const census = await adapter.enrichRecord({
+            ...cityRecord,
+            license: 'https://www.statcan.gc.ca/en/reference/licence'
+        }, source, { fetchJson });
+        expect(census.value.source.licenseUrl).toBe('https://www.statcan.gc.ca/en/reference/licence');
+    });
+
+    test('applies Ottawa portal terms while preserving explicit Police licensing', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'open.ouvert@ottawa.ca', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const source = getSource('ottawa-hub');
+        const cityRecord = record({
+            landingPage: 'https://open.ottawa.ca/datasets/ottawa::parks',
+            publisher: { name: 'City of Ottawa' },
+            license: null
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+        expect(city.status).toBe('included');
+        expect(city.value.places[0].placeId).toBe('sgc-cd-3506');
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseUrl: expect.stringContaining('/open-data-licence-version-20')
+        }));
+
+        const police = await adapter.enrichRecord({
+            ...cityRecord,
+            title: 'Ottawa Police Service Neighbourhoods',
+            license: 'https://data.ottawapolice.ca/pages/open-data-licence'
+        }, source, { fetchJson });
+        expect(police.value.source).toEqual(expect.objectContaining({
+            licenseTitleEn: 'Open Government Licence – Ottawa Police Service',
+            licenseUrl: 'https://data.ottawapolice.ca/pages/open-data-licence'
+        }));
+
+        const placeholderFetch = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'ExternalPublisher', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const placeholder = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: '{{source}}' }
+        }, source, { fetchJson: placeholderFetch });
+        expect(placeholder).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+    });
+
+    test('applies Halifax portal terms only to exact HRM publisher evidence', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'opendata_HRM', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+        const source = getSource('halifax-hub');
+        const cityRecord = record({
+            landingPage: 'https://data-hrm.hub.arcgis.com/datasets/HRM::parks',
+            publisher: { name: 'Halifax Regional Municipality' },
+            license: null
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+
+        expect(city.status).toBe('included');
+        expect(city.value.organization.titleEn).toBe('Halifax Regional Municipality');
+        expect(city.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-1209034', relationship: 'direct', includesDescendants: false
+        }));
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'Open Government Licence – Halifax',
+            licenseUrl: 'https://data-hrm.hub.arcgis.com/pages/open-data-licence'
+        }));
+
+        const restricted = await adapter.enrichRecord({
+            ...cityRecord,
+            license: 'Reproduction is permitted for non-commercial use only.'
+        }, source, { fetchJson });
+        expect(restricted).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+
+        const externalFetch = jest.fn(async () => ({ owner: 'ExternalPublisher', type: 'Feature Service' }));
+        const placeholder = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: '{{source}}' }
+        }, source, { fetchJson: externalFetch });
+        expect(placeholder).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+        expect(externalFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('admits only allowlisted Hamilton City department publishers', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'Hamilton_Open_Data', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
+        const source = getSource('hamilton-hub');
+        const cityRecord = record({
+            landingPage: 'https://open.hamilton.ca/datasets/SpatialSolutions::roads',
+            publisher: { name: 'City of Hamilton;Public Works;Hamilton Water' },
+            license: null
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+
+        expect(city.status).toBe('included');
+        expect(city.value.organization.titleEn).toBe('City of Hamilton');
+        expect(city.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3525', relationship: 'direct', includesDescendants: false
+        }));
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'City of Hamilton Open Data Licence',
+            licenseUrl: expect.stringContaining('/open-data-licence-terms-and-conditions'),
+            attributionEn: 'Contains public sector Data made available under the City of Hamilton’s Open Data Licence'
+        }));
+
+        const restricted = await adapter.enrichRecord({
+            ...cityRecord,
+            license: 'Available for personal, non-commercial use only.'
+        }, source, { fetchJson });
+        expect(restricted).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+
+        const unfamiliar = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: 'City of Hamilton;External Partner' }
+        }, source, { fetchJson });
+        expect(unfamiliar).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+
+        const placeholderFetch = jest.fn(async () => ({
+            owner: 'ExternalPublisher', type: 'Feature Service'
+        }));
+        const placeholder = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: '{{source}}' }
+        }, source, { fetchJson: placeholderFetch });
+        expect(placeholder).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+        expect(placeholderFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('applies Surrey portal terms only to exact City publisher evidence', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'SurreyGIS', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const source = getSource('surrey-hub');
+        const cityRecord = record({
+            landingPage: 'https://opendata-surrey.hub.arcgis.com/datasets/surrey::public-art',
+            publisher: { name: 'City of Surrey' },
+            license: '<p>Constraints go here</p>'
+        });
+        const city = await adapter.enrichRecord(cityRecord, source, { fetchJson });
+
+        expect(city.status).toBe('included');
+        expect(city.value.organization.titleEn).toBe('City of Surrey');
+        expect(city.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-5915004', relationship: 'direct', includesDescendants: false
+        }));
+        expect(city.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseTitleEn: 'Open Government License – Surrey',
+            licenseUrl: expect.stringContaining('/pages/55089a19491a4fe59a41e059fd8af708'),
+            attributionEn: 'Contains information licensed under the Open Government License – City of Surrey.'
+        }));
+
+        const restricted = await adapter.enrichRecord({
+            ...cityRecord,
+            license: 'Available for personal, non-commercial use only.'
+        }, source, { fetchJson });
+        expect(restricted).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+
+        const external = await adapter.enrichRecord({
+            ...cityRecord,
+            publisher: { name: 'Ministry of Education' },
+            license: null
+        }, source, { fetchJson });
+        expect(external).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+    });
+
+    test('admits only explicit Brampton CC BY or Statistics Canada records', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'Brampton', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPoint', fields: [] });
+        const source = getSource('brampton-hub');
+        const bramptonRecord = record({
+            landingPage: 'https://geohub.brampton.ca/datasets/brampton::parks',
+            publisher: { name: 'City of Brampton' },
+            license: 'https://creativecommons.org/licenses/by/4.0'
+        });
+        const allowed = await adapter.enrichRecord(bramptonRecord, source, { fetchJson });
+        expect(allowed.status).toBe('included');
+        expect(allowed.value.places[0].placeId).toBe('sgc-csd-3521010');
+        expect(allowed.value.source.licenseUrl).toBe('https://creativecommons.org/licenses/by/4.0/');
+
+        const missing = await adapter.enrichRecord({ ...bramptonRecord, license: null }, source, { fetchJson });
+        expect(missing).toEqual({ status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2' });
+
+        const restricted = await adapter.enrichRecord({
+            ...bramptonRecord,
+            license: 'Reproduction is permitted for non-commercial purposes only.'
+        }, source, { fetchJson });
+        expect(restricted).toEqual({ status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2' });
+    });
+
+    test('uses recognized Peel licences and keeps regional third-party records non-authoritative', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'RegionOfPeel', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
+        const source = getSource('peel-hub');
+        const peelRecord = record({
+            landingPage: 'https://data.peelregion.ca/datasets/RegionofPeel::roads',
+            publisher: { name: 'Region of Peel - Corporate Services' },
+            license: 'https://data.peelregion.ca/pages/license'
+        });
+        const regional = await adapter.enrichRecord(peelRecord, source, { fetchJson });
+        expect(regional.status).toBe('included');
+        expect(regional.value.organization.titleEn).toBe('Regional Municipality of Peel');
+        expect(regional.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-cd-3521', relationship: 'direct', includesDescendants: true
+        }));
+        expect(regional.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true, licenseUrl: 'https://data.peelregion.ca/pages/license'
+        }));
+
+        const census = await adapter.enrichRecord({
+            ...peelRecord,
+            publisher: { name: 'Statistics Canada' },
+            license: 'Statistics Canada Open License'
+        }, source, { fetchJson });
+        expect(census.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: false,
+            licenseUrl: 'https://www.statcan.gc.ca/en/reference/licence'
+        }));
+
+        const custom = await adapter.enrichRecord({
+            ...peelRecord,
+            publisher: { name: 'Canada Mortgage and Housing Corporation' },
+            license: 'https://www.cmhc-schl.gc.ca/en/data-and-research/cmhc-licence-agreement-use-of-data'
+        }, source, { fetchJson });
+        expect(custom).toEqual({ status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2' });
+
+        const websiteTerms = await adapter.enrichRecord({
+            ...peelRecord,
+            license: 'https://www.peelregion.ca/privacy/terms-of-use.asp'
+        }, source, { fetchJson });
+        expect(websiteTerms).toEqual({ status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2' });
+    });
+
+    test('rejects group layers instead of presenting them as downloadable tables', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'OshawaGIS', type: 'Feature Service' }
+            : { type: 'Group Layer' });
+        const result = await adapter.enrichRecord(record(), getSource('oshawa-hub'), { fetchJson });
+        expect(result).toEqual({ status: 'excluded', reason: 'non-leaf-layer', externalId: ITEM_ID + ':2' });
+    });
+
+    test('trusts placeholder publishers only on the exact configured HTTPS catalogue host', async () => {
+        const source = getSource('coquitlam-hub');
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'UnexpectedArcgisOwner', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolygon', fields: [] });
+        const placeholderRecord = record({
+            landingPage: 'https://data.coquitlam.ca/datasets/coquitlam::parks',
+            publisher: { name: '{{source}}' },
+            license: null
+        });
+
+        const trusted = await adapter.enrichRecord(placeholderRecord, source, { fetchJson });
+        expect(trusted.status).toBe('included');
+        expect(trusted.value.organization.titleEn).toBe('City of Coquitlam');
+        expect(trusted.value.source.raw).toEqual(expect.objectContaining({
+            publisher: 'City of Coquitlam', supplied_publisher: null
+        }));
+
+        const wrongHost = await adapter.enrichRecord(placeholderRecord, {
+            ...source,
+            catalogUrl: 'https://mirror.example/api/feed/dcat-us/1.1.json'
+        }, { fetchJson });
+        expect(wrongHost).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+    });
+
+    test('rejects v35 third-party and explicitly restricted ArcGIS records', async () => {
+        const fetchJson = jest.fn(async url => url.includes('/sharing/rest/content/items/')
+            ? { owner: 'MunicipalGIS', type: 'Feature Service' }
+            : { type: 'Feature Layer', geometryType: 'esriGeometryPolyline', fields: [] });
+
+        const mapleRidge = await adapter.enrichRecord(record({
+            publisher: { name: 'City of Maple Ridge' },
+            license: 'This record is governed by the TransLink terms of use.'
+        }), getSource('maple-ridge-hub'), { fetchJson });
+        expect(mapleRidge).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+
+        const poco = await adapter.enrichRecord(record({
+            publisher: { name: 'City of Port Coquitlam' },
+            license: 'PoCoMap is available for internal business and personal purpose only.'
+        }), getSource('port-coquitlam-hub'), { fetchJson });
+        expect(poco).toEqual({
+            status: 'excluded', reason: 'restricted-license', externalId: ITEM_ID + ':2'
+        });
+
+        const thirdParty = await adapter.enrichRecord(record({
+            publisher: { name: 'Metro Vancouver' },
+            license: null
+        }), getSource('new-westminster-hub'), { fetchJson });
+        expect(thirdParty).toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: ITEM_ID + ':2'
+        });
+    });
+
+    test('excludes configured unavailable ArcGIS service families without fetching their metadata', async () => {
+        const fetchJson = jest.fn(async url => {
+            if (url.includes('/sharing/rest/content/items/')) {
+                return { owner: 'CityOfAbbotsford', type: 'Feature Service' };
             }
-        };
-
-        const normalized = adapter.normalizeDataset(dataset);
-        expect(normalized).toBeNull();
-    });
-
-    test('synthesizes CSV and GeoJSON resource downloads from Hub feature services', () => {
-        const dataset = {
-            ...BASE_DATASET,
-            attributes: {
-                ...BASE_DATASET.attributes,
-                url: 'https://opendata.victoria.ca/datasets/test-dataset-1'
-            }
-        };
-
-        const normalized = adapter.normalizeDataset(dataset);
-        expect(normalized).not.toBeNull();
-        expect(normalized.resources.length).toBeGreaterThan(0);
-
-        const csvResource = normalized.resources.find(r => r.format === 'csv');
-        expect(csvResource).toBeDefined();
-        expect(csvResource.id).toBe('test-dataset-1-csv');
-        expect(csvResource.url).toBe('https://opendata.victoria.ca/datasets/test-dataset-1.csv');
-
-        const geojsonResource = normalized.resources.find(r => r.format === 'geojson');
-        expect(geojsonResource).toBeDefined();
-        expect(geojsonResource.id).toBe('test-dataset-1-geojson');
-        expect(geojsonResource.url).toBe('https://opendata.victoria.ca/datasets/test-dataset-1.geojson');
-    });
-
-    test('preserves explicit distributions provided by DCAT-US 1.1 feed', () => {
-        const dcatDataset = {
-            identifier: 'dcat-dataset-1',
-            title: 'Victoria Park Trees',
-            description: 'Inventory of public trees in Victoria parks',
-            publisher: {
-                name: 'City of Victoria'
-            },
-            modified: '2024-03-01T00:00:00.000Z',
-            issued: '2024-01-15T00:00:00.000Z',
-            license: 'https://opendata.victoria.ca/pages/open-data-licence',
-            keyword: ['parks', 'trees', 'urban-forestry'],
-            theme: ['Environment'],
-            distribution: [
-                {
-                    title: 'CSV',
-                    format: 'CSV',
-                    mediaType: 'text/csv',
-                    downloadURL: 'https://opendata.victoria.ca/datasets/dcat-dataset-1_0.csv',
-                    accessURL: 'https://opendata.victoria.ca/datasets/dcat-dataset-1'
-                },
-                {
-                    title: 'GeoJSON',
-                    format: 'GeoJSON',
-                    mediaType: 'application/geo+json',
-                    downloadURL: 'https://opendata.victoria.ca/datasets/dcat-dataset-1_0.geojson',
-                    accessURL: 'https://opendata.victoria.ca/datasets/dcat-dataset-1'
-                },
-                {
-                    title: 'Shapefile',
-                    format: 'ZIP',
-                    mediaType: 'application/zip',
-                    downloadURL: 'https://opendata.victoria.ca/datasets/dcat-dataset-1_0.zip',
-                    accessURL: 'https://opendata.victoria.ca/datasets/dcat-dataset-1'
-                }
-            ]
-        };
-
-        const normalized = adapter.normalizeDcatUsDataset(dcatDataset);
-        expect(normalized).not.toBeNull();
-        expect(normalized.id).toBe('dcat-dataset-1');
-        expect(normalized.titleEn).toBe('Victoria Park Trees');
-        expect(normalized.resources).toHaveLength(3);
-        expect(normalized.resources.map(r => r.format)).toEqual(['csv', 'geojson', 'zip']);
-        expect(normalized.placeAssignments).toEqual([{
-            placeId: 'sgc-csd-5917034',
-            relationship: 'direct'
-        }]);
-    });
-
-    test('drops DCAT-US datasets published by unconfigured organizations', () => {
-        const dcatDataset = {
-            identifier: 'external-dataset-1',
-            title: 'External Third Party Data',
-            description: 'Data from an unknown entity',
-            publisher: {
-                name: 'Unknown Regional Board'
-            },
+            throw new Error('unavailable service metadata should not be fetched');
+        });
+        const result = await adapter.enrichRecord(record({
+            publisher: { name: 'City of Abbotsford' },
+            license: null,
             distribution: [{
-                title: 'CSV',
-                format: 'CSV',
-                downloadURL: 'https://example.com/data.csv'
+                format: 'ArcGIS GeoServices REST API',
+                accessURL: 'https://maps.abbotsford.ca/arcgis/rest/services/GeocortexExt/Public/MapServer/2'
             }]
-        };
+        }), getSource('abbotsford-hub'), { fetchJson });
 
-        const normalized = adapter.normalizeDcatUsDataset(dcatDataset);
-        expect(normalized).toBeNull();
+        expect(result).toEqual({
+            status: 'excluded', reason: 'unavailable-service', externalId: ITEM_ID + ':2'
+        });
+        expect(fetchJson).toHaveBeenCalledTimes(1);
     });
 
-    test('drops DCAT-US datasets with restrictive non-commercial terms', () => {
-        const dcatDataset = {
-            identifier: 'restricted-dataset-1',
-            title: 'Research Survey Data',
-            description: 'Restricted dataset',
-            publisher: {
-                name: 'City of Victoria'
-            },
-            license: 'Restricted – Personal and Non-Commercial Research Only',
-            distribution: [{
-                title: 'CSV',
-                format: 'CSV',
-                downloadURL: 'https://opendata.victoria.ca/datasets/survey.csv'
-            }]
-        };
-
-        const normalized = adapter.normalizeDcatUsDataset(dcatDataset);
-        expect(normalized).toBeNull();
-    });
-
-    test('resolves Hamilton datasets and assigns City of Hamilton Open Data Licence', () => {
-        const hamiltonAdapter = new ArcgisHubAdapter(hamiltonSource);
-        const dataset = {
-            identifier: 'hamilton-bikeways',
-            title: 'Hamilton Bikeways and Multi-Use Trails',
-            description: 'Designated bicycle paths and multi-use trails across the city',
-            publisher: {
-                name: 'City of Hamilton'
-            },
-            distribution: [{
-                title: 'CSV',
-                format: 'CSV',
-                downloadURL: 'https://open.hamilton.ca/datasets/hamilton-bikeways.csv'
-            }]
-        };
-
-        const normalized = hamiltonAdapter.normalizeDcatUsDataset(dataset);
-        expect(normalized).not.toBeNull();
-        expect(normalized.organizationName).toBe('City of Hamilton');
-        expect(normalized.licenseTitleEn).toBe('City of Hamilton Open Data Licence');
-        expect(normalized.licenseUrl).toBe('https://open.hamilton.ca/pages/licence');
-        expect(normalized.placeAssignments).toEqual([{
-            placeId: 'sgc-cd-3525',
-            relationship: 'direct'
-        }]);
+    test('extracts canonical item/layer identities and strips unsafe markup', () => {
+        expect(adapter.identityFor(record())).toEqual({ itemId: ITEM_ID, layerId: 2 });
+        expect(adapter.htmlToText('<p>A &amp; B</p><style>x</style><script>y</script>')).toBe('A & B');
     });
 });

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -3,11 +3,7 @@ const { sources, getSource } = require('../config/catalogSources');
 describe('configured municipal catalogue sources', () => {
     test('syncs city portals before the authoritative portal in each regional cluster', () => {
         expect(sources.map(source => source.id)).toEqual([
-            'toronto-open-data', 'montreal-open-data', 'quebec-city-open-data',
-            'gatineau-open-data', 'trois-rivieres-open-data', 'repentigny-open-data',
-            'longueuil-open-data', 'saguenay-open-data', 'rimouski-open-data',
-            'shawinigan-open-data', 'levis-open-data', 'sherbrooke-open-data',
-            'laval-open-data',
+            'toronto-open-data', 'montreal-open-data', 'quebec-city-open-data', 'laval-open-data',
             'ottawa-hub', 'vancouver-open-data',
             'calgary-open-data', 'edmonton-open-data', 'winnipeg-open-data', 'halifax-hub',
             'hamilton-hub', 'surrey-hub',
@@ -21,11 +17,30 @@ describe('configured municipal catalogue sources', () => {
             'summerland-hub', 'norfolk-hub', 'haldimand-hub',
             'lethbridge-hub', 'medicine-hat-hub', 'airdrie-hub', 'canmore-hub',
             'penticton-hub', 'langley-city-hub', 'huron-hub', 'cumberland-hub',
-            'saint-john-hub',
+            'gatineau-open-data', 'trois-rivieres-open-data', 'repentigny-open-data',
+            'longueuil-open-data', 'saguenay-open-data', 'rimouski-open-data',
+            'shawinigan-open-data', 'levis-open-data', 'sherbrooke-open-data', 'saint-john-hub',
             'whitehorse-hub', 'st-johns-hub', 'charlottetown-hub', 'regina-hub',
             'windsor-hub', 'kingston-hub', 'red-deer-hub', 'kamloops-hub',
-            'nanaimo-hub', 'abbotsford-hub'
+            'nanaimo-hub', 'abbotsford-hub',
+            'northwest-territories-open-data', 'coquitlam-hub', 'prince-george-hub',
+            'new-westminster-hub', 'port-moody-hub', 'squamish-hub', 'maple-ridge-hub',
+            'port-coquitlam-hub', 'sherbrooke-geomatics-open-data', 'saint-hyacinthe-open-data'
         ]);
+    });
+
+    test('keeps every source identity unique and every enabled catalogue on its exact HTTPS host', () => {
+        expect(sources).toHaveLength(85);
+        expect(new Set(sources.map(source => source.id))).toHaveProperty('size', 85);
+        expect(sources.filter(source => source.enabled)).toHaveLength(82);
+
+        for (const source of sources.filter(source => source.enabled)) {
+            const catalog = new URL(source.catalogUrl);
+            expect(catalog.protocol).toBe('https:');
+            expect(catalog.hostname).toBe(source.upstreamHost);
+            expect(source.syncIntervalHours).toBe(24);
+            expect(source.maxDeleteFraction).toBeLessThanOrEqual(0.1);
+        }
     });
 
     test('configures Victoria as an exact-publisher ArcGIS source under its portal licence', () => {
@@ -61,8 +76,8 @@ describe('configured municipal catalogue sources', () => {
         expect(waterloo.placeRules).toEqual(expect.arrayContaining([
             expect.objectContaining({ placeId: 'sgc-cd-3530', relationship: 'direct', includesDescendants: true }),
             expect.objectContaining({ placeId: 'sgc-csd-3530013', relationship: 'direct', includesDescendants: false }),
-            expect.objectContaining({ placeId: 'sgc-csd-3530016', relationship: 'direct', includesDescendants: false }),
-            expect.objectContaining({ placeId: 'sgc-csd-3530010', relationship: 'direct', includesDescendants: false })
+            expect.objectContaining({ placeId: 'sgc-csd-3530010', relationship: 'direct', includesDescendants: false }),
+            expect.objectContaining({ placeId: 'sgc-csd-3530016', relationship: 'direct', includesDescendants: false })
         ]));
     });
 
@@ -72,11 +87,15 @@ describe('configured municipal catalogue sources', () => {
             kind: 'arcgis-hub', upstreamHost: 'open-london.opendata.arcgis.com',
             catalogUrl: 'https://open-london.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
         }));
-        expect(london.publisherAliases).toEqual(expect.arrayContaining([
-            expect.objectContaining({ name: 'City of London' })
-        ]));
+        expect(london.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://open.london.ca/pages/open-data-licence'
+            })
+        })]);
         expect(london.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-3539036', relationship: 'direct', includesDescendants: false
+            placeId: 'sgc-csd-3539036', relationship: 'direct',
+            includesDescendants: false
         })]);
     });
 
@@ -86,8 +105,15 @@ describe('configured municipal catalogue sources', () => {
             kind: 'arcgis-hub', upstreamHost: 'opendata.kelowna.ca',
             catalogUrl: 'https://opendata.kelowna.ca/api/feed/dcat-us/1.1.json'
         }));
+        expect(kelowna.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                titleEn: 'Open Government Licence – City of Kelowna'
+            })
+        })]);
         expect(kelowna.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-5935010', relationship: 'direct', includesDescendants: false
+            placeId: 'sgc-csd-5935010', relationship: 'direct',
+            includesDescendants: false
         })]);
     });
 
@@ -97,10 +123,18 @@ describe('configured municipal catalogue sources', () => {
             kind: 'arcgis-hub', upstreamHost: 'data-fredericton.opendata.arcgis.com',
             catalogUrl: 'https://data-fredericton.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
         }));
+        expect(fredericton.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://data-fredericton.opendata.arcgis.com/pages/open-data-licence'
+            })
+        })]);
         expect(fredericton.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-1310032', relationship: 'direct', includesDescendants: false
+            placeId: 'sgc-csd-1310032', relationship: 'direct',
+            includesDescendants: false
         })]);
     });
+
 
     test('configures Halifax as an exact-publisher ArcGIS source under its portal licence', () => {
         const halifax = getSource('halifax-hub');
@@ -108,8 +142,18 @@ describe('configured municipal catalogue sources', () => {
             kind: 'arcgis-hub', upstreamHost: 'data-hrm.hub.arcgis.com',
             catalogUrl: 'https://data-hrm.hub.arcgis.com/api/feed/dcat-us/1.1.json'
         }));
+        expect(halifax.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
+        ]));
+        expect(halifax.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://data-hrm.hub.arcgis.com/pages/open-data-licence'
+            })
+        })]);
         expect(halifax.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-1209034', relationship: 'direct', includesDescendants: false
+            placeId: 'sgc-csd-1209034', relationship: 'direct',
+            includesDescendants: false
         })]);
     });
 
@@ -117,22 +161,52 @@ describe('configured municipal catalogue sources', () => {
         const calgary = getSource('calgary-open-data');
         expect(calgary).toEqual(expect.objectContaining({
             kind: 'socrata', upstreamHost: 'data.calgary.ca',
-            catalogUrl: 'https://data.calgary.ca/api/catalog/v1'
+            placeId: 'sgc-csd-4806016',
+            defaultLicenseUrl: expect.stringContaining('Open-Calgary-Terms-of-Use')
         }));
-        expect(calgary.placeId).toBe('sgc-csd-4806016');
+        expect(calgary.socrataPolicy).toEqual({
+            publisher: expect.objectContaining({
+                mode: 'custom-field', allowed: ['The City of Calgary']
+            }),
+            license: expect.objectContaining({
+                mode: 'custom-field', comparison: 'url',
+                allowed: expect.arrayContaining([expect.stringContaining('Open-Data-Terms')])
+            })
+        });
     });
 
     test('configures Edmonton and Winnipeg with independent fail-closed Socrata policies', () => {
         const edmonton = getSource('edmonton-open-data');
         const winnipeg = getSource('winnipeg-open-data');
+
         expect(edmonton).toEqual(expect.objectContaining({
-            kind: 'socrata', upstreamHost: 'data.edmonton.ca'
+            kind: 'socrata', upstreamHost: 'data.edmonton.ca',
+            placeId: 'sgc-csd-4811061',
+            defaultLicenseUrl: expect.stringContaining('City-of-Edmonton-Open-Data-Terms-of-Use')
         }));
+        expect(edmonton.socrataPolicy).toEqual({
+            publisher: expect.objectContaining({
+                mode: 'attribution',
+                allowed: ['City of Edmonton', 'The City of Edmonton']
+            }),
+            license: expect.objectContaining({
+                mode: 'view-license-name', allowed: ['See Terms of Use']
+            })
+        });
+
         expect(winnipeg).toEqual(expect.objectContaining({
-            kind: 'socrata', upstreamHost: 'data.winnipeg.ca'
+            kind: 'socrata', upstreamHost: 'data.winnipeg.ca',
+            placeId: 'sgc-csd-4611040',
+            defaultLicenseUrl: 'https://data.winnipeg.ca/open-data-licence'
         }));
-        expect(edmonton.placeId).toBe('sgc-csd-4811061');
-        expect(winnipeg.placeId).toBe('sgc-csd-4611040');
+        expect(winnipeg.socrataPolicy.publisher).toEqual(expect.objectContaining({
+            mode: 'attribution', allowBlank: true,
+            allowed: expect.arrayContaining(['City of Winnipeg', 'Winnipeg Transit'])
+        }));
+        expect(winnipeg.socrataPolicy.license).toEqual(expect.objectContaining({
+            mode: 'custom-field', section: 'Licence', field: 'Licence',
+            allowed: ['Open Government Licence - Winnipeg']
+        }));
     });
 
     test('configures Hamilton as an allowlisted City publisher under its portal licence', () => {
@@ -141,32 +215,64 @@ describe('configured municipal catalogue sources', () => {
             kind: 'arcgis-hub', upstreamHost: 'open.hamilton.ca',
             catalogUrl: 'https://open.hamilton.ca/api/feed/dcat-us/1.1.json'
         }));
+        expect(hamilton.publisherAliases).toHaveLength(11);
+        expect(hamilton.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
+        ]));
+        expect(hamilton.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: expect.stringContaining('/open-data-licence-terms-and-conditions'),
+                attributionEn: 'Contains public sector Data made available under the City of Hamilton’s Open Data Licence'
+            })
+        })]);
         expect(hamilton.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-cd-3525', relationship: 'direct', includesDescendants: false
+            placeId: 'sgc-cd-3525', relationship: 'direct',
+            includesDescendants: false
         })]);
     });
 
     test('configures Vancouver as a record-licensed Opendatasoft city source', () => {
         const vancouver = getSource('vancouver-open-data');
         expect(vancouver).toEqual(expect.objectContaining({
-            kind: 'opendatasoft', upstreamHost: 'opendata.vancouver.ca',
-            catalogUrl: 'https://opendata.vancouver.ca/api/explore/v2.1'
+            kind: 'opendatasoft', metadataLanguage: 'en',
+            licenseMode: 'record-explicit', timezone: 'America/Vancouver',
+            upstreamHost: 'opendata.vancouver.ca'
         }));
+        expect(vancouver.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            licenseTitle: expect.any(RegExp),
+            licenseUrl: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://opendata.vancouver.ca/pages/licence/'
+            })
+        })]);
         expect(vancouver.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-5915022', relationship: 'direct', includesDescendants: false
+            placeId: 'sgc-csd-5915022', relationship: 'direct',
+            includesDescendants: false
         })]);
     });
 
     test('configures Ottawa as a canonical city with Police licence precedence', () => {
         const ottawa = getSource('ottawa-hub');
         expect(ottawa).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'open.ottawa.ca',
-            catalogUrl: 'https://open.ottawa.ca/api/feed/dcat-us/1.1.json'
+            kind: 'arcgis-hub', upstreamHost: 'open.ottawa.ca'
         }));
-        expect(ottawa.licenseRules.length).toBeGreaterThan(0);
-        expect(ottawa.placeRules).toEqual([expect.objectContaining({
+        expect(ottawa.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-cd-3506', relationship: 'direct', includesDescendants: false
-        })]);
+        }));
+        expect(ottawa.licenseRules[0]).toEqual(expect.objectContaining({
+            licensePattern: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://data.ottawapolice.ca/pages/open-data-licence'
+            })
+        }));
+        expect(ottawa.licenseRules[1]).toEqual(expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: expect.stringContaining('/open-data-licence-version-20')
+            })
+        }));
     });
 
     test('configures Surrey as an exact-publisher ArcGIS source under its portal licence', () => {
@@ -175,93 +281,108 @@ describe('configured municipal catalogue sources', () => {
             kind: 'arcgis-hub', upstreamHost: 'opendata-surrey.hub.arcgis.com',
             catalogUrl: 'https://opendata-surrey.hub.arcgis.com/api/feed/dcat-us/1.1.json'
         }));
-        expect(surrey.licenseRules).toEqual(expect.arrayContaining([
-            expect.objectContaining({
-                publisher: expect.any(RegExp),
-                license: expect.objectContaining({
-                    url: 'https://opendata-surrey.hub.arcgis.com/pages/open-data-licence'
-                })
-            })
+        expect(surrey.restrictedLicensePatterns).toEqual(expect.arrayContaining([
+            expect.any(RegExp)
         ]));
+        expect(surrey.licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp),
+            license: expect.objectContaining({
+                titleEn: 'Open Government License – Surrey',
+                url: expect.stringContaining('/pages/55089a19491a4fe59a41e059fd8af708'),
+                attributionEn: 'Contains information licensed under the Open Government License – City of Surrey.'
+            })
+        })]);
         expect(surrey.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-5915004', relationship: 'direct', includesDescendants: false
+            placeId: 'sgc-csd-5915004', relationship: 'direct',
+            includesDescendants: false
         })]);
     });
 
     test('configures Toronto as an authoritative CKAN city source', () => {
-        const toronto = getSource('toronto-open-data');
-        expect(toronto).toEqual(expect.objectContaining({
-            kind: 'ckan', upstreamHost: 'ckan0.cf.opendata.inter.prod-toronto.ca',
-            catalogUrl: 'https://ckan0.cf.opendata.inter.prod-toronto.ca/api/3/action'
+        expect(getSource('toronto-open-data')).toEqual(expect.objectContaining({
+            kind: 'ckan', placeId: 'sgc-cd-3520',
+            defaultLicenseUrl: 'https://open.toronto.ca/open-data-licence/'
         }));
-        expect(toronto.placeId).toBe('sgc-cd-3520');
     });
 
     test('configures Montréal as a French-first, record-licensed CKAN source', () => {
         const montreal = getSource('montreal-open-data');
         expect(montreal).toEqual(expect.objectContaining({
-            kind: 'ckan', upstreamHost: 'donnees.montreal.ca',
-            catalogUrl: 'https://donnees.montreal.ca/api/3/action'
+            kind: 'ckan', metadataLanguage: 'fr', licenseMode: 'record-explicit',
+            upstreamHost: 'donnees.montreal.ca', directGeoJsonMaps: true
         }));
-        expect(montreal.placeRules).toEqual(expect.arrayContaining([expect.objectContaining({
-            placeId: 'sgc-csd-2466023', relationship: 'direct', includesDescendants: false
-        })]));
+        expect(montreal.licenseRules.map(rule => rule.license.url)).toEqual([
+            'https://creativecommons.org/licenses/by/4.0/',
+            'https://open.canada.ca/en/open-government-licence-canada'
+        ]);
+        expect(montreal.placeRules).toEqual([
+            expect.objectContaining({
+                placeId: 'sgc-csd-2466023', relationship: 'direct',
+                publisher: expect.any(RegExp)
+            }),
+            expect.objectContaining({
+                placeId: 'sgc-csd-2466023', relationship: 'coverage'
+            })
+        ]);
     });
 
     test('configures Québec City and Laval as filtered shared CKAN sources', () => {
-        const quebec = getSource('quebec-city-open-data');
-        const laval = getSource('laval-open-data');
-        expect(quebec).toEqual(expect.objectContaining({
-            kind: 'ckan', upstreamHost: 'www.donneesquebec.ca'
-        }));
-        expect(laval).toEqual(expect.objectContaining({
-            kind: 'ckan', upstreamHost: 'www.donneesquebec.ca'
-        }));
-        expect(quebec.placeRules[0].placeId).toBe('sgc-csd-2423027');
-        expect(laval.placeRules[0].placeId).toBe('sgc-cd-2465');
+        for (const [id, organization, publisher, placeId] of [
+            ['quebec-city-open-data', 'ville-de-quebec', 'Ville de Québec', 'sgc-csd-2423027'],
+            ['laval-open-data', 'ville-de-laval', 'Ville de Laval', 'sgc-cd-2465']
+        ]) {
+            const source = getSource(id);
+            expect(source).toEqual(expect.objectContaining({
+                kind: 'ckan', metadataLanguage: 'fr', directGeoJsonMaps: true,
+                upstreamHost: 'www.donneesquebec.ca',
+                catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+                catalogOrganization: organization,
+                datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+                licenseMode: 'record-explicit'
+            }));
+            expect(source.authoritativePublishers).toEqual([
+                { publisher: expect.any(RegExp) }
+            ]);
+            expect(source.licenseRules).toEqual([expect.objectContaining({
+                publisher: expect.any(RegExp), licenseId: 'cc-by',
+                licenseTitle: 'Attribution (CC-BY 4.0)',
+                licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by'
+            })]);
+            expect(source.placeRules).toEqual([expect.objectContaining({
+                placeId, relationship: 'direct', includesDescendants: false
+            })]);
+            expect(source.authoritativePublishers[0].publisher.test(publisher)).toBe(true);
+        }
     });
 
     test('covers each direct feed without inventing a Clarington source', () => {
-        const oshawa = getSource('oshawa-hub');
-        const ajax = getSource('ajax-hub');
-        const pickering = getSource('pickering-hub');
-        const whitby = getSource('whitby-hub');
-        const durham = getSource('durham-hub');
-
-        expect(oshawa).toBeDefined();
-        expect(ajax).toBeDefined();
-        expect(pickering).toBeDefined();
-        expect(whitby).toBeDefined();
-        expect(durham).toBeDefined();
-
+        expect(getSource('ajax-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518005', relationship: 'direct'
+        }));
+        expect(getSource('pickering-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518001', relationship: 'direct'
+        }));
+        expect(getSource('whitby-hub').placeRules[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-3518009', relationship: 'direct'
+        }));
         expect(getSource('clarington-hub')).toBeNull();
-
-        expect(oshawa.placeRules[0].placeId).toBe('ca-on-oshawa');
-        expect(ajax.placeRules[0].placeId).toBe('sgc-csd-3518005');
-        expect(pickering.placeRules[0].placeId).toBe('sgc-csd-3518001');
-        expect(whitby.placeRules[0].placeId).toBe('sgc-csd-3518009');
-        expect(durham.placeRules[0].placeId).toBe('ca-on-durham');
-        expect(durham.placeRules[0].includesDescendants).toBe(true);
     });
 
     test('keeps Whitby fail-closed and requires explicit open-licence evidence', () => {
         const whitby = getSource('whitby-hub');
-        expect(whitby.licenseRules.length).toBeGreaterThan(0);
-        expect(whitby.restrictedLicensePatterns.length).toBeGreaterThan(0);
+        expect(whitby.licenseMode).toBe('record-explicit');
+        expect(whitby.restrictedLicensePatterns).toHaveLength(1);
+        expect(whitby.licenseRules[0].licensePattern).toBeInstanceOf(RegExp);
     });
 
     test('configures the Peel cluster with direct city and descendant regional coverage', () => {
-        const mississauga = getSource('mississauga-hub');
-        const brampton = getSource('brampton-hub');
-        const peel = getSource('peel-hub');
-
-        expect(mississauga.placeRules[0]).toEqual(expect.objectContaining({
+        expect(getSource('mississauga-hub').placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3521005', relationship: 'direct', includesDescendants: false
         }));
-        expect(brampton.placeRules[0]).toEqual(expect.objectContaining({
+        expect(getSource('brampton-hub').placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3521010', relationship: 'direct', includesDescendants: false
         }));
-        expect(peel.placeRules[0]).toEqual(expect.objectContaining({
+        expect(getSource('peel-hub').placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-cd-3521', relationship: 'direct', includesDescendants: true
         }));
     });
@@ -271,9 +392,19 @@ describe('configured municipal catalogue sources', () => {
         const brampton = getSource('brampton-hub');
         const peel = getSource('peel-hub');
 
-        expect(mississauga.licenseRules.length).toBeGreaterThan(0);
-        expect(brampton.licenseRules.length).toBeGreaterThan(0);
-        expect(peel.licenseRules.length).toBeGreaterThan(0);
+        expect(mississauga.licenseRules[1]).toEqual(expect.objectContaining({
+            publisher: expect.any(RegExp), license: expect.objectContaining({
+                url: 'https://www.mississauga.ca/file/COM/CityOfMississaugaTermsOfUse.pdf'
+            })
+        }));
+        expect(brampton).toEqual(expect.objectContaining({
+            licenseMode: 'record-explicit', restrictedLicensePatterns: expect.any(Array)
+        }));
+        expect(peel).toEqual(expect.objectContaining({
+            licenseMode: 'record-explicit', restrictedLicensePatterns: expect.any(Array)
+        }));
+        expect(brampton.licenseRules.some(rule => rule.license.url === 'https://creativecommons.org/licenses/by/4.0/')).toBe(true);
+        expect(peel.licenseRules.some(rule => rule.license.url === 'https://data.peelregion.ca/pages/license')).toBe(true);
     });
 
     test('configures Burlington, Oakville, and Milton within Halton Region', () => {
@@ -281,11 +412,25 @@ describe('configured municipal catalogue sources', () => {
         const oakville = getSource('oakville-hub');
         const milton = getSource('milton-hub');
 
+        expect(burlington).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'navburl-burlington.opendata.arcgis.com'
+        }));
         expect(burlington.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3524002', relationship: 'direct', includesDescendants: false
         }));
+
+        expect(oakville).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'portal-exploreoakville.opendata.arcgis.com'
+        }));
         expect(oakville.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3524001', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(milton).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'discover-milton.hub.arcgis.com'
         }));
         expect(milton.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3524009', relationship: 'direct', includesDescendants: false
@@ -295,7 +440,8 @@ describe('configured municipal catalogue sources', () => {
     test('configures Greater Sudbury as a single-tier city source', () => {
         const sudbury = getSource('sudbury-hub');
         expect(sudbury).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'opendata.greatersudbury.ca'
+            kind: 'arcgis-hub',
+            upstreamHost: 'opendata.greatersudbury.ca'
         }));
         expect(sudbury.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-cd-3553', relationship: 'direct', includesDescendants: false
@@ -306,8 +452,17 @@ describe('configured municipal catalogue sources', () => {
         const burnaby = getSource('burnaby-hub');
         const saskatoon = getSource('saskatoon-hub');
 
+        expect(burnaby).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'data.burnaby.ca'
+        }));
         expect(burnaby.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-5915025', relationship: 'direct', includesDescendants: false
+        }));
+
+        expect(saskatoon).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'opendata.saskatoon.ca'
         }));
         expect(saskatoon.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-4711066', relationship: 'direct', includesDescendants: false
@@ -318,24 +473,43 @@ describe('configured municipal catalogue sources', () => {
         const markham = getSource('markham-hub');
         const newmarket = getSource('newmarket-hub');
 
-        expect(markham.placeRules).toEqual(expect.arrayContaining([expect.objectContaining({
-            placeId: 'sgc-csd-3519036', relationship: 'direct', includesDescendants: false
-        })]));
-        expect(newmarket.placeRules).toEqual(expect.arrayContaining([expect.objectContaining({
+        expect(markham).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'data-markham.opendata.arcgis.com'
+        }));
+        expect(markham.placeRules).toEqual(expect.arrayContaining([
+            expect.objectContaining({ placeId: 'sgc-csd-3519036', relationship: 'direct', includesDescendants: false }),
+            expect.objectContaining({ placeId: 'sgc-cd-3519', relationship: 'direct', includesDescendants: true })
+        ]));
+
+        expect(newmarket).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'navigate-newmarket.hub.arcgis.com'
+        }));
+        expect(newmarket.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3519048', relationship: 'direct', includesDescendants: false
-        })]));
+        }));
     });
 
     test('configures Niagara Falls and Welland within Niagara Region', () => {
         const niagaraFalls = getSource('niagara-falls-hub');
         const welland = getSource('welland-hub');
 
-        expect(niagaraFalls.placeRules).toEqual(expect.arrayContaining([expect.objectContaining({
+        expect(niagaraFalls).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'open.niagarafalls.ca'
+        }));
+        expect(niagaraFalls.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3526043', relationship: 'direct', includesDescendants: false
-        })]));
-        expect(welland.placeRules).toEqual(expect.arrayContaining([expect.objectContaining({
+        }));
+
+        expect(welland).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub',
+            upstreamHost: 'open-welland.hub.arcgis.com'
+        }));
+        expect(welland.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3526032', relationship: 'direct', includesDescendants: false
-        })]));
+        }));
     });
 
     test('configures Moncton, Guelph, Saanich, and Belleville sources', () => {
@@ -381,71 +555,63 @@ describe('configured municipal catalogue sources', () => {
         const yellowknife = getSource('yellowknife-hub');
         const barrie = getSource('barrie-hub');
         const thunderbay = getSource('thunderbay-hub');
-        const chathamKent = getSource('chatham-kent-hub');
-        const kawarthaLakes = getSource('kawartha-lakes-hub');
+        const chatham = getSource('chatham-kent-hub');
+        const kawartha = getSource('kawartha-lakes-hub');
         const summerland = getSource('summerland-hub');
         const norfolk = getSource('norfolk-hub');
         const haldimand = getSource('haldimand-hub');
 
         expect(yellowknife).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub',
-            upstreamHost: 'data-yellowknife.hub.arcgis.com'
+            kind: 'arcgis-hub', upstreamHost: 'data-yellowknife.hub.arcgis.com'
         }));
         expect(yellowknife.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-6106023', relationship: 'direct', includesDescendants: false
         }));
 
         expect(barrie).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub',
-            upstreamHost: 'opendata.barrie.ca'
+            kind: 'arcgis-hub', upstreamHost: 'opendata.barrie.ca'
         }));
         expect(barrie.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3543042', relationship: 'direct', includesDescendants: false
         }));
 
         expect(thunderbay).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub',
-            upstreamHost: 'opendata-thunderbay.hub.arcgis.com'
+            kind: 'arcgis-hub', upstreamHost: 'opendata-thunderbay.hub.arcgis.com'
         }));
         expect(thunderbay.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3558004', relationship: 'direct', includesDescendants: false
         }));
 
-        expect(chathamKent).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub',
-            upstreamHost: 'opendata.chatham-kent.ca'
+        expect(chatham).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'opendata.chatham-kent.ca'
         }));
-        expect(chathamKent.placeRules[0]).toEqual(expect.objectContaining({
+        expect(chatham.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-cd-3536', relationship: 'direct', includesDescendants: false
         }));
 
-        expect(kawarthaLakes).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub',
-            upstreamHost: 'open-data-kawartha.hub.arcgis.com'
+        expect(kawartha).toEqual(expect.objectContaining({
+            kind: 'arcgis-hub', upstreamHost: 'open-data-kawartha.hub.arcgis.com'
         }));
-        expect(kawarthaLakes.placeRules[0]).toEqual(expect.objectContaining({
+        expect(kawartha.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-cd-3516', relationship: 'direct', includesDescendants: false
         }));
 
         expect(summerland).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub',
-            upstreamHost: 'open-data-summerland.hub.arcgis.com'
+            kind: 'arcgis-hub', upstreamHost: 'open-data-summerland.hub.arcgis.com'
         }));
         expect(summerland.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-5907035', relationship: 'direct', includesDescendants: false
         }));
 
         expect(norfolk).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub',
-            upstreamHost: 'data-norfolk.opendata.arcgis.com'
+            kind: 'arcgis-hub', upstreamHost: 'data-norfolk.opendata.arcgis.com'
         }));
         expect(norfolk.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3528052', relationship: 'direct', includesDescendants: false
         }));
 
         expect(haldimand).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub',
-            upstreamHost: 'opendata-haldimand.hub.arcgis.com'
+            kind: 'arcgis-hub', upstreamHost: 'opendata-haldimand.hub.arcgis.com'
         }));
         expect(haldimand.placeRules[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-csd-3528018', relationship: 'direct', includesDescendants: false
@@ -453,203 +619,145 @@ describe('configured municipal catalogue sources', () => {
     });
 
     test('configures v32 multi-province sources with official licences and direct place rules', () => {
-        const lethbridge = getSource('lethbridge-hub');
-        const medicineHat = getSource('medicine-hat-hub');
-        const airdrie = getSource('airdrie-hub');
-        const canmore = getSource('canmore-hub');
-        const penticton = getSource('penticton-hub');
-        const langleyCity = getSource('langley-city-hub');
-        const huron = getSource('huron-hub');
-        const cumberland = getSource('cumberland-hub');
-
-        expect(lethbridge).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'opendata.lethbridge.ca',
-            catalogUrl: 'https://opendata.lethbridge.ca/api/feed/dcat-us/1.1.json'
-        }));
-        expect(lethbridge.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-4802012', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(medicineHat).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'opendata.medicinehat.ca',
-            catalogUrl: 'https://opendata.medicinehat.ca/api/feed/dcat-us/1.1.json'
-        }));
-        expect(medicineHat.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-4801006', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(airdrie).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-airdrie.opendata.arcgis.com',
-            catalogUrl: 'https://data-airdrie.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(airdrie.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-4806021', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(canmore).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'opendata-canmore.opendata.arcgis.com',
-            catalogUrl: 'https://opendata-canmore.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(canmore.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-4815023', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(penticton).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'open.penticton.ca',
-            catalogUrl: 'https://open.penticton.ca/api/feed/dcat-us/1.1.json'
-        }));
-        expect(penticton.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-5907041', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(langleyCity).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-langleycity.opendata.arcgis.com',
-            catalogUrl: 'https://data-langleycity.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(langleyCity.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-5915001', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(huron).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-huron.opendata.arcgis.com',
-            catalogUrl: 'https://data-huron.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(huron.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-cd-3540', relationship: 'direct', includesDescendants: true
-        })]);
-
-        expect(cumberland).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-cumberlandns.opendata.arcgis.com',
-            catalogUrl: 'https://data-cumberlandns.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(cumberland.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-cd-1211', relationship: 'direct', includesDescendants: true
-        })]);
-    });
-
-    test('configures v33 Quebec and Atlantic Canada sources with official licences and direct place rules', () => {
-        const expectedSources = [
-            { id: 'gatineau-open-data', org: 'ville-de-gatineau', placeId: 'sgc-csd-2481017' },
-            { id: 'trois-rivieres-open-data', org: 'ville-de-trois-rivieres', placeId: 'sgc-csd-2437067' },
-            { id: 'repentigny-open-data', org: 'ville-de-repentigny', placeId: 'sgc-csd-2460013' },
-            { id: 'longueuil-open-data', org: 'ville-de-longueuil', placeId: 'sgc-csd-2458227' },
-            { id: 'saguenay-open-data', org: 'ville-de-saguenay', placeId: 'sgc-csd-2494068' },
-            { id: 'rimouski-open-data', org: 'ville-de-rimouski', placeId: 'sgc-csd-2410043' },
-            { id: 'shawinigan-open-data', org: 'ville-de-shawinigan', placeId: 'sgc-csd-2436033' },
-            { id: 'levis-open-data', org: 'ville-de-levis', placeId: 'sgc-csd-2425213' },
-            { id: 'sherbrooke-open-data', org: 'ville-de-sherbrooke', placeId: 'sgc-csd-2443027' }
+        const v32Sources = [
+            { id: 'lethbridge-hub', host: 'opendata.lethbridge.ca', placeId: 'sgc-csd-4802012' },
+            { id: 'medicine-hat-hub', host: 'opendata.medicinehat.ca', placeId: 'sgc-csd-4801006' },
+            { id: 'airdrie-hub', host: 'data-airdrie.opendata.arcgis.com', placeId: 'sgc-csd-4806021' },
+            { id: 'canmore-hub', host: 'opendata-canmore.opendata.arcgis.com', placeId: 'sgc-csd-4815023' },
+            { id: 'penticton-hub', host: 'open.penticton.ca', placeId: 'sgc-csd-5907041' },
+            { id: 'langley-city-hub', host: 'data-langleycity.opendata.arcgis.com', placeId: 'sgc-csd-5915001' },
+            { id: 'huron-hub', host: 'data-huron.opendata.arcgis.com', placeId: 'sgc-cd-3540' },
+            { id: 'cumberland-hub', host: 'data-cumberlandns.opendata.arcgis.com', placeId: 'sgc-cd-1211' }
         ];
 
-        for (const item of expectedSources) {
-            const source = getSource(item.id);
+        for (const { id, host, placeId } of v32Sources) {
+            const source = getSource(id);
             expect(source).toBeDefined();
-            expect(source.kind).toBe('ckan');
-            expect(source.upstreamHost).toBe('www.donneesquebec.ca');
-            expect(source.catalogOrganization).toBe(item.org);
-            expect(source.placeRules[0].placeId).toBe(item.placeId);
+            expect(source.kind).toBe('arcgis-hub');
+            expect(source.upstreamHost).toBe(host);
+            expect(source.placeRules[0].placeId).toBe(placeId);
             expect(source.placeRules[0].relationship).toBe('direct');
-            expect(source.defaultOrganizationTitleFr).toBeDefined();
         }
-
-        const saintJohn = getSource('saint-john-hub');
-        expect(saintJohn).toBeDefined();
-        expect(saintJohn.kind).toBe('arcgis-hub');
-        expect(saintJohn.upstreamHost).toBe('catalogue-saintjohn.opendata.arcgis.com');
-        expect(saintJohn.placeRules[0].placeId).toBe('sgc-csd-1301006');
-        expect(saintJohn.placeRules[0].relationship).toBe('direct');
-        expect(saintJohn.licenseRules[0].license.titleEn).toBe('Open Government Licence – City of Saint John');
     });
 
-    test('configures v34 capital cities and municipal expansion sources with official licences and direct place rules', () => {
-        const whitehorse = getSource('whitehorse-hub');
-        const stJohns = getSource('st-johns-hub');
-        const charlottetown = getSource('charlottetown-hub');
-        const regina = getSource('regina-hub');
-        const windsor = getSource('windsor-hub');
-        const kingston = getSource('kingston-hub');
-        const redDeer = getSource('red-deer-hub');
-        const kamloops = getSource('kamloops-hub');
-        const nanaimo = getSource('nanaimo-hub');
-        const abbotsford = getSource('abbotsford-hub');
+    test('configures the Données Québec expansion as organization-scoped and record-licensed', () => {
+        const expected = [
+            ['gatineau-open-data', 'ville-de-gatineau', 'sgc-csd-2481017'],
+            ['trois-rivieres-open-data', 'ville-de-trois-rivieres', 'sgc-csd-2437067'],
+            ['repentigny-open-data', 'ville-de-repentigny', 'sgc-csd-2460013'],
+            ['longueuil-open-data', 'ville-de-longueuil', 'sgc-csd-2458227'],
+            ['saguenay-open-data', 'ville-de-saguenay', 'sgc-csd-2494068'],
+            ['rimouski-open-data', 'ville-de-rimouski', 'sgc-csd-2410043'],
+            ['shawinigan-open-data', 'ville-de-shawinigan', 'sgc-csd-2436033'],
+            ['levis-open-data', 'ville-de-levis', 'sgc-csd-2425213'],
+            ['sherbrooke-open-data', 'ville-de-sherbrooke', 'sgc-csd-2443027'],
+            ['sherbrooke-geomatics-open-data', 'ville-de-sherbrooke-donnees-geomatiques', 'sgc-csd-2443027'],
+            ['saint-hyacinthe-open-data', 'ville-de-saint-hyacinthe', 'sgc-csd-2454048']
+        ];
 
-        expect(whitehorse).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-whitehorse.opendata.arcgis.com',
-            catalogUrl: 'https://data-whitehorse.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
+        for (const [id, organization, placeId] of expected) {
+            const source = getSource(id);
+            expect(source).toEqual(expect.objectContaining({
+                kind: 'ckan', enabled: true, metadataLanguage: 'fr',
+                catalogOrganization: organization, directGeoJsonMaps: true,
+                licenseMode: 'record-explicit', upstreamHost: 'www.donneesquebec.ca'
+            }));
+            expect(source.licenseRules).toEqual([expect.objectContaining({
+                licenseId: expect.any(RegExp),
+                license: expect.objectContaining({ url: 'https://creativecommons.org/licenses/by/4.0/' })
+            })]);
+            expect(source.placeRules).toEqual([expect.objectContaining({
+                placeId, relationship: 'direct', includesDescendants: false
+            })]);
+        }
+    });
+
+    test('uses the live v34 catalogues and keeps unavailable municipalities disabled', () => {
+        for (const id of ['whitehorse-hub', 'st-johns-hub', 'charlottetown-hub']) {
+            expect(getSource(id)).toEqual(expect.objectContaining({
+                enabled: false,
+                disabledReason: expect.any(String),
+                licenseRules: []
+            }));
+        }
+
+        expect(getSource('regina-hub')).toEqual(expect.objectContaining({
+            kind: 'ckan', upstreamHost: 'openregina.ca',
+            catalogUrl: 'https://openregina.ca/api/3/action',
+            catalogOrganization: 'city-of-regina',
+            licenseMode: 'record-explicit'
         }));
-        expect(whitehorse.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-6001009', relationship: 'direct', includesDescendants: false
+        expect(getSource('regina-hub').licenseRules).toEqual([expect.objectContaining({
+            publisher: expect.any(RegExp), licenseId: expect.any(RegExp),
+            licenseTitle: expect.any(RegExp),
+            license: expect.objectContaining({ url: expect.stringContaining('/open-government-licence/') })
+        })]);
+        expect(getSource('red-deer-hub')).toEqual(expect.objectContaining({
+            kind: 'red-deer', upstreamHost: 'data.reddeer.ca',
+            catalogUrl: 'https://data.reddeer.ca/api/datasets',
+            placeId: 'sgc-csd-4808011'
+        }));
+
+        const arcgis = [
+            ['windsor-hub', 'open-data-portal-citywindsor.hub.arcgis.com', 'sgc-csd-3537039'],
+            ['kingston-hub', 'opendatakingston.cityofkingston.ca', 'sgc-csd-3510010'],
+            ['kamloops-hub', 'mydata-kamloops.opendata.arcgis.com', 'sgc-csd-5933042'],
+            ['nanaimo-hub', 'gisdata.nanaimo.ca', 'sgc-csd-5921007'],
+            ['abbotsford-hub', 'opendata-abbotsford.hub.arcgis.com', 'sgc-csd-5909052']
+        ];
+        for (const [id, host, placeId] of arcgis) {
+            const source = getSource(id);
+            expect(source).toEqual(expect.objectContaining({
+                kind: 'arcgis-hub', enabled: true, upstreamHost: host,
+                catalogUrl: `https://${host}/api/feed/dcat-us/1.1.json`
+            }));
+            expect(source.placeRules).toEqual([expect.objectContaining({ placeId })]);
+        }
+        expect(getSource('abbotsford-hub').unavailableServicePatterns).toEqual([
+            expect.any(RegExp)
+        ]);
+        expect(getSource('abbotsford-hub').unavailableServicePatterns[0].test(
+            'https://maps.abbotsford.ca/arcgis/rest/services/GeocortexExt/Public/MapServer/2'
+        )).toBe(true);
+    });
+
+    test('configures the v35 Northwest Territories and British Columbia sources fail-closed', () => {
+        const gnwt = getSource('northwest-territories-open-data');
+        expect(gnwt).toEqual(expect.objectContaining({
+            kind: 'ckan', upstreamHost: 'opendata.gov.nt.ca',
+            licenseMode: 'record-explicit', enabled: true
+        }));
+        expect(gnwt.licenseRules).toEqual([expect.objectContaining({
+            licenseId: expect.any(RegExp),
+            license: expect.objectContaining({
+                url: 'https://www.gov.nt.ca/en/open-government-licence-northwest-territories'
+            })
+        })]);
+        expect(gnwt.placeRules).toEqual([expect.objectContaining({
+            placeId: 'sgc-pr-61', relationship: 'direct', includesDescendants: true
         })]);
 
-        expect(stJohns).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'map-stjohns.opendata.arcgis.com',
-            catalogUrl: 'https://map-stjohns.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(stJohns.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-1001519', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(charlottetown).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'city-charlottetown.opendata.arcgis.com',
-            catalogUrl: 'https://city-charlottetown.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(charlottetown.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-1102075', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(regina).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'open-regina.hub.arcgis.com',
-            catalogUrl: 'https://open-regina.hub.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(regina.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-4706027', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(windsor).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'opendata.citywindsor.ca',
-            catalogUrl: 'https://opendata.citywindsor.ca/api/feed/dcat-us/1.1.json'
-        }));
-        expect(windsor.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-3537039', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(kingston).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data.cityofkingston.ca',
-            catalogUrl: 'https://data.cityofkingston.ca/api/feed/dcat-us/1.1.json'
-        }));
-        expect(kingston.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-3510010', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(redDeer).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-reddeer.opendata.arcgis.com',
-            catalogUrl: 'https://data-reddeer.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(redDeer.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-4808011', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(kamloops).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-kamloops.opendata.arcgis.com',
-            catalogUrl: 'https://data-kamloops.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(kamloops.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-5933042', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(nanaimo).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-nanaimo.opendata.arcgis.com',
-            catalogUrl: 'https://data-nanaimo.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(nanaimo.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-5921007', relationship: 'direct', includesDescendants: false
-        })]);
-
-        expect(abbotsford).toEqual(expect.objectContaining({
-            kind: 'arcgis-hub', upstreamHost: 'data-abbotsford.opendata.arcgis.com',
-            catalogUrl: 'https://data-abbotsford.opendata.arcgis.com/api/feed/dcat-us/1.1.json'
-        }));
-        expect(abbotsford.placeRules).toEqual([expect.objectContaining({
-            placeId: 'sgc-csd-5909052', relationship: 'direct', includesDescendants: false
-        })]);
+        const bc = [
+            ['coquitlam-hub', 'data.coquitlam.ca', 'sgc-csd-5915034'],
+            ['prince-george-hub', 'data-cityofpg.opendata.arcgis.com', 'sgc-csd-5953023'],
+            ['new-westminster-hub', 'opendata.newwestcity.ca', 'sgc-csd-5915029'],
+            ['port-moody-hub', 'data.portmoody.ca', 'sgc-csd-5915043'],
+            ['squamish-hub', 'data.squamish.ca', 'sgc-csd-5931006'],
+            ['maple-ridge-hub', 'opengov.mapleridge.ca', 'sgc-csd-5915075'],
+            ['port-coquitlam-hub', 'data-poco.hub.arcgis.com', 'sgc-csd-5915039']
+        ];
+        for (const [id, host, placeId] of bc) {
+            const source = getSource(id);
+            expect(source).toEqual(expect.objectContaining({
+                kind: 'arcgis-hub', upstreamHost: host, enabled: true,
+                placeholderPublisher: expect.any(String)
+            }));
+            expect(source.placeRules).toEqual([expect.objectContaining({
+                placeId, relationship: 'direct', includesDescendants: false
+            })]);
+            expect(source.restrictedLicensePatterns.length).toBeGreaterThanOrEqual(3);
+        }
+        expect(getSource('maple-ridge-hub').restrictedLicensePatterns.some(pattern => pattern.test('TransLink terms'))).toBe(true);
+        expect(getSource('port-coquitlam-hub').restrictedLicensePatterns.some(pattern => pattern.test('PoCoMap'))).toBe(true);
     });
 });

--- a/server/__tests__/ckanSourceAdapter.test.js
+++ b/server/__tests__/ckanSourceAdapter.test.js
@@ -5,6 +5,8 @@ const source = getSource('toronto-open-data');
 const montreal = getSource('montreal-open-data');
 const quebecCity = getSource('quebec-city-open-data');
 const laval = getSource('laval-open-data');
+const gnwt = getSource('northwest-territories-open-data');
+const regina = getSource('regina-hub');
 
 function packageRecord(overrides = {}) {
     return {
@@ -251,14 +253,63 @@ describe('generic CKAN source adapter', () => {
         expect(lavalResult.value.places[0]).toEqual(expect.objectContaining({
             placeId: 'sgc-cd-2465'
         }));
+    });
 
-        const gatineau = getSource('gatineau-open-data');
-        const gatineauResult = await adapter.enrichRecord({ ...record,
-            id: 'gatineau-record',
-            organization: { id: 'ville-de-gatineau', name: 'ville-de-gatineau', title: 'Ville de Gatineau' }
-        }, gatineau);
-        expect(gatineauResult.value.places[0]).toEqual(expect.objectContaining({
-            placeId: 'sgc-csd-2481017'
+    test('admits only GNWT-licensed records and builds source-aware DataStore URLs', async () => {
+        const record = packageRecord({
+            id: 'gnwt-record', name: 'wildlife-observations', title: 'Wildlife Observations',
+            license_id: 'GNWT', license_title: 'Open Government Licence - Northwest Territories',
+            organization: {
+                id: 'environment-and-climate-change',
+                name: 'environment-and-climate-change',
+                title: 'Environment and Climate Change'
+            },
+            resources: [{
+                id: 'gnwt-datastore', name: 'Wildlife observations', format: 'CSV',
+                datastore_active: true, record_count: 25,
+                url: 'https://opendata.gov.nt.ca/unused.csv'
+            }]
+        });
+        const result = await adapter.enrichRecord(record, gnwt);
+
+        expect(result.status).toBe('included');
+        expect(result.value.source).toEqual(expect.objectContaining({
+            licenseUrl: 'https://www.gov.nt.ca/en/open-government-licence-northwest-territories'
+        }));
+        expect(result.value.resources[0]).toEqual(expect.objectContaining({
+            datastoreActive: true,
+            url: 'https://opendata.gov.nt.ca/datastore/dump/gnwt-datastore'
+        }));
+        expect(result.value.places).toEqual([expect.objectContaining({
+            placeId: 'sgc-pr-61', relationship: 'direct', includesDescendants: true
+        })]);
+
+        await expect(adapter.enrichRecord({ ...record, license_id: 'notspecified' }, gnwt))
+            .resolves.toEqual(expect.objectContaining({ status: 'excluded', reason: 'unlicensed' }));
+    });
+
+    test('applies Regina portal terms only to its exact CKAN publisher evidence', async () => {
+        const record = packageRecord({
+            id: 'regina-record', name: 'building-permits', title: 'Building Permits',
+            license_id: 'notspecified', license_title: 'Open Gov. License',
+            organization: {
+                id: 'city-of-regina', name: 'city-of-regina', title: 'City of Regina'
+            }
+        });
+        const result = await adapter.enrichRecord(record, regina);
+        expect(result.status).toBe('included');
+        expect(result.value.source).toEqual(expect.objectContaining({
+            isAuthoritative: true,
+            licenseUrl: 'https://www.regina.ca/city-government/open-data/open-government-licence/index.html'
+        }));
+        expect(result.value.places[0]).toEqual(expect.objectContaining({
+            placeId: 'sgc-csd-4706027', relationship: 'direct'
+        }));
+
+        await expect(adapter.enrichRecord({ ...record, organization: {
+            id: 'external', name: 'external', title: 'External Publisher'
+        } }, regina)).resolves.toEqual(expect.objectContaining({
+            status: 'excluded', reason: 'unlicensed'
         }));
     });
 });

--- a/server/__tests__/opsApi.test.js
+++ b/server/__tests__/opsApi.test.js
@@ -59,6 +59,26 @@ describe('ops API', () => {
         expect(res.body.data.ok).toBe(true);
     });
 
+    it('registers every enabled source job and omits fail-closed disabled sources', async () => {
+        catalogReadQueries.getJobHealth.mockResolvedValue({
+            syncRows: [], evictLastOkAt: null, mapQueue: {}
+        });
+        const res = await request(app).get('/api/v1/ops');
+        const sourceJobs = Object.keys(res.body.data.jobs).filter(name => name.startsWith('source:'));
+
+        expect(res.status).toBe(200);
+        expect(sourceJobs).toHaveLength(82);
+        expect(sourceJobs).toEqual(expect.arrayContaining([
+            'source:regina-hub',
+            'source:red-deer-hub',
+            'source:northwest-territories-open-data',
+            'source:saint-hyacinthe-open-data'
+        ]));
+        expect(sourceJobs).not.toContain('source:whitehorse-hub');
+        expect(sourceJobs).not.toContain('source:st-johns-hub');
+        expect(sourceJobs).not.toContain('source:charlottetown-hub');
+    });
+
     it('keeps the newest source success across legacy and current run kinds', async () => {
         const now = new Date();
         const legacy = new Date(Date.now() - 72 * 3600 * 1000).toISOString();

--- a/server/__tests__/queryApi.test.js
+++ b/server/__tests__/queryApi.test.js
@@ -56,6 +56,24 @@ describe('query API datastore path', () => {
         }));
     });
 
+    test('routes a namespaced GNWT resource to the GNWT DataStore action base', async () => {
+        queries.getResourceById.mockResolvedValue(makeRow({
+            id: 'ckan-northwest-territories-open-data-resource-local', datastore_active: true,
+            raw: {
+                provider: 'ckan', source_id: 'northwest-territories-open-data',
+                upstream_resource_id: 'gnwt-upstream-id'
+            }
+        }));
+        ckan.datastoreSearch.mockResolvedValue({ fields: [], records: [], total: 0 });
+        const res = await request(app)
+            .get('/api/v1/resources/ckan-northwest-territories-open-data-resource-local/query');
+        expect(res.status).toBe(200);
+        expect(ckan.datastoreSearch).toHaveBeenCalledWith(expect.objectContaining({
+            resourceId: 'gnwt-upstream-id',
+            baseUrl: 'https://opendata.gov.nt.ca/api/3/action'
+        }));
+    });
+
     test('datastore proxy responses are cached', async () => {
         queries.getResourceById.mockResolvedValue(makeRow({ id: 'ds-cache', datastore_active: true }));
         ckan.datastoreSearch.mockResolvedValue({ fields: [], records: [], total: 0 });

--- a/server/__tests__/redDeerAdapter.test.js
+++ b/server/__tests__/redDeerAdapter.test.js
@@ -1,0 +1,79 @@
+const adapter = require('../services/redDeerAdapter');
+const { getSource } = require('../config/catalogSources');
+
+const source = getSource('red-deer-hub');
+const record = {
+    dataUrl: 'https://data.reddeer.ca/api/datasets/building-permits?skip=0&take=50',
+    metaDataUrl: 'https://data.reddeer.ca/api/datasets/building-permits/metadata',
+    name: 'Building Permits',
+    description: 'Building permits issued monthly by The City of Red Deer',
+    category: 'Inspections & Licensing',
+    formats: 'Excel, CSV, JSON',
+    keywords: 'Building, Permit, Construction',
+    owner: 'Inspections & Licensing',
+    lastUpdateDate: '2026-08-29T04:00:04.017'
+};
+
+describe('Red Deer catalogue adapter', () => {
+    test('discovers a complete exact-host catalogue', async () => {
+        const result = await adapter.discover(source, {
+            fetchJson: jest.fn().mockResolvedValue({ totalCount: 1, datasets: [record] })
+        });
+
+        expect(result).toEqual([record]);
+    });
+
+    test('rejects incomplete catalogues and off-host dataset URLs', async () => {
+        await expect(adapter.discover(source, {
+            fetchJson: jest.fn().mockResolvedValue({ totalCount: 2, datasets: [record] })
+        })).rejects.toThrow('invalid or incomplete');
+
+        await expect(adapter.discover(source, {
+            fetchJson: jest.fn().mockResolvedValue({
+                totalCount: 1,
+                datasets: [{ ...record, dataUrl: 'https://example.com/api/datasets/building-permits' }]
+            })
+        })).rejects.toThrow('outside its configured HTTPS host');
+    });
+
+    test('normalizes official downloads, licence provenance, and direct place coverage', async () => {
+        const result = await adapter.enrichRecord(record, source);
+
+        expect(result.status).toBe('included');
+        expect(result.value.dataset).toEqual(expect.objectContaining({
+            id: 'red-deer-building-permits',
+            titleEn: 'Building Permits',
+            keywordsEn: ['Building', 'Permit', 'Construction']
+        }));
+        expect(result.value.resources).toEqual([
+            expect.objectContaining({
+                id: 'red-deer-building-permits-excel', format: 'XLSX',
+                url: 'https://data.reddeer.ca/datasets/buildingpermits/download/excel'
+            }),
+            expect.objectContaining({
+                id: 'red-deer-building-permits-csv', format: 'CSV',
+                url: 'https://data.reddeer.ca/datasets/buildingpermits/download/csv'
+            }),
+            expect.objectContaining({
+                id: 'red-deer-building-permits-json', format: 'JSON',
+                url: 'https://data.reddeer.ca/datasets/buildingpermits/download/json'
+            })
+        ]);
+        expect(result.value.source).toEqual(expect.objectContaining({
+            sourceId: 'red-deer-hub', isAuthoritative: true,
+            licenseUrl: 'https://data.reddeer.ca/about'
+        }));
+        expect(result.value.places).toEqual([expect.objectContaining({
+            placeId: 'sgc-csd-4808011', relationship: 'direct', includesDescendants: false
+        })]);
+    });
+
+    test('excludes unsupported downloads and missing licence configuration', async () => {
+        await expect(adapter.enrichRecord({ ...record, formats: 'MrSID' }, source)).resolves.toEqual({
+            status: 'excluded', reason: 'not-loadable', externalId: 'building-permits'
+        });
+        await expect(adapter.enrichRecord(record, { ...source, license: null })).resolves.toEqual({
+            status: 'excluded', reason: 'unlicensed', externalId: 'building-permits'
+        });
+    });
+});

--- a/server/__tests__/spatialIntegration.test.js
+++ b/server/__tests__/spatialIntegration.test.js
@@ -642,4 +642,79 @@ spatialDescribe('PostGIS viewport integration', () => {
         `, [orgId, datasetId]);
         expect(references.rows).toEqual([{ place_id: 'sgc-cd-2465', dataset_moved: true }]);
     });
+
+    test('migration 029 repairs partial rollout state and seeds v35 idempotently', async () => {
+        await client.query("UPDATE places SET name_fr = 'QuÃ©bec' WHERE id = 'sgc-pr-24'");
+        await client.query(`
+            UPDATE places
+            SET slug = 'coquitlam-bc-broken', type_en = 'Municipality',
+                featured = false, latitude = NULL, longitude = NULL
+            WHERE id = 'sgc-csd-5915034'
+        `);
+        await client.query(`
+            DELETE FROM place_aliases
+            WHERE slug IN ('coquitlam-city-bc', 'regina-city-sk')
+        `);
+
+        const migration = fs.readFileSync(path.join(
+            __dirname, '..', 'sql', 'migrations', '029_recovery_and_high_volume_places.sql'
+        ), 'utf8');
+        await client.query(migration);
+        await client.query(migration);
+
+        const places = await client.query(`
+            SELECT id, slug, kind, parent_id, type_en, type_fr, featured,
+                   latitude, longitude, default_zoom
+            FROM places
+            WHERE id IN (
+                'sgc-pr-61', 'sgc-csd-5915034', 'sgc-csd-5953023',
+                'sgc-csd-5915029', 'sgc-csd-5915043', 'sgc-csd-5931006',
+                'sgc-csd-5915075', 'sgc-csd-5915039', 'sgc-csd-2454048'
+            )
+            ORDER BY id
+        `);
+        expect(places.rows).toHaveLength(9);
+        expect(places.rows.find(row => row.id === 'sgc-pr-61')).toEqual(expect.objectContaining({
+            slug: 'northwest-territories', kind: 'territory',
+            parent_id: 'ca', featured: false
+        }));
+        expect(places.rows.find(row => row.id === 'sgc-csd-5915034')).toEqual(expect.objectContaining({
+            slug: 'coquitlam-bc', kind: 'municipality', parent_id: 'sgc-cd-5915',
+            type_en: 'City', type_fr: 'Ville', featured: true,
+            latitude: 49.2838, longitude: -122.7932, default_zoom: 10
+        }));
+        expect(places.rows.filter(row => row.id.startsWith('sgc-csd-')).every(row => row.featured)).toBe(true);
+
+        const identifiers = await client.query(`
+            SELECT count(*)::int AS count
+            FROM place_identifiers
+            WHERE vintage = '2021' AND (
+                (scheme = 'sgc-pr' AND value = '61') OR
+                (scheme = 'sgc-csd' AND value IN (
+                    '5915034', '5953023', '5915029', '5915043',
+                    '5931006', '5915075', '5915039', '2454048'
+                ))
+            )
+        `);
+        expect(identifiers.rows[0].count).toBe(9);
+
+        const aliases = await client.query(`
+            SELECT slug, place_id FROM place_aliases
+            WHERE slug IN ('coquitlam-city-bc', 'regina-city-sk')
+            ORDER BY slug
+        `);
+        expect(aliases.rows).toEqual([
+            { slug: 'coquitlam-city-bc', place_id: 'sgc-csd-5915034' },
+            { slug: 'regina-city-sk', place_id: 'sgc-csd-4706027' }
+        ]);
+
+        const unicode = await client.query(`
+            SELECT name_fr,
+                   (SELECT count(*)::int FROM places
+                    WHERE name_en LIKE '%' || U&'\\FFFD' || '%'
+                       OR name_fr LIKE '%' || U&'\\FFFD' || '%') AS damaged
+            FROM places WHERE id = 'sgc-pr-24'
+        `);
+        expect(unicode.rows).toEqual([{ name_fr: 'Québec', damaged: 0 }]);
+    });
 });

--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -1,4 +1,4 @@
-const { normalize } = require('../scripts/sync-places');
+const { normalize, rowsFrom } = require('../scripts/sync-places');
 
 describe('Statistics Canada SGC place normalization', () => {
     test('builds stable province, region and municipality ancestry', () => {
@@ -118,6 +118,19 @@ describe('Statistics Canada SGC place normalization', () => {
         expect(result.places.find(place => place.id === 'sgc-csd-2466023')).toEqual(expect.objectContaining({
             slug: 'montreal-qc', nameEn: 'Montréal'
         }));
+    });
+
+    test('decodes the official Windows-1252 accents and rejects replacement characters', () => {
+        const csv = Buffer.concat([
+            Buffer.from('Level,Code,Class title\r\n2,24,Qu'),
+            Buffer.from([0xe9]),
+            Buffer.from('bec\r\n')
+        ]);
+        expect(rowsFrom(csv, 'windows-1252')).toEqual([{
+            Level: '2', Code: '24', 'Class title': 'Québec'
+        }]);
+        expect(() => rowsFrom(Buffer.from([0x61, 0x2c, 0x62, 0x0a, 0xc3, 0x28])))
+            .toThrow(/replacement characters/i);
     });
 
     test('keeps Montréal region and city distinct and features only the city', () => {
@@ -787,149 +800,76 @@ describe('Statistics Canada SGC place normalization', () => {
         }));
     });
 
-    test('features Gatineau, Trois-Rivières, Repentigny, Longueuil, Saguenay, Rimouski, Shawinigan, Lévis, Sherbrooke, and Saint John', () => {
+    test('normalizes the v33-v35 municipalities with canonical ancestry and viewports', () => {
         const en = [
             { Level: '2', Code: '24', 'Class title': 'Quebec' },
             { Level: '3', Code: '2481', 'Class title': 'Gatineau' },
             { Level: '4', Code: '2481017', 'Class title': 'Gatineau' },
-            { Level: '3', Code: '2437', 'Class title': 'Francheville' },
-            { Level: '4', Code: '2437067', 'Class title': 'Trois-Rivières' },
-            { Level: '3', Code: '2460', 'Class title': 'L’Assomption' },
-            { Level: '4', Code: '2460013', 'Class title': 'Repentigny' },
-            { Level: '3', Code: '2458', 'Class title': 'Longueuil' },
-            { Level: '4', Code: '2458227', 'Class title': 'Longueuil' },
-            { Level: '3', Code: '2494', 'Class title': 'Le Saguenay-et-son-Fjord' },
-            { Level: '4', Code: '2494068', 'Class title': 'Saguenay' },
-            { Level: '3', Code: '2410', 'Class title': 'Rimouski-Neigette' },
-            { Level: '4', Code: '2410043', 'Class title': 'Rimouski' },
-            { Level: '3', Code: '2436', 'Class title': 'Le Centre-de-la-Mauricie' },
-            { Level: '4', Code: '2436033', 'Class title': 'Shawinigan' },
-            { Level: '3', Code: '2425', 'Class title': 'Les Chutes-de-la-Chaudière' },
+            { Level: '3', Code: '2425', 'Class title': 'Lévis' },
             { Level: '4', Code: '2425213', 'Class title': 'Lévis' },
-            { Level: '3', Code: '2443', 'Class title': 'Sherbrooke' },
-            { Level: '4', Code: '2443027', 'Class title': 'Sherbrooke' },
+            { Level: '3', Code: '2454', 'Class title': 'Les Maskoutains' },
+            { Level: '4', Code: '2454048', 'Class title': 'Saint-Hyacinthe' },
             { Level: '2', Code: '13', 'Class title': 'New Brunswick' },
             { Level: '3', Code: '1301', 'Class title': 'Saint John' },
-            { Level: '4', Code: '1301006', 'Class title': 'Saint John' }
+            { Level: '4', Code: '1301006', 'Class title': 'Saint John' },
+            { Level: '2', Code: '59', 'Class title': 'British Columbia' },
+            { Level: '3', Code: '5915', 'Class title': 'Greater Vancouver' },
+            { Level: '4', Code: '5915034', 'Class title': 'Coquitlam' },
+            { Level: '4', Code: '5915029', 'Class title': 'New Westminster' },
+            { Level: '4', Code: '5915043', 'Class title': 'Port Moody' },
+            { Level: '4', Code: '5915075', 'Class title': 'Maple Ridge' },
+            { Level: '4', Code: '5915039', 'Class title': 'Port Coquitlam' },
+            { Level: '3', Code: '5953', 'Class title': 'Fraser-Fort George' },
+            { Level: '4', Code: '5953023', 'Class title': 'Prince George' },
+            { Level: '3', Code: '5931', 'Class title': 'Squamish-Lillooet' },
+            { Level: '4', Code: '5931006', 'Class title': 'Squamish' },
+            { Level: '3', Code: '5933', 'Class title': 'Thompson-Nicola' },
+            { Level: '4', Code: '5933042', 'Class title': 'Kamloops' },
+            { Level: '2', Code: '60', 'Class title': 'Yukon' },
+            { Level: '3', Code: '6001', 'Class title': 'Yukon' },
+            { Level: '4', Code: '6001009', 'Class title': 'Whitehorse' },
+            { Level: '2', Code: '47', 'Class title': 'Saskatchewan' },
+            { Level: '3', Code: '4706', 'Class title': 'Division No. 6' },
+            { Level: '4', Code: '4706027', 'Class title': 'Regina' },
+            { Level: '2', Code: '61', 'Class title': 'Northwest Territories' },
+            { Level: '3', Code: '6106', 'Class title': 'Region 6' },
+            { Level: '4', Code: '6106023', 'Class title': 'Yellowknife' }
         ];
-        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
+        const frenchNames = new Map([
+            ['24', 'Québec'], ['2425', 'Lévis'], ['2425213', 'Lévis'],
+            ['61', 'Territoires du Nord-Ouest']
+        ]);
+        const fr = en.map(row => ({
+            Code: row.Code,
+            'Titres de classes': frenchNames.get(row.Code) || row['Class title']
+        }));
         const result = normalize(en, fr);
 
-        expect(result.places.find(place => place.id === 'sgc-csd-2481017')).toEqual(expect.objectContaining({
-            slug: 'gatineau-qc', kind: 'municipality', parentId: 'sgc-cd-2481',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 45.4765, longitude: -75.7013, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-2437067')).toEqual(expect.objectContaining({
-            slug: 'trois-rivieres-qc', kind: 'municipality', parentId: 'sgc-cd-2437',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 46.3432, longitude: -72.5421, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-2460013')).toEqual(expect.objectContaining({
-            slug: 'repentigny-qc', kind: 'municipality', parentId: 'sgc-cd-2460',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 45.7423, longitude: -73.4497, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-2458227')).toEqual(expect.objectContaining({
-            slug: 'longueuil-qc', kind: 'municipality', parentId: 'sgc-cd-2458',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 45.5312, longitude: -73.5181, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-2494068')).toEqual(expect.objectContaining({
-            slug: 'saguenay-qc', kind: 'municipality', parentId: 'sgc-cd-2494',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 48.4284, longitude: -71.0684, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-2410043')).toEqual(expect.objectContaining({
-            slug: 'rimouski-qc', kind: 'municipality', parentId: 'sgc-cd-2410',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 48.4488, longitude: -68.5240, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-2436033')).toEqual(expect.objectContaining({
-            slug: 'shawinigan-qc', kind: 'municipality', parentId: 'sgc-cd-2436',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 46.5667, longitude: -72.7500, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-2425213')).toEqual(expect.objectContaining({
-            slug: 'levis-qc', kind: 'municipality', parentId: 'sgc-cd-2425',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 46.8033, longitude: -71.1779, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-2443027')).toEqual(expect.objectContaining({
-            slug: 'sherbrooke-qc', kind: 'municipality', parentId: 'sgc-cd-2443',
-            typeEn: 'City', typeFr: 'Ville', featured: true, latitude: 45.4042, longitude: -71.8929, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-1301006')).toEqual(expect.objectContaining({
-            slug: 'saint-john-nb', kind: 'municipality', parentId: 'sgc-cd-1301',
-            typeEn: 'City', typeFr: 'Cité', featured: true, latitude: 45.2733, longitude: -66.0633, defaultZoom: 10
-        }));
-    });
-
-    test("features Whitehorse, St. John's, Charlottetown, Regina, Windsor, Kingston, Red Deer, Kamloops, Nanaimo, and Abbotsford", () => {
-        const en = [
-            { Code: '6001009', Level: '4', 'Class title': 'Whitehorse' },
-            { Code: '1001519', Level: '4', 'Class title': "St. John's" },
-            { Code: '1102075', Level: '4', 'Class title': 'Charlottetown' },
-            { Code: '4706027', Level: '4', 'Class title': 'Regina' },
-            { Code: '3537039', Level: '4', 'Class title': 'Windsor' },
-            { Code: '3510010', Level: '4', 'Class title': 'Kingston' },
-            { Code: '4808011', Level: '4', 'Class title': 'Red Deer' },
-            { Code: '5933042', Level: '4', 'Class title': 'Kamloops' },
-            { Code: '5921007', Level: '4', 'Class title': 'Nanaimo' },
-            { Code: '5909052', Level: '4', 'Class title': 'Abbotsford' }
+        const expected = [
+            ['sgc-csd-2481017', 'gatineau-qc', 'sgc-cd-2481', 45.4765, -75.7013],
+            ['sgc-csd-2425213', 'levis-qc', 'sgc-cd-2425', 46.8033, -71.1779],
+            ['sgc-csd-2454048', 'saint-hyacinthe-qc', 'sgc-cd-2454', 45.6307, -72.9569],
+            ['sgc-csd-1301006', 'saint-john-nb', 'sgc-cd-1301', 45.2733, -66.0633],
+            ['sgc-csd-5915034', 'coquitlam-bc', 'sgc-cd-5915', 49.2838, -122.7932],
+            ['sgc-csd-5915029', 'new-westminster-bc', 'sgc-cd-5915', 49.2057, -122.911],
+            ['sgc-csd-5915043', 'port-moody-bc', 'sgc-cd-5915', 49.2838, -122.8317],
+            ['sgc-csd-5915075', 'maple-ridge-bc', 'sgc-cd-5915', 49.2193, -122.5984],
+            ['sgc-csd-5915039', 'port-coquitlam-bc', 'sgc-cd-5915', 49.2628, -122.7811],
+            ['sgc-csd-5953023', 'prince-george-bc', 'sgc-cd-5953', 53.9171, -122.7497],
+            ['sgc-csd-5931006', 'squamish-bc', 'sgc-cd-5931', 49.7016, -123.1558],
+            ['sgc-csd-5933042', 'kamloops-bc', 'sgc-cd-5933', 50.6745, -120.3273],
+            ['sgc-csd-6001009', 'whitehorse-yt', 'sgc-cd-6001', 60.7212, -135.0568],
+            ['sgc-csd-4706027', 'regina-sk', 'sgc-cd-4706', 50.4452, -104.6189]
         ];
-        const fr = en.map(row => ({ Code: row.Code, 'Titres de classes': row['Class title'] }));
-        const result = normalize(en, fr);
-
-        expect(result.places.find(place => place.id === 'sgc-csd-6001009')).toEqual(expect.objectContaining({
-            slug: 'whitehorse-yt', kind: 'municipality', parentId: 'sgc-cd-6001',
-            featured: true, latitude: 60.7212, longitude: -135.0568, defaultZoom: 10
+        for (const [id, slug, parentId, latitude, longitude] of expected) {
+            expect(result.places.find(place => place.id === id)).toEqual(expect.objectContaining({
+                slug, parentId, kind: 'municipality', featured: true,
+                latitude, longitude
+            }));
+        }
+        expect(result.places.find(place => place.id === 'sgc-pr-61')).toEqual(expect.objectContaining({
+            kind: 'territory', nameFr: 'Territoires du Nord-Ouest', featured: false
         }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-1001519')).toEqual(expect.objectContaining({
-            slug: 'st-johns-nl', kind: 'municipality', parentId: 'sgc-cd-1001',
-            featured: true, latitude: 47.5615, longitude: -52.7126, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-1102075')).toEqual(expect.objectContaining({
-            slug: 'charlottetown-pe', kind: 'municipality', parentId: 'sgc-cd-1102',
-            featured: true, latitude: 46.2382, longitude: -63.1311, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-4706027')).toEqual(expect.objectContaining({
-            slug: 'regina-sk', kind: 'municipality', parentId: 'sgc-cd-4706',
-            featured: true, latitude: 50.4452, longitude: -104.6189, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-3537039')).toEqual(expect.objectContaining({
-            slug: 'windsor-on', kind: 'municipality', parentId: 'sgc-cd-3537',
-            featured: true, latitude: 42.3149, longitude: -83.0364, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-3510010')).toEqual(expect.objectContaining({
-            slug: 'kingston-on', kind: 'municipality', parentId: 'sgc-cd-3510',
-            featured: true, latitude: 44.2312, longitude: -76.4860, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-4808011')).toEqual(expect.objectContaining({
-            slug: 'red-deer-ab', kind: 'municipality', parentId: 'sgc-cd-4808',
-            featured: true, latitude: 52.2690, longitude: -113.8116, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-5933042')).toEqual(expect.objectContaining({
-            slug: 'kamloops-bc', kind: 'municipality', parentId: 'sgc-cd-5933',
-            featured: true, latitude: 50.6745, longitude: -120.3273, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-5921007')).toEqual(expect.objectContaining({
-            slug: 'nanaimo-bc', kind: 'municipality', parentId: 'sgc-cd-5921',
-            featured: true, latitude: 49.1659, longitude: -123.9401, defaultZoom: 10
-        }));
-
-        expect(result.places.find(place => place.id === 'sgc-csd-5909052')).toEqual(expect.objectContaining({
-            slug: 'abbotsford-bc', kind: 'municipality', parentId: 'sgc-cd-5909',
-            featured: true, latitude: 49.0504, longitude: -122.3045, defaultZoom: 10
-        }));
+        expect(JSON.stringify(result)).not.toContain('\uFFFD');
     });
 });

--- a/server/config/catalogSourceExpansions.js
+++ b/server/config/catalogSourceExpansions.js
@@ -1,0 +1,361 @@
+'use strict';
+
+const DONNEES_QUEBEC_ACTION = 'https://www.donneesquebec.ca/recherche/api/3/action';
+const DONNEES_QUEBEC_DATASET = 'https://www.donneesquebec.ca/recherche/dataset';
+const DEFAULT_RESTRICTED_LICENSE_PATTERNS = [
+    /non.?commercial/i,
+    /personal use only/i,
+    /by-nc/i
+];
+
+function portalLicense(titleEn, titleFr, url, attributionNameEn, attributionNameFr) {
+    return {
+        titleEn,
+        titleFr,
+        url,
+        attributionEn: 'Contains information licensed under ' + attributionNameEn + '.',
+        attributionFr: 'Contient des renseignements visés par ' + attributionNameFr + '.'
+    };
+}
+
+const EXPANSION_LICENSES = {
+    SAINT_JOHN_LICENSE: portalLicense(
+        'Open Government Licence – City of Saint John',
+        'Licence du gouvernement ouvert – Ville de Saint John',
+        'https://catalogue-saintjohn.opendata.arcgis.com/pages/open-government-licence-city-of-saint-john',
+        'the Open Government Licence – City of Saint John',
+        'la Licence du gouvernement ouvert – Ville de Saint John'
+    ),
+    // Intentionally null until the municipalities publish verifiable licence
+    // evidence for a machine-readable catalogue. Their configs remain disabled.
+    WHITEHORSE_LICENSE: null,
+    ST_JOHNS_LICENSE: null,
+    CHARLOTTETOWN_LICENSE: null,
+    REGINA_LICENSE: portalLicense(
+        'Open Government Licence – City of Regina',
+        'Licence du gouvernement ouvert – Ville de Regina',
+        'https://www.regina.ca/city-government/open-data/open-government-licence/index.html',
+        'the Open Government Licence – City of Regina',
+        'la Licence du gouvernement ouvert – Ville de Regina'
+    ),
+    WINDSOR_LICENSE: portalLicense(
+        'City of Windsor Open Data Licence',
+        'Licence de données ouvertes de la Ville de Windsor',
+        'https://opendata.citywindsor.ca/Documents/OpenDataTermsofUse.pdf',
+        'the City of Windsor Open Data Licence',
+        'la Licence de données ouvertes de la Ville de Windsor'
+    ),
+    KINGSTON_LICENSE: portalLicense(
+        'City of Kingston Open Data Licence',
+        'Licence de données ouvertes de la Ville de Kingston',
+        'https://www.cityofkingston.ca/documents/10180/144997/CityofKingston_OpenDataLicense.pdf',
+        'the City of Kingston Open Data Licence',
+        'la Licence de données ouvertes de la Ville de Kingston'
+    ),
+    RED_DEER_LICENSE: portalLicense(
+        'Open Government Licence – The City of Red Deer',
+        'Licence du gouvernement ouvert – Ville de Red Deer',
+        'https://data.reddeer.ca/about',
+        'the Open Government Licence – The City of Red Deer',
+        'la Licence du gouvernement ouvert – Ville de Red Deer'
+    ),
+    KAMLOOPS_LICENSE: portalLicense(
+        'Open Government Licence – Kamloops',
+        'Licence du gouvernement ouvert – Kamloops',
+        'https://www.kamloops.ca/open-data-catalogue-disclaimer',
+        'the Open Government Licence – Kamloops',
+        'la Licence du gouvernement ouvert – Kamloops'
+    ),
+    NANAIMO_LICENSE: portalLicense(
+        'Open Government Licence – Nanaimo',
+        'Licence du gouvernement ouvert – Nanaimo',
+        'https://www.nanaimo.ca/your-government/maps-data/open-data-catalogue/open-data-catalogue-licence',
+        'the Open Government Licence – Nanaimo',
+        'la Licence du gouvernement ouvert – Nanaimo'
+    ),
+    ABBOTSFORD_LICENSE: portalLicense(
+        'City of Abbotsford Open Data Licence',
+        'Licence de données ouvertes de la Ville d’Abbotsford',
+        'https://opendata-abbotsford.hub.arcgis.com/pages/city-of-abbotsford-open-data-licence',
+        'the City of Abbotsford Open Data Licence',
+        'la Licence de données ouvertes de la Ville d’Abbotsford'
+    ),
+    GNWT_LICENSE: portalLicense(
+        'Open Government Licence – Northwest Territories',
+        'Licence du gouvernement ouvert – Territoires du Nord-Ouest',
+        'https://www.gov.nt.ca/en/open-government-licence-northwest-territories',
+        'the Open Government Licence – Northwest Territories',
+        'la Licence du gouvernement ouvert – Territoires du Nord-Ouest'
+    ),
+    COQUITLAM_LICENSE: portalLicense(
+        'Open Government Licence – City of Coquitlam',
+        'Licence du gouvernement ouvert – Ville de Coquitlam',
+        'https://www.coquitlam.ca/894/Open-Government-Licence',
+        'the Open Government Licence – City of Coquitlam',
+        'la Licence du gouvernement ouvert – Ville de Coquitlam'
+    ),
+    PRINCE_GEORGE_LICENSE: portalLicense(
+        'Open Government Licence – City of Prince George',
+        'Licence du gouvernement ouvert – Ville de Prince George',
+        'https://pgmapinfo.princegeorge.ca/opendata/CityofPrinceGeorge_Open_Government_License_Open_Data.pdf',
+        'the Open Government Licence – City of Prince George',
+        'la Licence du gouvernement ouvert – Ville de Prince George'
+    ),
+    NEW_WESTMINSTER_LICENSE: portalLicense(
+        'Open Government Licence – City of New Westminster',
+        'Licence du gouvernement ouvert – Ville de New Westminster',
+        'https://opendata.newwestcity.ca/pages/terms-of-use',
+        'the Open Government Licence – City of New Westminster',
+        'la Licence du gouvernement ouvert – Ville de New Westminster'
+    ),
+    PORT_MOODY_LICENSE: portalLicense(
+        'City of Port Moody Open Data Terms of Use',
+        'Conditions d’utilisation des données ouvertes de la Ville de Port Moody',
+        'https://www.portmoody.ca/city-government/open-data-portal/open-data-terms-of-use/',
+        'the City of Port Moody Open Data Terms of Use',
+        'les Conditions d’utilisation des données ouvertes de la Ville de Port Moody'
+    ),
+    SQUAMISH_LICENSE: portalLicense(
+        'Open Government Licence – District of Squamish',
+        'Licence du gouvernement ouvert – District de Squamish',
+        'https://squamish.ca/government-and-administration/maps-and-data/open-data/',
+        'the Open Government Licence – District of Squamish',
+        'la Licence du gouvernement ouvert – District de Squamish'
+    ),
+    MAPLE_RIDGE_LICENSE: portalLicense(
+        'Open Government Licence – City of Maple Ridge',
+        'Licence du gouvernement ouvert – Ville de Maple Ridge',
+        'https://www.mapleridge.ca/terms-use',
+        'the Open Government Licence – City of Maple Ridge',
+        'la Licence du gouvernement ouvert – Ville de Maple Ridge'
+    ),
+    PORT_COQUITLAM_LICENSE: portalLicense(
+        'Open Government Licence – City of Port Coquitlam',
+        'Licence du gouvernement ouvert – Ville de Port Coquitlam',
+        'https://data-poco.hub.arcgis.com/pages/terms',
+        'the Open Government Licence – City of Port Coquitlam',
+        'la Licence du gouvernement ouvert – Ville de Port Coquitlam'
+    )
+};
+
+function exactPattern(value) {
+    const escaped = String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp('^' + escaped + '$', 'i');
+}
+
+function donneesQuebecSource({ id, organization, cityEn, cityFr, publisherPattern, placeId }) {
+    return {
+        id,
+        kind: 'ckan',
+        nameEn: cityEn + ' Open Data',
+        nameFr: 'Données ouvertes de ' + cityFr,
+        homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/' + organization,
+        datasetBaseUrl: DONNEES_QUEBEC_DATASET,
+        catalogUrl: DONNEES_QUEBEC_ACTION,
+        upstreamHost: 'www.donneesquebec.ca',
+        catalogOrganization: organization,
+        enabled: true,
+        syncIntervalHours: 24,
+        maxDeleteFraction: 0.1,
+        metadataLanguage: 'fr',
+        directGeoJsonMaps: true,
+        defaultOrganizationId: organization,
+        defaultOrganizationName: organization,
+        defaultOrganizationTitleEn: cityEn,
+        defaultOrganizationTitleFr: cityFr,
+        licenseMode: 'record-explicit',
+        authoritativePublishers: [{ publisher: publisherPattern }],
+        licenseRules: [{ publisher: publisherPattern, licenseId: /^cc-by$/i, license: null }],
+        placeRules: [{
+            publisher: publisherPattern,
+            placeId,
+            relationship: 'direct',
+            includesDescendants: false
+        }]
+    };
+}
+
+function arcgisMunicipalSource({
+    id,
+    cityEn,
+    cityFr,
+    host,
+    homepageUrl,
+    placeId,
+    license,
+    publisherPatterns,
+    includesDescendants = false,
+    restrictedLicensePatterns = [],
+    unavailableServicePatterns = [],
+    enabled = true,
+    disabledReason = null
+}) {
+    const publisher = exactPattern(cityEn);
+    return {
+        id,
+        kind: 'arcgis-hub',
+        nameEn: cityEn + ' Open Data',
+        nameFr: 'Données ouvertes de ' + cityFr,
+        homepageUrl: homepageUrl || 'https://' + host + '/',
+        catalogUrl: 'https://' + host + '/api/feed/dcat-us/1.1.json',
+        upstreamHost: host,
+        enabled,
+        ...(disabledReason ? { disabledReason } : {}),
+        syncIntervalHours: 24,
+        maxDeleteFraction: 0.1,
+        placeholderPublisher: cityEn,
+        restrictedLicensePatterns: DEFAULT_RESTRICTED_LICENSE_PATTERNS.concat(restrictedLicensePatterns),
+        unavailableServicePatterns,
+        publisherAliases: publisherPatterns.map(pattern => ({ publisher: pattern, name: cityEn })),
+        authoritativePublishers: [{ publisher }],
+        licenseRules: license ? [{ publisher, license }] : [],
+        placeRules: [{
+            publisher,
+            placeId,
+            relationship: 'direct',
+            includesDescendants
+        }]
+    };
+}
+
+function reginaSource() {
+    const license = EXPANSION_LICENSES.REGINA_LICENSE;
+    return {
+        id: 'regina-hub',
+        kind: 'ckan',
+        nameEn: 'City of Regina Open Data',
+        nameFr: 'Données ouvertes de la Ville de Regina',
+        homepageUrl: 'https://openregina.ca/',
+        datasetBaseUrl: 'https://openregina.ca/dataset',
+        catalogUrl: 'https://openregina.ca/api/3/action',
+        upstreamHost: 'openregina.ca',
+        catalogOrganization: 'city-of-regina',
+        enabled: true,
+        syncIntervalHours: 24,
+        maxDeleteFraction: 0.1,
+        metadataLanguage: 'en',
+        defaultOrganizationId: 'city-of-regina',
+        defaultOrganizationName: 'city-of-regina',
+        defaultOrganizationTitleEn: 'City of Regina',
+        defaultOrganizationTitleFr: 'Ville de Regina',
+        licenseMode: 'record-explicit',
+        licenseRules: [{
+            publisher: /^city of regina$/i,
+            licenseId: /^notspecified$/i,
+            licenseTitle: /^open gov\. license$/i,
+            license
+        }],
+        authoritativePublishers: [{ publisher: /^city of regina$/i }],
+        placeRules: [{
+            publisher: /^city of regina$/i,
+            placeId: 'sgc-csd-4706027',
+            relationship: 'direct',
+            includesDescendants: false
+        }]
+    };
+}
+
+function redDeerSource() {
+    return {
+        id: 'red-deer-hub',
+        kind: 'red-deer',
+        nameEn: 'City of Red Deer Open Data',
+        nameFr: 'Données ouvertes de la Ville de Red Deer',
+        homepageUrl: 'https://data.reddeer.ca/',
+        catalogUrl: 'https://data.reddeer.ca/api/datasets',
+        upstreamHost: 'data.reddeer.ca',
+        enabled: true,
+        syncIntervalHours: 24,
+        maxDeleteFraction: 0.1,
+        publisher: 'The City of Red Deer',
+        license: EXPANSION_LICENSES.RED_DEER_LICENSE,
+        placeId: 'sgc-csd-4808011'
+    };
+}
+
+function gnwtSource() {
+    return {
+        id: 'northwest-territories-open-data',
+        kind: 'ckan',
+        nameEn: 'Northwest Territories Open Data',
+        nameFr: 'Données ouvertes des Territoires du Nord-Ouest',
+        homepageUrl: 'https://opendata.gov.nt.ca/',
+        datasetBaseUrl: 'https://opendata.gov.nt.ca/dataset',
+        catalogUrl: 'https://opendata.gov.nt.ca/api/3/action',
+        upstreamHost: 'opendata.gov.nt.ca',
+        enabled: true,
+        syncIntervalHours: 24,
+        maxDeleteFraction: 0.1,
+        metadataLanguage: 'en',
+        defaultOrganizationId: 'government-of-the-northwest-territories',
+        defaultOrganizationName: 'government-of-the-northwest-territories',
+        defaultOrganizationTitleEn: 'Government of the Northwest Territories',
+        defaultOrganizationTitleFr: 'Gouvernement des Territoires du Nord-Ouest',
+        licenseMode: 'record-explicit',
+        licenseRules: [{ licenseId: /^GNWT$/i, license: EXPANSION_LICENSES.GNWT_LICENSE }],
+        placeRules: [{
+            publisher: /.*/,
+            placeId: 'sgc-pr-61',
+            relationship: 'direct',
+            includesDescendants: true
+        }]
+    };
+}
+
+function buildExpansionSources({ ccBy4License }) {
+    if (!ccBy4License || !ccBy4License.url) throw new Error('CC BY 4.0 licence is required');
+
+    const dq = options => {
+        const source = donneesQuebecSource(options);
+        source.licenseRules[0].license = ccBy4License;
+        return source;
+    };
+
+    return [
+        dq({ id: 'gatineau-open-data', organization: 'ville-de-gatineau', cityEn: 'City of Gatineau', cityFr: 'la Ville de Gatineau', publisherPattern: /^ville de gatineau$/i, placeId: 'sgc-csd-2481017' }),
+        dq({ id: 'trois-rivieres-open-data', organization: 'ville-de-trois-rivieres', cityEn: 'City of Trois-Rivières', cityFr: 'la Ville de Trois-Rivières', publisherPattern: /^ville de trois-rivi[eè]res$/i, placeId: 'sgc-csd-2437067' }),
+        dq({ id: 'repentigny-open-data', organization: 'ville-de-repentigny', cityEn: 'City of Repentigny', cityFr: 'la Ville de Repentigny', publisherPattern: /^ville de repentigny$/i, placeId: 'sgc-csd-2460013' }),
+        dq({ id: 'longueuil-open-data', organization: 'ville-de-longueuil', cityEn: 'City of Longueuil', cityFr: 'la Ville de Longueuil', publisherPattern: /^ville de longueuil$/i, placeId: 'sgc-csd-2458227' }),
+        dq({ id: 'saguenay-open-data', organization: 'ville-de-saguenay', cityEn: 'City of Saguenay', cityFr: 'la Ville de Saguenay', publisherPattern: /^ville de saguenay$/i, placeId: 'sgc-csd-2494068' }),
+        dq({ id: 'rimouski-open-data', organization: 'ville-de-rimouski', cityEn: 'City of Rimouski', cityFr: 'la Ville de Rimouski', publisherPattern: /^ville de rimouski$/i, placeId: 'sgc-csd-2410043' }),
+        dq({ id: 'shawinigan-open-data', organization: 'ville-de-shawinigan', cityEn: 'City of Shawinigan', cityFr: 'la Ville de Shawinigan', publisherPattern: /^ville de shawinigan$/i, placeId: 'sgc-csd-2436033' }),
+        dq({ id: 'levis-open-data', organization: 'ville-de-levis', cityEn: 'City of Lévis', cityFr: 'la Ville de Lévis', publisherPattern: /^ville de l[eé]vis$/i, placeId: 'sgc-csd-2425213' }),
+        dq({ id: 'sherbrooke-open-data', organization: 'ville-de-sherbrooke', cityEn: 'City of Sherbrooke', cityFr: 'la Ville de Sherbrooke', publisherPattern: /^ville de sherbrooke$/i, placeId: 'sgc-csd-2443027' }),
+        arcgisMunicipalSource({ id: 'saint-john-hub', cityEn: 'City of Saint John', cityFr: 'la Ville de Saint John', host: 'catalogue-saintjohn.opendata.arcgis.com', placeId: 'sgc-csd-1301006', license: EXPANSION_LICENSES.SAINT_JOHN_LICENSE, publisherPatterns: [/^the city of saint john$/i, /^city of saint john$/i] }),
+
+        // These three municipalities do not currently publish the documented
+        // ArcGIS Hub feeds or an equivalent machine-readable catalogue under
+        // a verified open-data licence. Retain their stable source identities,
+        // but keep scheduled sync fail-closed until the municipalities expose
+        // an admissible catalogue again.
+        arcgisMunicipalSource({ id: 'whitehorse-hub', cityEn: 'City of Whitehorse', cityFr: 'la Ville de Whitehorse', host: 'data-whitehorse.opendata.arcgis.com', homepageUrl: 'https://data.whitehorse.ca/', placeId: 'sgc-csd-6001009', license: EXPANSION_LICENSES.WHITEHORSE_LICENSE, publisherPatterns: [/^(?:the )?city of whitehorse$/i], enabled: false, disabledReason: 'No live machine-readable catalogue with verified open-data terms' }),
+        arcgisMunicipalSource({ id: 'st-johns-hub', cityEn: "City of St. John's", cityFr: "la Ville de St. John's", host: 'map-stjohns.opendata.arcgis.com', homepageUrl: 'https://map.stjohns.ca/', placeId: 'sgc-csd-1001519', license: EXPANSION_LICENSES.ST_JOHNS_LICENSE, publisherPatterns: [/^(?:the )?city of st\.?\s*john'?s$/i], enabled: false, disabledReason: 'No live ArcGIS Hub feed or verified portal-wide open-data licence' }),
+        arcgisMunicipalSource({ id: 'charlottetown-hub', cityEn: 'City of Charlottetown', cityFr: 'la Ville de Charlottetown', host: 'city-charlottetown.opendata.arcgis.com', homepageUrl: 'https://www.charlottetown.ca/resident_services/maps', placeId: 'sgc-csd-1102075', license: EXPANSION_LICENSES.CHARLOTTETOWN_LICENSE, publisherPatterns: [/^(?:the )?city of charlottetown$/i], enabled: false, disabledReason: 'No live machine-readable municipal catalogue with verified open-data terms' }),
+        reginaSource(),
+        arcgisMunicipalSource({ id: 'windsor-hub', cityEn: 'City of Windsor', cityFr: 'la Ville de Windsor', host: 'open-data-portal-citywindsor.hub.arcgis.com', homepageUrl: 'https://opendata.citywindsor.ca/', placeId: 'sgc-csd-3537039', license: EXPANSION_LICENSES.WINDSOR_LICENSE, publisherPatterns: [/^(?:the )?city of windsor$/i, /^the corporation of the city of windsor$/i] }),
+        arcgisMunicipalSource({ id: 'kingston-hub', cityEn: 'City of Kingston', cityFr: 'la Ville de Kingston', host: 'opendatakingston.cityofkingston.ca', placeId: 'sgc-csd-3510010', license: EXPANSION_LICENSES.KINGSTON_LICENSE, publisherPatterns: [/^(?:the )?city of kingston$/i, /^the corporation of the city of kingston$/i, /^information systems & technology - gis group$/i], restrictedLicensePatterns: [/commercial purposes?[^.]{0,160}(?:strictly )?prohibited/i, /express written permission of opta/i] }),
+        redDeerSource(),
+        arcgisMunicipalSource({ id: 'kamloops-hub', cityEn: 'City of Kamloops', cityFr: 'la Ville de Kamloops', host: 'mydata-kamloops.opendata.arcgis.com', placeId: 'sgc-csd-5933042', license: EXPANSION_LICENSES.KAMLOOPS_LICENSE, publisherPatterns: [/^(?:the )?city of kamloops$/i] }),
+        arcgisMunicipalSource({ id: 'nanaimo-hub', cityEn: 'City of Nanaimo', cityFr: 'la Ville de Nanaimo', host: 'gisdata.nanaimo.ca', placeId: 'sgc-csd-5921007', license: EXPANSION_LICENSES.NANAIMO_LICENSE, publisherPatterns: [/^(?:the )?city of nanaimo$/i], restrictedLicensePatterns: [/disclaimer that pops up/i] }),
+        arcgisMunicipalSource({ id: 'abbotsford-hub', cityEn: 'City of Abbotsford', cityFr: 'la Ville d’Abbotsford', host: 'opendata-abbotsford.hub.arcgis.com', placeId: 'sgc-csd-5909052', license: EXPANSION_LICENSES.ABBOTSFORD_LICENSE, publisherPatterns: [/^(?:the )?city of abbotsford$/i], restrictedLicensePatterns: [/data sharing agreement with metro vancouver/i], unavailableServicePatterns: [/^https:\/\/maps\.abbotsford\.ca\/arcgis\/rest\/services\/GeocortexExt\//i] }),
+
+        gnwtSource(),
+        arcgisMunicipalSource({ id: 'coquitlam-hub', cityEn: 'City of Coquitlam', cityFr: 'la Ville de Coquitlam', host: 'data.coquitlam.ca', placeId: 'sgc-csd-5915034', license: EXPANSION_LICENSES.COQUITLAM_LICENSE, publisherPatterns: [/^city of coquitlam$/i] }),
+        arcgisMunicipalSource({ id: 'prince-george-hub', cityEn: 'City of Prince George', cityFr: 'la Ville de Prince George', host: 'data-cityofpg.opendata.arcgis.com', placeId: 'sgc-csd-5953023', license: EXPANSION_LICENSES.PRINCE_GEORGE_LICENSE, publisherPatterns: [/^city of prince george$/i] }),
+        arcgisMunicipalSource({ id: 'new-westminster-hub', cityEn: 'City of New Westminster', cityFr: 'la Ville de New Westminster', host: 'opendata.newwestcity.ca', placeId: 'sgc-csd-5915029', license: EXPANSION_LICENSES.NEW_WESTMINSTER_LICENSE, publisherPatterns: [/^city of new westminster(?:, british columbia, canada)?$/i] }),
+        arcgisMunicipalSource({ id: 'port-moody-hub', cityEn: 'City of Port Moody', cityFr: 'la Ville de Port Moody', host: 'data.portmoody.ca', placeId: 'sgc-csd-5915043', license: EXPANSION_LICENSES.PORT_MOODY_LICENSE, publisherPatterns: [/^city of port moody$/i] }),
+        arcgisMunicipalSource({ id: 'squamish-hub', cityEn: 'District of Squamish', cityFr: 'le District de Squamish', host: 'data.squamish.ca', placeId: 'sgc-csd-5931006', license: EXPANSION_LICENSES.SQUAMISH_LICENSE, publisherPatterns: [/^district of squamish$/i] }),
+        arcgisMunicipalSource({ id: 'maple-ridge-hub', cityEn: 'City of Maple Ridge', cityFr: 'la Ville de Maple Ridge', host: 'opengov.mapleridge.ca', placeId: 'sgc-csd-5915075', license: EXPANSION_LICENSES.MAPLE_RIDGE_LICENSE, publisherPatterns: [/^(?:city of )?maple ridge$/i], restrictedLicensePatterns: [/translink/i] }),
+        arcgisMunicipalSource({ id: 'port-coquitlam-hub', cityEn: 'City of Port Coquitlam', cityFr: 'la Ville de Port Coquitlam', host: 'data-poco.hub.arcgis.com', placeId: 'sgc-csd-5915039', license: EXPANSION_LICENSES.PORT_COQUITLAM_LICENSE, publisherPatterns: [/^city of port coquitlam$/i], restrictedLicensePatterns: [/pocomap/i, /internal business and personal purpose/i] }),
+        dq({ id: 'sherbrooke-geomatics-open-data', organization: 'ville-de-sherbrooke-donnees-geomatiques', cityEn: 'City of Sherbrooke Geomatics', cityFr: 'la Ville de Sherbrooke – données géomatiques', publisherPattern: /^ville de sherbrooke - donn[eé]es g[eé]omatiques$/i, placeId: 'sgc-csd-2443027' }),
+        dq({ id: 'saint-hyacinthe-open-data', organization: 'ville-de-saint-hyacinthe', cityEn: 'City of Saint-Hyacinthe', cityFr: 'la Ville de Saint-Hyacinthe', publisherPattern: /^ville de saint-hyacinthe$/i, placeId: 'sgc-csd-2454048' })
+    ];
+}
+
+module.exports = {
+    buildExpansionSources,
+    EXPANSION_LICENSES,
+    arcgisMunicipalSource,
+    donneesQuebecSource,
+    exactPattern
+};

--- a/server/config/catalogSources.js
+++ b/server/config/catalogSources.js
@@ -1,5 +1,2382 @@
-const { readFileSync } = require('fs');
-const { join } = require('path');
+const {
+    buildExpansionSources,
+    EXPANSION_LICENSES
+} = require('./catalogSourceExpansions');
 
-// Re-export canonical catalog sources configuration
-module.exports = require(join(__dirname, 'catalogSources.js'));
+const OSHAWA_LICENSE = {
+    titleEn: 'Open Government Licence – The Corporation of the City of Oshawa',
+    titleFr: 'Licence du gouvernement ouvert – The Corporation of the City of Oshawa',
+    url: 'https://map.oshawa.ca/OpenData/Open%20Government%20Licence%20version%202.0%20-%20Oshawa.pdf',
+    attributionEn: 'Contains information licensed under the Open Government Licence – The Corporation of the City of Oshawa.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – The Corporation of the City of Oshawa.'
+};
+
+const DURHAM_LICENSE = {
+    titleEn: 'Region of Durham Open Data Licence v1.0',
+    titleFr: 'Licence de données ouvertes de la région de Durham v1.0',
+    url: 'https://www.durham.ca/regional-government/access-to-information/open-data/',
+    attributionEn: "Contains public sector information made available under The Regional Municipality of Durham's Open Data Licence.",
+    attributionFr: "Contient des renseignements du secteur public fournis selon la licence de données ouvertes de la municipalité régionale de Durham."
+};
+
+const AJAX_LICENSE = {
+    titleEn: 'Town of Ajax Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville d’Ajax',
+    url: 'https://townofajax.maps.arcgis.com/sharing/rest/content/items/22e2d8e248724d7cb0310dc2db675abd/data',
+    attributionEn: 'Contains information made available under the Town of Ajax Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville d’Ajax.'
+};
+
+const PICKERING_LICENSE = {
+    titleEn: 'City of Pickering Open Data Licence v1.0',
+    titleFr: 'Licence de données ouvertes de la Ville de Pickering v1.0',
+    url: 'https://www.pickering.ca/media/depbgebg/opendatalicencepickeringv1_acc.pdf',
+    attributionEn: 'Contains information made available under the City of Pickering Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Pickering.'
+};
+
+const WHITBY_LICENSE = {
+    titleEn: 'The Corporation of the Town of Whitby Open Government Licence',
+    titleFr: 'Licence du gouvernement ouvert de la Corporation de la Ville de Whitby',
+    url: 'https://whitby.maps.arcgis.com/sharing/rest/content/items/223810efc31c40b3aff99dd74f809a97/data',
+    attributionEn: 'Contains information licensed under The Corporation of the Town of Whitby Open Government Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert de la Corporation de la Ville de Whitby.'
+};
+
+const CLOCA_LICENSE = {
+    titleEn: 'CLOCA Open Data Licence v1',
+    titleFr: 'Licence de données ouvertes de la CLOCA v1',
+    url: 'https://www.arcgis.com/home/item.html?id=20586dab57ce40fd9b102d97c144302c',
+    attributionEn: 'Contains information made available under the CLOCA Open Data Licence v1.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la CLOCA v1.'
+};
+
+const ONTARIO_LICENSE = {
+    titleEn: 'Open Government Licence – Ontario',
+    titleFr: 'Licence du gouvernement ouvert – Ontario',
+    url: 'https://www.ontario.ca/page/open-government-licence-ontario',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Ontario.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ontario.'
+};
+
+const TORONTO_LICENSE = {
+    titleEn: 'Open Government Licence – Toronto',
+    titleFr: 'Licence du gouvernement ouvert – Toronto',
+    url: 'https://open.toronto.ca/open-data-licence/',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Toronto.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Toronto.'
+};
+
+const OTTAWA_LICENSE = {
+    titleEn: 'Open Government Licence – City of Ottawa',
+    titleFr: 'Licence du gouvernement ouvert – Ville d’Ottawa',
+    url: 'https://ottawa.ca/en/city-hall/open-transparent-and-accountable-government/open-data/open-data-licence-version-20',
+    attributionEn: 'Contains information licensed under the Open Government Licence – City of Ottawa.',
+    attributionFr: 'Contient de l’information visée par la Licence du gouvernement ouvert – Ville d’Ottawa.'
+};
+
+const OTTAWA_POLICE_LICENSE = {
+    titleEn: 'Open Government Licence – Ottawa Police Service',
+    titleFr: 'Licence du gouvernement ouvert – Service de police d’Ottawa',
+    url: 'https://data.ottawapolice.ca/pages/open-data-licence',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Ottawa Police Service.',
+    attributionFr: 'Contient de l’information visée par la Licence du gouvernement ouvert – Service de police d’Ottawa.'
+};
+
+const VANCOUVER_LICENSE = {
+    titleEn: 'Open Government Licence – Vancouver',
+    titleFr: 'Licence du gouvernement ouvert – Vancouver',
+    url: 'https://opendata.vancouver.ca/pages/licence/',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Vancouver.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Vancouver.'
+};
+
+const CALGARY_LICENSE = {
+    titleEn: 'Open Government Licence – City of Calgary v2.1',
+    titleFr: 'Licence du gouvernement ouvert – Ville de Calgary v2.1',
+    url: 'https://data.calgary.ca/stories/s/Open-Calgary-Terms-of-Use/u45n-7awa/',
+    attributionEn: 'Contains information licensed under the Open Government Licence – City of Calgary.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville de Calgary.'
+};
+
+const EDMONTON_LICENSE = {
+    titleEn: 'Open Government Licence – Edmonton',
+    titleFr: 'Licence du gouvernement ouvert – Edmonton',
+    url: 'https://data.edmonton.ca/stories/s/City-of-Edmonton-Open-Data-Terms-of-Use/msh8-if28/',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Edmonton.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Edmonton.'
+};
+
+const WINNIPEG_LICENSE = {
+    titleEn: 'Open Government Licence – Winnipeg',
+    titleFr: 'Licence du gouvernement ouvert – Winnipeg',
+    url: 'https://data.winnipeg.ca/open-data-licence',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Winnipeg.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Winnipeg.'
+};
+
+const HALIFAX_LICENSE = {
+    titleEn: 'Open Government Licence – Halifax',
+    titleFr: 'Licence du gouvernement ouvert – Halifax',
+    url: 'https://data-hrm.hub.arcgis.com/pages/open-data-licence',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Halifax.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Halifax.'
+};
+
+const HAMILTON_LICENSE = {
+    titleEn: 'City of Hamilton Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Hamilton',
+    url: 'https://www.hamilton.ca/city-council/data-maps/open-data/open-data-licence-terms-and-conditions',
+    attributionEn: 'Contains public sector Data made available under the City of Hamilton’s Open Data Licence',
+    attributionFr: 'Contient des données du secteur public fournies selon la licence de données ouvertes de la Ville de Hamilton.'
+};
+
+const SURREY_LICENSE = {
+    titleEn: 'Open Government License – Surrey',
+    titleFr: 'Licence du gouvernement ouvert – Surrey',
+    url: 'https://opendata-surrey.hub.arcgis.com/pages/55089a19491a4fe59a41e059fd8af708',
+    attributionEn: 'Contains information licensed under the Open Government License – City of Surrey.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville de Surrey.'
+};
+
+// The feed currently publishes the City itself plus these exact department
+// paths. Keep the allowlist fail-closed: an unfamiliar publisher string must be
+// reviewed before portal-wide City terms can be applied to it.
+const VICTORIA_LICENSE = {
+    titleEn: 'Open Data Licence – City of Victoria',
+    titleFr: 'Licence de données ouvertes – Ville de Victoria',
+    url: 'https://opendata.victoria.ca/pages/open-data-licence',
+    attributionEn: 'Contains information licensed under the Open Data Licence – City of Victoria.',
+    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes – Ville de Victoria.'
+};
+
+const WATERLOO_REGION_LICENSE = {
+    titleEn: 'Region of Waterloo Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la municipalité régionale de Waterloo',
+    url: 'https://www.regionofwaterloo.ca/en/regional-government/open-data.aspx#Open-Data-Licence',
+    attributionEn: 'Contains public sector information made available under The Regional Municipality of Waterloo’s Open Data Licence.',
+    attributionFr: 'Contient des renseignements du secteur public fournis selon la licence de données ouvertes de la municipalité régionale de Waterloo.'
+};
+
+const KITCHENER_LICENSE = {
+    titleEn: 'City of Kitchener Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Kitchener',
+    url: 'https://open-kitchenergis.opendata.arcgis.com/pages/licence',
+    attributionEn: 'Contains information licensed under the Open Government Licence - The Corporation of the City of Kitchener.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert - The Corporation of the City of Kitchener.'
+};
+
+const CAMBRIDGE_LICENSE = {
+    titleEn: 'City of Cambridge Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Cambridge',
+    url: 'https://www.cambridge.ca/en/your-city/open-data.aspx',
+    attributionEn: 'Contains information made available under the City of Cambridge Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Cambridge.'
+};
+
+const WATERLOO_CITY_LICENSE = {
+    titleEn: 'City of Waterloo Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Waterloo',
+    url: 'https://data.waterloo.ca/pages/open-data-licence',
+    attributionEn: 'Contains information made available under the City of Waterloo Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Waterloo.'
+};
+
+const LONDON_LICENSE = {
+    titleEn: 'City of London Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de London',
+    url: 'https://open.london.ca/pages/open-data-licence',
+    attributionEn: 'Contains information made available under the City of London Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de London.'
+};
+
+const KELOWNA_LICENSE = {
+    titleEn: 'Open Government Licence – City of Kelowna',
+    titleFr: 'Licence du gouvernement ouvert – Ville de Kelowna',
+    url: 'https://www.kelowna.ca/city-hall/open-data/open-government-licence',
+    attributionEn: 'Contains information licensed under the Open Government Licence – City of Kelowna.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville de Kelowna.'
+};
+
+const FREDERICTON_LICENSE = {
+    titleEn: 'Open Data Licence – City of Fredericton',
+    titleFr: 'Licence de données ouvertes – Ville de Fredericton',
+    url: 'https://data-fredericton.opendata.arcgis.com/pages/open-data-licence',
+    attributionEn: 'Contains information made available under the Open Data Licence – City of Fredericton.',
+    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes – Ville de Fredericton.'
+};
+
+const BURLINGTON_LICENSE = {
+    titleEn: 'City of Burlington Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Burlington',
+    url: 'https://opendata.burlington.ca/opendata-terms-of-use/City%20of%20Burlington%20-%20Open%20Data%20Terms%20of%20Use.pdf',
+    attributionEn: 'Contains information made available under the City of Burlington Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Burlington.'
+};
+
+const OAKVILLE_LICENSE = {
+    titleEn: 'Town of Oakville Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville d’Oakville',
+    url: 'https://www.oakville.ca/town-hall/town-studies-plans-projects/town-initiatives/open-data/open-data-licence/',
+    attributionEn: 'Contains information made available under the Town of Oakville Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville d’Oakville.'
+};
+
+const MILTON_LICENSE = {
+    titleEn: 'Open Government Licence – Milton',
+    titleFr: 'Licence du gouvernement ouvert – Milton',
+    url: 'https://discover-milton.hub.arcgis.com/pages/disclaimer-and-terms-of-use',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Milton.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Milton.'
+};
+
+const SUDBURY_LICENSE = {
+    titleEn: 'City of Greater Sudbury Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville du Grand Sudbury',
+    url: 'https://www.greatersudbury.ca/inside-city-hall/open-data/policy/',
+    attributionEn: 'Contains information made available under the City of Greater Sudbury Open Data Policy and Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la politique et la licence de données ouvertes de la Ville du Grand Sudbury.'
+};
+
+const BURNABY_LICENSE = {
+    titleEn: 'Open Government Licence – City of Burnaby',
+    titleFr: 'Licence du gouvernement ouvert – Ville de Burnaby',
+    url: 'https://data.burnaby.ca/pages/open-government-licence',
+    attributionEn: 'Contains information licensed under the Open Government Licence – City of Burnaby.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Ville de Burnaby.'
+};
+
+const SASKATOON_LICENSE = {
+    titleEn: 'City of Saskatoon Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Saskatoon',
+    url: 'https://www.saskatoon.ca/city-hall/open-data/open-data-licence',
+    attributionEn: 'Contains information made available under the City of Saskatoon Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Saskatoon.'
+};
+
+const YORK_REGION_LICENSE = {
+    titleEn: 'York Region Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la région de York',
+    url: 'https://www.york.ca/about-york-region/open-data',
+    attributionEn: 'Contains information made available under the York Region Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la région de York.'
+};
+
+const MARKHAM_LICENSE = {
+    titleEn: 'City of Markham Open Data Terms',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Markham',
+    url: 'https://data-markham.opendata.arcgis.com/',
+    attributionEn: 'Contains information made available under the City of Markham Open Data Terms.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Markham.'
+};
+
+const NEWMARKET_LICENSE = {
+    titleEn: 'Town of Newmarket Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Newmarket',
+    url: 'https://navigate-newmarket.hub.arcgis.com/',
+    attributionEn: 'Contains information made available under the Town of Newmarket Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Newmarket.'
+};
+
+const NIAGARA_FALLS_LICENSE = {
+    titleEn: 'City of Niagara Falls Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Niagara Falls',
+    url: 'https://open.niagarafalls.ca/pages/terms-of-use',
+    attributionEn: 'Contains information made available under the City of Niagara Falls Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Niagara Falls.'
+};
+
+const WELLAND_LICENSE = {
+    titleEn: 'City of Welland Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Welland',
+    url: 'https://open.welland.ca/pages/terms-of-use',
+    attributionEn: 'Contains information made available under the City of Welland Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Welland.'
+};
+
+const MONCTON_LICENSE = {
+    titleEn: 'City of Moncton Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisations des ensembles de données de la Ville de Moncton',
+    url: 'https://www5.moncton.ca/docs/Open_Data_Terms_of_Use.pdf',
+    attributionEn: 'Contains information made available under the City of Moncton Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisations des ensembles de données de la Ville de Moncton.'
+};
+
+const GUELPH_LICENSE = {
+    titleEn: 'City of Guelph Open Data License',
+    titleFr: 'Licence de données ouvertes de la Ville de Guelph',
+    url: 'https://explore.guelph.ca/pages/open-data-license',
+    attributionEn: 'Contains information made available under the City of Guelph Open Data License.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Guelph.'
+};
+
+const SAANICH_LICENSE = {
+    titleEn: 'Open Government Licence – District of Saanich',
+    titleFr: 'Licence du gouvernement ouvert – District of Saanich',
+    url: 'https://opendata-saanich.hub.arcgis.com/',
+    attributionEn: 'Contains information licensed under the Open Government Licence – District of Saanich.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – District of Saanich.'
+};
+
+const BELLEVILLE_LICENSE = {
+    titleEn: 'City of Belleville Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Belleville',
+    url: 'https://opendata-bellevillegis.hub.arcgis.com/',
+    attributionEn: 'Contains information made available under the City of Belleville Open Data Licence.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la Ville de Belleville.'
+};
+
+const YELLOWKNIFE_LICENSE = {
+    titleEn: 'City of Yellowknife Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Yellowknife',
+    url: 'https://data-yellowknife.hub.arcgis.com/',
+    attributionEn: 'Contains information made available under the City of Yellowknife Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Yellowknife.'
+};
+
+const BARRIE_LICENSE = {
+    titleEn: 'City of Barrie Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Barrie',
+    url: 'https://opendata.barrie.ca/',
+    attributionEn: 'Contains information made available under the City of Barrie Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Barrie.'
+};
+
+const THUNDER_BAY_LICENSE = {
+    titleEn: 'City of Thunder Bay Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Thunder Bay',
+    url: 'https://www.thunderbay.ca/en/city-services/resources/City-of-Thunder-Bay-Open-Data-Licence.pdf',
+    attributionEn: 'Contains information licensed under the City of Thunder Bay Open Data Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Thunder Bay.'
+};
+
+const CHATHAM_KENT_LICENSE = {
+    titleEn: 'Municipality of Chatham-Kent Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la municipalité de Chatham-Kent',
+    url: 'https://opendata.chatham-kent.ca/',
+    attributionEn: 'Contains information made available under the Municipality of Chatham-Kent Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la municipalité de Chatham-Kent.'
+};
+
+const KAWARTHA_LAKES_LICENSE = {
+    titleEn: 'City of Kawartha Lakes Open Data Terms',
+    titleFr: 'Conditions des données ouvertes de la Ville de Kawartha Lakes',
+    url: 'https://open-data-kawartha.hub.arcgis.com/',
+    attributionEn: 'Contains information licensed by the City of Kawartha Lakes.',
+    attributionFr: 'Contient des renseignements fournis par la Ville de Kawartha Lakes.'
+};
+
+const SUMMERLAND_LICENSE = {
+    titleEn: 'District of Summerland Open Government Licence',
+    titleFr: 'Licence du gouvernement ouvert du district de Summerland',
+    url: 'https://www.summerland.ca/docs/default-source/gis/summerland-open-government-licence.pdf',
+    attributionEn: 'Contains information licensed under the District of Summerland Open Government Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert du district de Summerland.'
+};
+
+const NORFOLK_LICENSE = {
+    titleEn: 'Norfolk County Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes du comté de Norfolk',
+    url: 'https://data-norfolk.opendata.arcgis.com/',
+    attributionEn: 'Contains information licensed by Norfolk County.',
+    attributionFr: 'Contient des renseignements fournis par le comté de Norfolk.'
+};
+
+const HALDIMAND_LICENSE = {
+    titleEn: 'Haldimand County Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes du comté de Haldimand',
+    url: 'https://opendata-haldimand.hub.arcgis.com/',
+    attributionEn: 'Contains information licensed by The Corporation of Haldimand County.',
+    attributionFr: 'Contient des renseignements fournis par la Corporation du comté de Haldimand.'
+};
+
+const LETHBRIDGE_LICENSE = {
+    titleEn: 'City of Lethbridge Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Lethbridge',
+    url: 'https://opendata.lethbridge.ca/pages/terms-of-use',
+    attributionEn: 'Contains information licensed under the City of Lethbridge Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements visés par les conditions d’utilisation des données ouvertes de la Ville de Lethbridge.'
+};
+
+const MEDICINE_HAT_LICENSE = {
+    titleEn: 'City of Medicine Hat Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Medicine Hat',
+    url: 'https://opendata.medicinehat.ca/pages/licence',
+    attributionEn: 'Contains information licensed under the City of Medicine Hat Open Data Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Medicine Hat.'
+};
+
+const AIRDRIE_LICENSE = {
+    titleEn: 'City of Airdrie Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville d’Airdrie',
+    url: 'https://data-airdrie.opendata.arcgis.com/pages/terms-of-use',
+    attributionEn: 'Contains information licensed under the City of Airdrie Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements visés par les conditions d’utilisation des données ouvertes de la Ville d’Airdrie.'
+};
+
+const CANMORE_LICENSE = {
+    titleEn: 'Town of Canmore Open Data Terms',
+    titleFr: 'Conditions des données ouvertes de la Ville de Canmore',
+    url: 'https://opendata-canmore.opendata.arcgis.com/pages/terms',
+    attributionEn: 'Contains information licensed under the Town of Canmore Open Data Terms.',
+    attributionFr: 'Contient des renseignements visés par les conditions des données ouvertes de la Ville de Canmore.'
+};
+
+const PENTICTON_LICENSE = {
+    titleEn: 'City of Penticton Open Data Terms',
+    titleFr: 'Conditions des données ouvertes de la Ville de Penticton',
+    url: 'https://open.penticton.ca/pages/terms',
+    attributionEn: 'Contains information licensed under the City of Penticton Open Data Terms.',
+    attributionFr: 'Contient des renseignements visés par les conditions des données ouvertes de la Ville de Penticton.'
+};
+
+const LANGLEY_CITY_LICENSE = {
+    titleEn: 'City of Langley Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la Ville de Langley',
+    url: 'https://data-langleycity.opendata.arcgis.com/pages/licence',
+    attributionEn: 'Contains information licensed under the City of Langley Open Data Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la Ville de Langley.'
+};
+
+const HURON_LICENSE = {
+    titleEn: 'County of Huron Open Data Licence',
+    titleFr: 'Licence de données ouvertes du comté de Huron',
+    url: 'https://data-huron.opendata.arcgis.com/pages/licence',
+    attributionEn: 'Contains information licensed under the County of Huron Open Data Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes du comté de Huron.'
+};
+
+const CUMBERLAND_LICENSE = {
+    titleEn: 'Municipality of the County of Cumberland Open Data Licence',
+    titleFr: 'Licence de données ouvertes de la municipalité du comté de Cumberland',
+    url: 'https://data-cumberlandns.opendata.arcgis.com/pages/licence',
+    attributionEn: 'Contains information licensed under the Municipality of the County of Cumberland Open Data Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence de données ouvertes de la municipalité du comté de Cumberland.'
+};
+
+const HAMILTON_PUBLISHER_PATTERNS = [
+    /^city of hamilton$/i,
+    /^city of hamilton;\s*corporate services;\s*information technology$/i,
+    /^city of hamilton;\s*planning and economic development;\s*planning$/i,
+    /^city of hamilton;\s*public works;\s*transportation operations & maintenance$/i,
+    /^city of hamilton,\s*corporate services,\s*information technology,\s*business applications,\s*spatial solutions and data services$/i,
+    /^city of hamilton;\s*public works;\s*hamilton water$/i,
+    /^city of hamilton;\s*public works;\s*engineering services$/i,
+    /^city of hamilton;\s*planning and economic development;\s*transportation planning and parking$/i,
+    /^city of hamilton;\s*public works;\s*environmental services$/i,
+    /^city of hamilton;\s*planning and economic development;\s*parking and by-law services$/i,
+    /^city of hamilton;;$/i
+];
+
+const MISSISSAUGA_LICENSE = {
+    titleEn: 'City of Mississauga Open Data Terms of Use',
+    titleFr: 'Conditions d’utilisation des données ouvertes de la Ville de Mississauga',
+    url: 'https://www.mississauga.ca/file/COM/CityOfMississaugaTermsOfUse.pdf',
+    attributionEn: 'Contains information made available under the City of Mississauga Open Data Terms of Use.',
+    attributionFr: 'Contient des renseignements fournis selon les conditions d’utilisation des données ouvertes de la Ville de Mississauga.'
+};
+
+const CC_BY_4_LICENSE = {
+    titleEn: 'Creative Commons Attribution 4.0 International',
+    titleFr: 'Creative Commons Attribution 4.0 International',
+    url: 'https://creativecommons.org/licenses/by/4.0/',
+    attributionEn: 'Licensed under Creative Commons Attribution 4.0 International.',
+    attributionFr: 'Sous licence Creative Commons Attribution 4.0 International.'
+};
+
+const OGL_CANADA_LICENSE = {
+    titleEn: 'Open Government Licence – Canada',
+    titleFr: 'Licence du gouvernement ouvert – Canada',
+    url: 'https://open.canada.ca/en/open-government-licence-canada',
+    attributionEn: 'Contains information licensed under the Open Government Licence – Canada.',
+    attributionFr: 'Contient des renseignements visés par la Licence du gouvernement ouvert – Canada.'
+};
+
+const STATCAN_LICENSE = {
+    titleEn: 'Statistics Canada Open Licence',
+    titleFr: 'Licence ouverte de Statistique Canada',
+    url: 'https://www.statcan.gc.ca/en/reference/licence',
+    attributionEn: 'Contains information licensed under the Statistics Canada Open Licence.',
+    attributionFr: 'Contient des renseignements visés par la Licence ouverte de Statistique Canada.'
+};
+
+const PEEL_LICENSE = {
+    titleEn: 'Open Data Licence for The Regional Municipality of Peel v1.0',
+    titleFr: 'Licence de données ouvertes de la municipalité régionale de Peel v1.0',
+    url: 'https://data.peelregion.ca/pages/license',
+    attributionEn: 'Contains information made available under the Open Data Licence for The Regional Municipality of Peel.',
+    attributionFr: 'Contient des renseignements fournis selon la licence de données ouvertes de la municipalité régionale de Peel.'
+};
+
+const DURHAM_PUBLISHER = /(regional municipality of durham|region of durham)/i;
+const ONTARIO_PUBLISHER = /(ontario|ministry of natural resources|aviation, forest fire)/i;
+const CONSERVATION_PUBLISHER = /(conservation ontario|central lake ontario)/i;
+
+const regionalRules = {
+    licenseRules: [
+        { publisher: DURHAM_PUBLISHER, license: DURHAM_LICENSE },
+        { publisher: /township of (brock|scugog|uxbridge)/i, license: DURHAM_LICENSE },
+        { publisher: CONSERVATION_PUBLISHER, license: CLOCA_LICENSE },
+        { publisher: ONTARIO_PUBLISHER, license: ONTARIO_LICENSE }
+    ],
+    placeRules: [
+        { publisher: DURHAM_PUBLISHER, placeId: 'ca-on-durham', relationship: 'coverage', includesDescendants: true },
+        { publisher: CONSERVATION_PUBLISHER, placeId: 'ca-on-durham', relationship: 'coverage', includesDescendants: true },
+        { publisher: ONTARIO_PUBLISHER, placeId: 'ca-on', relationship: 'coverage', includesDescendants: true }
+    ]
+};
+
+// Daily sync order is intentional. Within each regional cluster, municipal
+// portals run before the regional portal so a future shared ArcGIS item keeps
+// the authoritative regional metadata while retaining every provenance row.
+const sources = [{
+    id: 'toronto-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Toronto Open Data',
+    nameFr: 'Données ouvertes de la Ville de Toronto',
+    homepageUrl: 'https://open.toronto.ca/',
+    catalogUrl: 'https://ckan0.cf.opendata.inter.prod-toronto.ca/api/3/action',
+    upstreamHost: 'ckan0.cf.opendata.inter.prod-toronto.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    placeId: 'sgc-cd-3520',
+    metadataLanguage: 'en',
+    defaultOrganizationId: 'city-of-toronto',
+    defaultOrganizationName: 'city-of-toronto',
+    defaultOrganizationTitleEn: 'City of Toronto',
+    defaultOrganizationTitleFr: 'Ville de Toronto',
+    defaultLicenseTitleEn: TORONTO_LICENSE.titleEn,
+    defaultLicenseTitleFr: TORONTO_LICENSE.titleFr,
+    defaultLicenseUrl: TORONTO_LICENSE.url,
+    defaultAttributionEn: TORONTO_LICENSE.attributionEn,
+    defaultAttributionFr: TORONTO_LICENSE.attributionFr
+}, {
+    id: 'montreal-open-data',
+    kind: 'ckan',
+    nameEn: 'Montréal Open Data',
+    nameFr: 'Données ouvertes de la Ville de Montréal',
+    homepageUrl: 'https://donnees.montreal.ca/',
+    catalogUrl: 'https://donnees.montreal.ca/api/3/action',
+    upstreamHost: 'donnees.montreal.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-montreal',
+    defaultOrganizationName: 'ville-de-montreal',
+    defaultOrganizationTitleFr: 'Ville de Montréal',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de montréal$/i }],
+    licenseRules: [
+        { licenseId: /^cc-by$/i, license: CC_BY_4_LICENSE },
+        { licenseId: /^ogl-canada-2\.0$/i, license: OGL_CANADA_LICENSE }
+    ],
+    placeRules: [
+        {
+            publisher: /^ville de montréal$/i,
+            placeId: 'sgc-csd-2466023',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            placeId: 'sgc-csd-2466023',
+            relationship: 'coverage',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'quebec-city-open-data',
+    kind: 'ckan',
+    nameEn: 'Québec City Open Data',
+    nameFr: 'Données ouvertes de la Ville de Québec',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-quebec',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-quebec',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-quebec',
+    defaultOrganizationName: 'ville-de-quebec',
+    defaultOrganizationTitleEn: 'Québec City',
+    defaultOrganizationTitleFr: 'Ville de Québec',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de québec$/i }],
+    licenseRules: [{
+        publisher: /^ville de québec$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de québec$/i,
+        placeId: 'sgc-csd-2423027',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'laval-open-data',
+    kind: 'ckan',
+    nameEn: 'City of Laval Open Data',
+    nameFr: 'Données ouvertes de la Ville de Laval',
+    homepageUrl: 'https://www.donneesquebec.ca/recherche/organization/ville-de-laval',
+    datasetBaseUrl: 'https://www.donneesquebec.ca/recherche/dataset',
+    catalogUrl: 'https://www.donneesquebec.ca/recherche/api/3/action',
+    upstreamHost: 'www.donneesquebec.ca',
+    catalogOrganization: 'ville-de-laval',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'fr',
+    directGeoJsonMaps: true,
+    defaultOrganizationId: 'ville-de-laval',
+    defaultOrganizationName: 'ville-de-laval',
+    defaultOrganizationTitleEn: 'City of Laval',
+    defaultOrganizationTitleFr: 'Ville de Laval',
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^ville de laval$/i }],
+    licenseRules: [{
+        publisher: /^ville de laval$/i,
+        licenseId: 'cc-by',
+        licenseTitle: 'Attribution (CC-BY 4.0)',
+        licenseUrl: 'https://www.donneesquebec.ca/licence/#cc-by',
+        license: CC_BY_4_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^ville de laval$/i,
+        placeId: 'sgc-cd-2465',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'ottawa-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Ottawa Open Data',
+    nameFr: 'Données ouvertes de la Ville d’Ottawa',
+    homepageUrl: 'https://open.ottawa.ca/',
+    catalogUrl: 'https://open.ottawa.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open.ottawa.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of ottawa$/i, name: 'City of Ottawa' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of ottawa$/i }],
+    // The City licence applies portal-wide. Explicit Ottawa Police licence
+    // evidence wins first so those records retain their own attribution.
+    licenseRules: [
+        {
+            licensePattern: /data\.ottawapolice\.ca\/pages\/open-data-licence/i,
+            license: OTTAWA_POLICE_LICENSE
+        },
+        { publisher: /^city of ottawa$/i, license: OTTAWA_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /^city of ottawa$/i,
+        placeId: 'sgc-cd-3506',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'vancouver-open-data',
+    kind: 'opendatasoft',
+    nameEn: 'City of Vancouver Open Data',
+    nameFr: 'Données ouvertes de la Ville de Vancouver',
+    homepageUrl: 'https://opendata.vancouver.ca/',
+    catalogUrl: 'https://opendata.vancouver.ca/api/explore/v2.1',
+    upstreamHost: 'opendata.vancouver.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'en',
+    timezone: 'America/Vancouver',
+    defaultOrganizationId: 'city-of-vancouver',
+    defaultOrganizationName: 'city-of-vancouver',
+    defaultOrganizationTitleEn: 'City of Vancouver',
+    defaultOrganizationTitleFr: 'Ville de Vancouver',
+    defaultLicenseTitleEn: VANCOUVER_LICENSE.titleEn,
+    defaultLicenseTitleFr: VANCOUVER_LICENSE.titleFr,
+    defaultLicenseUrl: VANCOUVER_LICENSE.url,
+    defaultAttributionEn: VANCOUVER_LICENSE.attributionEn,
+    defaultAttributionFr: VANCOUVER_LICENSE.attributionFr,
+    licenseMode: 'record-explicit',
+    authoritativePublishers: [{ publisher: /^city of vancouver$/i }],
+    licenseRules: [{
+        publisher: /^city of vancouver$/i,
+        licenseTitle: /^open government licence\s*[-–]\s*vancouver$/i,
+        licenseUrl: /^https:\/\/opendata\.vancouver\.ca\/pages\/licence\/?$/i,
+        license: VANCOUVER_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^city of vancouver$/i,
+        placeId: 'sgc-csd-5915022',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'calgary-open-data',
+    kind: 'socrata',
+    nameEn: 'City of Calgary Open Data',
+    nameFr: 'Données ouvertes de la Ville de Calgary',
+    homepageUrl: 'https://data.calgary.ca/',
+    catalogUrl: 'https://data.calgary.ca/api/catalog/v1',
+    upstreamHost: 'data.calgary.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'en',
+    placeId: 'sgc-csd-4806016',
+    defaultOrganizationId: 'city-of-calgary',
+    defaultOrganizationName: 'city-of-calgary',
+    defaultOrganizationTitleEn: 'City of Calgary',
+    defaultOrganizationTitleFr: 'Ville de Calgary',
+    defaultLicenseTitleEn: CALGARY_LICENSE.titleEn,
+    defaultLicenseTitleFr: CALGARY_LICENSE.titleFr,
+    defaultLicenseUrl: CALGARY_LICENSE.url,
+    defaultAttributionEn: CALGARY_LICENSE.attributionEn,
+    defaultAttributionFr: CALGARY_LICENSE.attributionFr,
+    socrataPolicy: {
+        publisher: {
+            mode: 'custom-field', section: 'Data Supplier', field: 'Organization',
+            allowed: ['The City of Calgary']
+        },
+        license: {
+            mode: 'custom-field', section: 'License/Attribution',
+            fields: ['License URL', 'License-URL'], comparison: 'url',
+            allowed: [
+                'https://data.calgary.ca/d/Open-Data-Terms/u45n-7awa',
+                'https://data.calgary.ca/stories/s/u45n-7awa/'
+            ]
+        }
+    }
+}, {
+    id: 'edmonton-open-data',
+    kind: 'socrata',
+    nameEn: 'City of Edmonton Open Data',
+    nameFr: 'Données ouvertes de la Ville d’Edmonton',
+    homepageUrl: 'https://data.edmonton.ca/',
+    catalogUrl: 'https://data.edmonton.ca/api/catalog/v1',
+    upstreamHost: 'data.edmonton.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'en',
+    placeId: 'sgc-csd-4811061',
+    defaultOrganizationId: 'city-of-edmonton',
+    defaultOrganizationName: 'city-of-edmonton',
+    defaultOrganizationTitleEn: 'City of Edmonton',
+    defaultOrganizationTitleFr: 'Ville d’Edmonton',
+    defaultLicenseTitleEn: EDMONTON_LICENSE.titleEn,
+    defaultLicenseTitleFr: EDMONTON_LICENSE.titleFr,
+    defaultLicenseUrl: EDMONTON_LICENSE.url,
+    defaultAttributionEn: EDMONTON_LICENSE.attributionEn,
+    defaultAttributionFr: EDMONTON_LICENSE.attributionFr,
+    socrataPolicy: {
+        publisher: {
+            mode: 'attribution',
+            allowed: ['City of Edmonton', 'The City of Edmonton']
+        },
+        license: {
+            mode: 'view-license-name',
+            allowed: ['See Terms of Use']
+        }
+    }
+}, {
+    id: 'winnipeg-open-data',
+    kind: 'socrata',
+    nameEn: 'City of Winnipeg Open Data',
+    nameFr: 'Données ouvertes de la Ville de Winnipeg',
+    homepageUrl: 'https://data.winnipeg.ca/',
+    catalogUrl: 'https://data.winnipeg.ca/api/catalog/v1',
+    upstreamHost: 'data.winnipeg.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    metadataLanguage: 'en',
+    placeId: 'sgc-csd-4611040',
+    defaultOrganizationId: 'city-of-winnipeg',
+    defaultOrganizationName: 'city-of-winnipeg',
+    defaultOrganizationTitleEn: 'City of Winnipeg',
+    defaultOrganizationTitleFr: 'Ville de Winnipeg',
+    defaultLicenseTitleEn: WINNIPEG_LICENSE.titleEn,
+    defaultLicenseTitleFr: WINNIPEG_LICENSE.titleFr,
+    defaultLicenseUrl: WINNIPEG_LICENSE.url,
+    defaultAttributionEn: WINNIPEG_LICENSE.attributionEn,
+    defaultAttributionFr: WINNIPEG_LICENSE.attributionFr,
+    socrataPolicy: {
+        publisher: {
+            mode: 'attribution', allowBlank: true,
+            allowed: ['City of Winnipeg', 'Winnipeg Transit', 'Public Works', 'City Clerks']
+        },
+        license: {
+            mode: 'custom-field', section: 'Licence', field: 'Licence',
+            allowed: ['Open Government Licence - Winnipeg']
+        }
+    }
+}, {
+    id: 'halifax-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Halifax Regional Municipality Open Data',
+    nameFr: 'Données ouvertes de la municipalité régionale d’Halifax',
+    homepageUrl: 'https://data-hrm.hub.arcgis.com/',
+    catalogUrl: 'https://data-hrm.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-hrm.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^halifax regional municipality$/i, name: 'Halifax Regional Municipality' }
+    ],
+    authoritativePublishers: [{ publisher: /^halifax regional municipality$/i }],
+    // The official Halifax licence applies portal-wide, but only exact HRM
+    // publisher evidence is admitted. Placeholder and external records remain
+    // fail-closed, and explicit restricted terms are checked first.
+    licenseRules: [{
+        publisher: /^halifax regional municipality$/i,
+        license: HALIFAX_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^halifax regional municipality$/i,
+        placeId: 'sgc-csd-1209034',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'hamilton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Hamilton Open Data',
+    nameFr: 'Données ouvertes de la Ville de Hamilton',
+    homepageUrl: 'https://open.hamilton.ca/',
+    catalogUrl: 'https://open.hamilton.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open.hamilton.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: HAMILTON_PUBLISHER_PATTERNS.map(publisher => ({
+        publisher, name: 'City of Hamilton'
+    })),
+    authoritativePublishers: [{ publisher: /^city of hamilton$/i }],
+    // The official licence governs the open-data catalogue. Apply it only
+    // after an exact configured City/department publisher match and after the
+    // restricted-terms check above.
+    licenseRules: [{
+        publisher: /^city of hamilton$/i,
+        license: HAMILTON_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^city of hamilton$/i,
+        placeId: 'sgc-cd-3525',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'surrey-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Surrey Open Data',
+    nameFr: 'Données ouvertes de la Ville de Surrey',
+    homepageUrl: 'https://opendata-surrey.hub.arcgis.com/',
+    catalogUrl: 'https://opendata-surrey.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-surrey.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^city of surrey$/i, name: 'City of Surrey' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of surrey$/i }],
+    // Surrey's official open-data page applies this licence portal-wide. Keep
+    // admission tied to exact City publisher evidence; generic ArcGIS
+    // placeholder text is not a restriction, while explicit restrictive terms
+    // and external publishers still fail closed.
+    licenseRules: [{
+        publisher: /^city of surrey$/i,
+        license: SURREY_LICENSE
+    }],
+    placeRules: [{
+        publisher: /^city of surrey$/i,
+        placeId: 'sgc-csd-5915004',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'oshawa-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Oshawa Open Data Hub',
+    nameFr: 'Portail de données ouvertes de la Ville d’Oshawa',
+    homepageUrl: 'https://city-oshawa.opendata.arcgis.com/',
+    catalogUrl: 'https://city-oshawa.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'city-oshawa.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^(the corporation of the )?city of oshawa$/i, name: 'City of Oshawa' },
+        { publisher: DURHAM_PUBLISHER, name: 'Regional Municipality of Durham' }
+    ],
+    authoritativePublishers: [{ publisher: /city of oshawa/i }],
+    licenseRules: [
+        { publisher: /city of oshawa/i, license: OSHAWA_LICENSE },
+        ...regionalRules.licenseRules
+    ],
+    placeRules: [
+        { publisher: /city of oshawa/i, placeId: 'ca-on-oshawa', relationship: 'direct', includesDescendants: false },
+        ...regionalRules.placeRules
+    ]
+}, {
+    id: 'ajax-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Town of Ajax Open Data Portal',
+    nameFr: 'Portail de données ouvertes de la Ville d’Ajax',
+    homepageUrl: 'https://opendata.ajax.ca/',
+    catalogUrl: 'https://opendata.ajax.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.ajax.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^(the corporation of the )?town of ajax$/i, name: 'Town of Ajax' }
+    ],
+    authoritativePublishers: [{ publisher: /town of ajax/i }],
+    licenseRules: [{ publisher: /town of ajax/i, license: AJAX_LICENSE }],
+    placeRules: [{
+        publisher: /town of ajax/i,
+        placeId: 'sgc-csd-3518005',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'pickering-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Pickering Open Data Portal',
+    nameFr: 'Portail de données ouvertes de la Ville de Pickering',
+    homepageUrl: 'https://opendata.pickering.ca/',
+    catalogUrl: 'https://opendata.pickering.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.pickering.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^(the )?city of pickering$/i, name: 'City of Pickering' },
+        { publisher: /^opendata_cityofpickering$/i, name: 'City of Pickering' },
+        { publisher: DURHAM_PUBLISHER, name: 'Regional Municipality of Durham' }
+    ],
+    authoritativePublishers: [{ publisher: /city of pickering/i }],
+    licenseRules: [
+        { publisher: /city of pickering/i, license: PICKERING_LICENSE },
+        ...regionalRules.licenseRules
+    ],
+    placeRules: [
+        {
+            publisher: /city of pickering/i,
+            placeId: 'sgc-csd-3518001',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        ...regionalRules.placeRules
+    ]
+}, {
+    id: 'whitby-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Town of Whitby GeoHub',
+    nameFr: 'Géoportail de la Ville de Whitby',
+    homepageUrl: 'https://geohub-whitby.hub.arcgis.com/',
+    catalogUrl: 'https://geohub-whitby.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'geohub-whitby.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    licenseMode: 'record-explicit',
+    restrictedLicensePatterns: [/personal,?\s+non-commercial/i],
+    publisherAliases: [
+        { publisher: /^(the corporation of the )?town of whitby$/i, name: 'Town of Whitby' }
+    ],
+    authoritativePublishers: [{ publisher: /town of whitby/i }],
+    licenseRules: [{
+        publisher: /town of whitby/i,
+        licensePattern: /(223810efc31c40b3aff99dd74f809a97|open government licen[cs]e)/i,
+        license: WHITBY_LICENSE
+    }],
+    placeRules: [{
+        publisher: /town of whitby/i,
+        placeId: 'sgc-csd-3518009',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'durham-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Regional Municipality of Durham Open Data',
+    nameFr: 'Données ouvertes de la municipalité régionale de Durham',
+    homepageUrl: 'https://opendata.durham.ca/',
+    catalogUrl: 'https://opendata.durham.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.durham.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: DURHAM_PUBLISHER, name: 'Regional Municipality of Durham' }
+    ],
+    authoritativePublishers: [
+        { publisher: DURHAM_PUBLISHER },
+        { publisher: /township of (brock|scugog|uxbridge)/i }
+    ],
+    licenseRules: regionalRules.licenseRules,
+    placeRules: [
+        { publisher: DURHAM_PUBLISHER, placeId: 'ca-on-durham', relationship: 'direct', includesDescendants: true },
+        {
+            publisher: /township of brock/i,
+            placeId: 'sgc-csd-3518039',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /township of scugog/i,
+            placeId: 'sgc-csd-3518020',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /township of uxbridge/i,
+            placeId: 'sgc-csd-3518029',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        { publisher: ONTARIO_PUBLISHER, placeId: 'ca-on', relationship: 'coverage', includesDescendants: true }
+    ]
+}, {
+    id: 'mississauga-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Mississauga Open Data',
+    nameFr: 'Données ouvertes de Mississauga',
+    homepageUrl: 'https://data.mississauga.ca/',
+    catalogUrl: 'https://data.mississauga.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data.mississauga.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of mississauga$/i, name: 'City of Mississauga' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of mississauga$/i }],
+    // The portal-wide terms apply to City datasets even when an ArcGIS item
+    // omits its per-record licence. More specific third-party terms win first.
+    licenseRules: [
+        { licensePattern: /statcan\.gc\.ca|statistics canada open licen[cs]e/i, license: STATCAN_LICENSE },
+        { publisher: /^city of mississauga$/i, license: MISSISSAUGA_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /^city of mississauga$/i,
+        placeId: 'sgc-csd-3521005',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'brampton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Brampton GeoHub',
+    nameFr: 'Géoportail de Brampton',
+    homepageUrl: 'https://geohub.brampton.ca/',
+    catalogUrl: 'https://geohub.brampton.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'geohub.brampton.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    licenseMode: 'record-explicit',
+    restrictedLicensePatterns: [/non.?commercial/i, /elections\.on\.ca/i],
+    publisherAliases: [
+        { publisher: /^city of brampton$/i, name: 'City of Brampton' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of brampton$/i }],
+    licenseRules: [
+        { licensePattern: /statcan\.gc\.ca|statistics canada open licen[cs]e/i, license: STATCAN_LICENSE },
+        {
+            licensePattern: /creativecommons\.org\/licenses\/by\/4\.0|creative commons attribution|creative commons by-law/i,
+            license: CC_BY_4_LICENSE
+        }
+    ],
+    placeRules: [{
+        publisher: /^city of brampton$/i,
+        placeId: 'sgc-csd-3521010',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'peel-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Peel Region Data Portal',
+    nameFr: 'Portail de données de la région de Peel',
+    homepageUrl: 'https://data.peelregion.ca/',
+    catalogUrl: 'https://data.peelregion.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data.peelregion.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    licenseMode: 'record-explicit',
+    restrictedLicensePatterns: [/peelregion\.ca\/privacy\/terms-of-use/i],
+    publisherAliases: [
+        { publisher: /regional municipality of peel|region of peel/i, name: 'Regional Municipality of Peel' }
+    ],
+    authoritativePublishers: [{ publisher: /^regional municipality of peel$/i }],
+    licenseRules: [
+        { licensePattern: /statcan\.gc\.ca|statistics canada open licen[cs]e/i, license: STATCAN_LICENSE },
+        {
+            licensePattern: /data\.peelregion\.ca\/pages\/license|open data licence for the regional municipality of peel/i,
+            license: PEEL_LICENSE
+        },
+        { licensePattern: /ontario\.ca\/page\/open-government-licence/i, license: ONTARIO_LICENSE }
+    ],
+    placeRules: [{
+        placeId: 'sgc-cd-3521',
+        relationship: 'direct',
+        includesDescendants: true
+    }]
+},
+{
+    id: 'victoria-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Victoria Open Data',
+    nameFr: 'Données ouvertes de la Ville de Victoria',
+    homepageUrl: 'https://opendata.victoria.ca/',
+    catalogUrl: 'https://opendata.victoria.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.victoria.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of victoria$/i, name: 'City of Victoria' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of victoria$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /^city of victoria$/i,
+            license: VICTORIA_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^city of victoria$/i,
+            placeId: 'sgc-csd-5917034',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'waterloo-region-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Region of Waterloo Open Data',
+    nameFr: 'Données ouvertes de la région de Waterloo',
+    homepageUrl: 'https://rowopendata-rmw.opendata.arcgis.com/',
+    catalogUrl: 'https://rowopendata-rmw.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'rowopendata-rmw.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^region of waterloo$/i, name: 'Region of Waterloo' },
+        { publisher: /^city of kitchener$/i, name: 'City of Kitchener' },
+        { publisher: /^city of cambridge$/i, name: 'City of Cambridge' },
+        { publisher: /^city of waterloo$/i, name: 'City of Waterloo' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^region of waterloo$/i },
+        { publisher: /^city of kitchener$/i },
+        { publisher: /^city of cambridge$/i },
+        { publisher: /^city of waterloo$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /^region of waterloo$/i,
+            license: WATERLOO_REGION_LICENSE
+        },
+        {
+            publisher: /^city of kitchener$/i,
+            license: KITCHENER_LICENSE
+        },
+        {
+            publisher: /^city of cambridge$/i,
+            license: CAMBRIDGE_LICENSE
+        },
+        {
+            publisher: /^city of waterloo$/i,
+            license: WATERLOO_CITY_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^region of waterloo$/i,
+            placeId: 'sgc-cd-3530',
+            relationship: 'direct',
+            includesDescendants: true
+        },
+        {
+            publisher: /^city of kitchener$/i,
+            placeId: 'sgc-csd-3530013',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /^city of cambridge$/i,
+            placeId: 'sgc-csd-3530010',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /^city of waterloo$/i,
+            placeId: 'sgc-csd-3530016',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'london-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of London Open Data',
+    nameFr: 'Données ouvertes de la Ville de London',
+    homepageUrl: 'https://open-london.opendata.arcgis.com/',
+    catalogUrl: 'https://open-london.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-london.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of london$/i, name: 'City of London' },
+        { publisher: /^cityoflondon_admin$/i, name: 'City of London' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of london$/i },
+        { publisher: /^cityoflondon_admin$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /.*/,
+            license: LONDON_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-3539036',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'kelowna-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Kelowna Open Data',
+    nameFr: 'Données ouvertes de la Ville de Kelowna',
+    homepageUrl: 'https://opendata.kelowna.ca/',
+    catalogUrl: 'https://opendata.kelowna.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.kelowna.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of kelowna$/i, name: 'City of Kelowna' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of kelowna$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /^city of kelowna$/i,
+            license: KELOWNA_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^city of kelowna$/i,
+            placeId: 'sgc-csd-5935010',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'fredericton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Fredericton Open Data',
+    nameFr: 'Données ouvertes de la Ville de Fredericton',
+    homepageUrl: 'https://data-fredericton.opendata.arcgis.com/',
+    catalogUrl: 'https://data-fredericton.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-fredericton.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of fredericton$/i, name: 'City of Fredericton' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of fredericton$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /^city of fredericton$/i,
+            license: FREDERICTON_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^city of fredericton$/i,
+            placeId: 'sgc-csd-1310032',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'burlington-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Burlington Open Data',
+    nameFr: 'Données ouvertes de la Ville de Burlington',
+    homepageUrl: 'https://navburl-burlington.opendata.arcgis.com/',
+    catalogUrl: 'https://navburl-burlington.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'navburl-burlington.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of burlington$/i, name: 'City of Burlington' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Burlington' }
+    ],
+    authoritativePublishers: [
+        { publisher: /burlington/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /.*/,
+            license: BURLINGTON_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-3524002',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'oakville-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Town of Oakville Open Data',
+    nameFr: 'Données ouvertes de la Ville d’Oakville',
+    homepageUrl: 'https://portal-exploreoakville.opendata.arcgis.com/',
+    catalogUrl: 'https://portal-exploreoakville.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'portal-exploreoakville.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^town of oakville$/i, name: 'Town of Oakville' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^town of oakville$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /^town of oakville$/i,
+            license: OAKVILLE_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^town of oakville$/i,
+            placeId: 'sgc-csd-3524001',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'milton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Town of Milton Open Data',
+    nameFr: 'Données ouvertes de la Ville de Milton',
+    homepageUrl: 'https://discover-milton.hub.arcgis.com/',
+    catalogUrl: 'https://discover-milton.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'discover-milton.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^town of milton$/i, name: 'Town of Milton' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^town of milton$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /^town of milton$/i,
+            license: MILTON_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /^town of milton$/i,
+            placeId: 'sgc-csd-3524009',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'sudbury-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Greater Sudbury Open Data',
+    nameFr: 'Données ouvertes de la Ville du Grand Sudbury',
+    homepageUrl: 'https://opendata.greatersudbury.ca/',
+    catalogUrl: 'https://opendata.greatersudbury.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.greatersudbury.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of greater sudbury$/i, name: 'City of Greater Sudbury' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Greater Sudbury' }
+    ],
+    authoritativePublishers: [
+        { publisher: /greater sudbury/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /.*/,
+            license: SUDBURY_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-cd-3553',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'burnaby-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Burnaby Open Data',
+    nameFr: 'Données ouvertes de la Ville de Burnaby',
+    homepageUrl: 'https://data.burnaby.ca/',
+    catalogUrl: 'https://data.burnaby.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data.burnaby.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of burnaby$/i, name: 'City of Burnaby' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Burnaby' }
+    ],
+    authoritativePublishers: [
+        { publisher: /burnaby/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /.*/,
+            license: BURNABY_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-5915025',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'saskatoon-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Saskatoon Open Data',
+    nameFr: 'Données ouvertes de la Ville de Saskatoon',
+    homepageUrl: 'https://opendata.saskatoon.ca/',
+    catalogUrl: 'https://opendata.saskatoon.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.saskatoon.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of saskatoon$/i, name: 'City of Saskatoon' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Saskatoon' }
+    ],
+    authoritativePublishers: [
+        { publisher: /saskatoon/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        {
+            publisher: /.*/,
+            license: SASKATOON_LICENSE
+        }
+    ],
+    placeRules: [
+        {
+            publisher: /.*/,
+            placeId: 'sgc-csd-4711066',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'markham-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Markham Open Data',
+    nameFr: 'Données ouvertes de la Ville de Markham',
+    homepageUrl: 'https://open.markham.ca/',
+    catalogUrl: 'https://data-markham.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-markham.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of markham$/i, name: 'City of Markham' },
+        { publisher: /^regional municipality of york$/i, name: 'York Region' },
+        { publisher: /^york region$/i, name: 'York Region' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Markham' }
+    ],
+    authoritativePublishers: [
+        { publisher: /markham/i },
+        { publisher: /york/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /york/i, license: YORK_REGION_LICENSE },
+        { publisher: /.*/, license: MARKHAM_LICENSE }
+    ],
+    placeRules: [
+        {
+            publisher: /markham/i,
+            placeId: 'sgc-csd-3519036',
+            relationship: 'direct',
+            includesDescendants: false
+        },
+        {
+            publisher: /york/i,
+            placeId: 'sgc-cd-3519',
+            relationship: 'direct',
+            includesDescendants: true
+        },
+        {
+            publisher: /^\{\{source\}\}$/i,
+            placeId: 'sgc-csd-3519036',
+            relationship: 'direct',
+            includesDescendants: false
+        }
+    ]
+}, {
+    id: 'newmarket-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Town of Newmarket Open Data',
+    nameFr: 'Données ouvertes de la Ville de Newmarket',
+    homepageUrl: 'https://navigate-newmarket.hub.arcgis.com/',
+    catalogUrl: 'https://navigate-newmarket.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'navigate-newmarket.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^town of newmarket$/i, name: 'Town of Newmarket' },
+        { publisher: /^\{\{source\}\}$/i, name: 'Town of Newmarket' }
+    ],
+    authoritativePublishers: [
+        { publisher: /newmarket/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: NEWMARKET_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3519048',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'niagara-falls-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Niagara Falls Open Data',
+    nameFr: 'Données ouvertes de la Ville de Niagara Falls',
+    homepageUrl: 'https://open.niagarafalls.ca/',
+    catalogUrl: 'https://open.niagarafalls.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open.niagarafalls.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of niagara falls$/i, name: 'City of Niagara Falls' },
+        { publisher: /^the city of niagara falls$/i, name: 'City of Niagara Falls' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Niagara Falls' }
+    ],
+    authoritativePublishers: [
+        { publisher: /niagara falls/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: NIAGARA_FALLS_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3526043',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'welland-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Welland Open Data',
+    nameFr: 'Données ouvertes de la Ville de Welland',
+    homepageUrl: 'https://open.welland.ca/',
+    catalogUrl: 'https://open-welland.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-welland.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of welland$/i, name: 'City of Welland' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Welland' }
+    ],
+    authoritativePublishers: [
+        { publisher: /welland/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: WELLAND_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3526032',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'moncton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Moncton Open Data',
+    nameFr: 'Données ouvertes de la Ville de Moncton',
+    homepageUrl: 'https://open.moncton.ca/',
+    catalogUrl: 'https://open.moncton.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open.moncton.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of moncton$/i, name: 'City of Moncton' },
+        { publisher: /^ville de moncton$/i, name: 'City of Moncton' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Moncton' }
+    ],
+    authoritativePublishers: [
+        { publisher: /moncton/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: MONCTON_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-1307022',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'guelph-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Guelph Open Data',
+    nameFr: 'Données ouvertes de la Ville de Guelph',
+    homepageUrl: 'https://explore.guelph.ca/',
+    catalogUrl: 'https://geodatahub-cityofguelph.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'geodatahub-cityofguelph.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of guelph$/i, name: 'City of Guelph' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Guelph' }
+    ],
+    authoritativePublishers: [
+        { publisher: /guelph/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: GUELPH_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3523008',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'saanich-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'District of Saanich Open Data',
+    nameFr: 'Données ouvertes du district de Saanich',
+    homepageUrl: 'https://opendata-saanich.hub.arcgis.com/',
+    catalogUrl: 'https://opendata-saanich.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-saanich.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^district of saanich$/i, name: 'District of Saanich' },
+        { publisher: /^saanich$/i, name: 'District of Saanich' }
+    ],
+    authoritativePublishers: [
+        { publisher: /saanich/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: SAANICH_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-5917021',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'belleville-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Belleville Open Data',
+    nameFr: 'Données ouvertes de la Ville de Belleville',
+    homepageUrl: 'https://opendata-bellevillegis.hub.arcgis.com/',
+    catalogUrl: 'https://opendata-bellevillegis.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-bellevillegis.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [
+        /non.?commercial/i,
+        /personal use only/i
+    ],
+    publisherAliases: [
+        { publisher: /^city of belleville/i, name: 'City of Belleville' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of belleville/i }],
+    licenseRules: [
+        { publisher: /^city of belleville/i, license: BELLEVILLE_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /^city of belleville/i,
+        placeId: 'sgc-csd-3512005',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'yellowknife-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Yellowknife Open Data',
+    nameFr: 'Données ouvertes de la Ville de Yellowknife',
+    homepageUrl: 'https://data-yellowknife.hub.arcgis.com/',
+    catalogUrl: 'https://data-yellowknife.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-yellowknife.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^city of yellowknife$/i, name: 'City of Yellowknife' }
+    ],
+    authoritativePublishers: [{ publisher: /^city of yellowknife$/i }],
+    licenseRules: [
+        { publisher: /.*/, license: YELLOWKNIFE_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-6106023',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'barrie-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Barrie Open Data',
+    nameFr: 'Données ouvertes de la Ville de Barrie',
+    homepageUrl: 'https://opendata.barrie.ca/',
+    catalogUrl: 'https://opendata.barrie.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.barrie.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^the city of barrie$/i, name: 'City of Barrie' },
+        { publisher: /^city of barrie$/i, name: 'City of Barrie' }
+    ],
+    authoritativePublishers: [{ publisher: /city of barrie/i }],
+    licenseRules: [
+        { publisher: /.*/, license: BARRIE_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3543042',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'thunderbay-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Thunder Bay Open Data',
+    nameFr: 'Données ouvertes de la Ville de Thunder Bay',
+    homepageUrl: 'https://opendata-thunderbay.hub.arcgis.com/',
+    catalogUrl: 'https://opendata-thunderbay.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-thunderbay.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^city of thunder bay$/i, name: 'City of Thunder Bay' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Thunder Bay' }
+    ],
+    authoritativePublishers: [
+        { publisher: /city of thunder bay/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: THUNDER_BAY_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3558004',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'chatham-kent-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Municipality of Chatham-Kent Open Data',
+    nameFr: 'Données ouvertes de la municipalité de Chatham-Kent',
+    homepageUrl: 'https://opendata.chatham-kent.ca/',
+    catalogUrl: 'https://opendata.chatham-kent.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.chatham-kent.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^municipality of chatham-kent$/i, name: 'Municipality of Chatham-Kent' }
+    ],
+    authoritativePublishers: [{ publisher: /^municipality of chatham-kent$/i }],
+    licenseRules: [
+        { publisher: /.*/, license: CHATHAM_KENT_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-cd-3536',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'kawartha-lakes-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Kawartha Lakes Open Data',
+    nameFr: 'Données ouvertes de la Ville de Kawartha Lakes',
+    homepageUrl: 'https://open-data-kawartha.hub.arcgis.com/',
+    catalogUrl: 'https://open-data-kawartha.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-data-kawartha.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^city of kawartha lakes$/i, name: 'City of Kawartha Lakes' },
+        { publisher: /^\{\{source\}\}$/i, name: 'City of Kawartha Lakes' }
+    ],
+    authoritativePublishers: [
+        { publisher: /kawartha lakes/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: KAWARTHA_LAKES_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-cd-3516',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'summerland-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'District of Summerland Open Data',
+    nameFr: 'Données ouvertes du district de Summerland',
+    homepageUrl: 'https://open-data-summerland.hub.arcgis.com/',
+    catalogUrl: 'https://open-data-summerland.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open-data-summerland.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^districtofsummerland$/i, name: 'District of Summerland' },
+        { publisher: /^district of summerland$/i, name: 'District of Summerland' },
+        { publisher: /^\{\{source\}\}$/i, name: 'District of Summerland' }
+    ],
+    authoritativePublishers: [
+        { publisher: /summerland/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: SUMMERLAND_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-5907035',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'norfolk-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Norfolk County Open Data',
+    nameFr: 'Données ouvertes du comté de Norfolk',
+    homepageUrl: 'https://data-norfolk.opendata.arcgis.com/',
+    catalogUrl: 'https://data-norfolk.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-norfolk.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^map norfolk$/i, name: 'Norfolk County' },
+        { publisher: /^norfolk county$/i, name: 'Norfolk County' }
+    ],
+    authoritativePublishers: [{ publisher: /norfolk/i }],
+    licenseRules: [
+        { publisher: /.*/, license: NORFOLK_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3528052',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'haldimand-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Haldimand County Open Data',
+    nameFr: 'Données ouvertes du comté de Haldimand',
+    homepageUrl: 'https://opendata-haldimand.hub.arcgis.com/',
+    catalogUrl: 'https://opendata-haldimand.hub.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-haldimand.hub.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i],
+    publisherAliases: [
+        { publisher: /^the corporation of haldimand county$/i, name: 'Haldimand County' },
+        { publisher: /^haldimand county$/i, name: 'Haldimand County' },
+        { publisher: /^\{\{source\}\}$/i, name: 'Haldimand County' }
+    ],
+    authoritativePublishers: [
+        { publisher: /haldimand/i },
+        { publisher: /^\{\{source\}\}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: HALDIMAND_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-3528018',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'lethbridge-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Lethbridge Open Data',
+    nameFr: 'Données ouvertes de la Ville de Lethbridge',
+    homepageUrl: 'https://opendata.lethbridge.ca/',
+    catalogUrl: 'https://opendata.lethbridge.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.lethbridge.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of lethbridge$/i, name: 'City of Lethbridge' },
+        { publisher: /^{{source}}$/i, name: 'City of Lethbridge' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of lethbridge$/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /^city of lethbridge$/i, license: LETHBRIDGE_LICENSE },
+        { publisher: /^{{source}}$/i, license: LETHBRIDGE_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-4802012',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'medicine-hat-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Medicine Hat Open Data',
+    nameFr: 'Données ouvertes de la Ville de Medicine Hat',
+    homepageUrl: 'https://opendata.medicinehat.ca/',
+    catalogUrl: 'https://opendata.medicinehat.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata.medicinehat.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of medicine hat$/i, name: 'City of Medicine Hat' },
+        { publisher: /^{{source}}$/i, name: 'City of Medicine Hat' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of medicine hat$/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /^city of medicine hat$/i, license: MEDICINE_HAT_LICENSE },
+        { publisher: /^{{source}}$/i, license: MEDICINE_HAT_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-4801006',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'airdrie-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Airdrie Open Data',
+    nameFr: 'Données ouvertes de la Ville d’Airdrie',
+    homepageUrl: 'https://data-airdrie.opendata.arcgis.com/',
+    catalogUrl: 'https://data-airdrie.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-airdrie.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of airdrie$/i, name: 'City of Airdrie' },
+        { publisher: /^{{source}}$/i, name: 'City of Airdrie' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of airdrie$/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /^city of airdrie$/i, license: AIRDRIE_LICENSE },
+        { publisher: /^{{source}}$/i, license: AIRDRIE_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-4806021',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'canmore-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Town of Canmore Open Data',
+    nameFr: 'Données ouvertes de la Ville de Canmore',
+    homepageUrl: 'https://opendata-canmore.opendata.arcgis.com/',
+    catalogUrl: 'https://opendata-canmore.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'opendata-canmore.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^town of canmore$/i, name: 'Town of Canmore' },
+        { publisher: /^canmore$/i, name: 'Town of Canmore' },
+        { publisher: /^{{source}}$/i, name: 'Town of Canmore' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^town of canmore$/i },
+        { publisher: /^canmore$/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /^town of canmore$/i, license: CANMORE_LICENSE },
+        { publisher: /^canmore$/i, license: CANMORE_LICENSE },
+        { publisher: /^{{source}}$/i, license: CANMORE_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-4815023',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'penticton-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Penticton Open Data',
+    nameFr: 'Données ouvertes de la Ville de Penticton',
+    homepageUrl: 'https://open.penticton.ca/',
+    catalogUrl: 'https://open.penticton.ca/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'open.penticton.ca',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of penticton$/i, name: 'City of Penticton' },
+        { publisher: /^{{source}}$/i, name: 'City of Penticton' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of penticton$/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /^city of penticton$/i, license: PENTICTON_LICENSE },
+        { publisher: /^{{source}}$/i, license: PENTICTON_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-5907041',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'langley-city-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'City of Langley Open Data',
+    nameFr: 'Données ouvertes de la Ville de Langley',
+    homepageUrl: 'https://data-langleycity.opendata.arcgis.com/',
+    catalogUrl: 'https://data-langleycity.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-langleycity.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    publisherAliases: [
+        { publisher: /^city of langley$/i, name: 'City of Langley' },
+        { publisher: /^{{source}}$/i, name: 'City of Langley' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^city of langley$/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /^city of langley$/i, license: LANGLEY_CITY_LICENSE },
+        { publisher: /^{{source}}$/i, license: LANGLEY_CITY_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-csd-5915001',
+        relationship: 'direct',
+        includesDescendants: false
+    }]
+}, {
+    id: 'huron-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'County of Huron Open Data',
+    nameFr: 'Données ouvertes du comté de Huron',
+    homepageUrl: 'https://data-huron.opendata.arcgis.com/',
+    catalogUrl: 'https://data-huron.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-huron.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i, /by-nc/i],
+    publisherAliases: [
+        { publisher: /^county of huron$/i, name: 'County of Huron' },
+        { publisher: /^huron county$/i, name: 'County of Huron' },
+        { publisher: /^{{source}}$/i, name: 'County of Huron' }
+    ],
+    authoritativePublishers: [
+        { publisher: /^county of huron$/i },
+        { publisher: /^huron county$/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /^county of huron$/i, license: HURON_LICENSE },
+        { publisher: /^huron county$/i, license: HURON_LICENSE },
+        { publisher: /^{{source}}$/i, license: HURON_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-cd-3540',
+        relationship: 'direct',
+        includesDescendants: true
+    }]
+}, {
+    id: 'cumberland-hub',
+    kind: 'arcgis-hub',
+    nameEn: 'Municipality of the County of Cumberland Open Data',
+    nameFr: 'Données ouvertes de la municipalité du comté de Cumberland',
+    homepageUrl: 'https://data-cumberlandns.opendata.arcgis.com/',
+    catalogUrl: 'https://data-cumberlandns.opendata.arcgis.com/api/feed/dcat-us/1.1.json',
+    upstreamHost: 'data-cumberlandns.opendata.arcgis.com',
+    enabled: true,
+    syncIntervalHours: 24,
+    maxDeleteFraction: 0.1,
+    restrictedLicensePatterns: [/non.?commercial/i, /personal use only/i, /by-nc/i],
+    publisherAliases: [
+        { publisher: /^municipality of the county of cumberland$/i, name: 'Municipality of the County of Cumberland' },
+        { publisher: /^cumberland county$/i, name: 'Municipality of the County of Cumberland' },
+        { publisher: /^{{source}}$/i, name: 'Municipality of the County of Cumberland' }
+    ],
+    authoritativePublishers: [
+        { publisher: /cumberland/i },
+        { publisher: /^{{source}}$/i }
+    ],
+    licenseRules: [
+        { publisher: /.*/, license: CUMBERLAND_LICENSE }
+    ],
+    placeRules: [{
+        publisher: /.*/,
+        placeId: 'sgc-cd-1211',
+        relationship: 'direct',
+        includesDescendants: true
+    }]
+}
+];
+
+// Keep post-v32 releases additive: the recovered v32 registry above remains
+// unchanged, while v33-v35 sources share one fail-closed expansion layer.
+sources.push(...buildExpansionSources({ ccBy4License: CC_BY_4_LICENSE }));
+
+function getSource(id) {
+    return sources.find(source => source.id === id) || null;
+}
+
+module.exports = {
+    sources,
+    getSource,
+    OSHAWA_LICENSE,
+    DURHAM_LICENSE,
+    AJAX_LICENSE,
+    PICKERING_LICENSE,
+    WHITBY_LICENSE,
+    CLOCA_LICENSE,
+    ONTARIO_LICENSE,
+    TORONTO_LICENSE,
+    OTTAWA_LICENSE,
+    OTTAWA_POLICE_LICENSE,
+    VANCOUVER_LICENSE,
+    CALGARY_LICENSE,
+    EDMONTON_LICENSE,
+    WINNIPEG_LICENSE,
+    HALIFAX_LICENSE,
+    HAMILTON_LICENSE,
+    SURREY_LICENSE,
+    VICTORIA_LICENSE,
+    WATERLOO_REGION_LICENSE,
+    KITCHENER_LICENSE,
+    CAMBRIDGE_LICENSE,
+    WATERLOO_CITY_LICENSE,
+    LONDON_LICENSE,
+    KELOWNA_LICENSE,
+    FREDERICTON_LICENSE,
+    BURLINGTON_LICENSE,
+    OAKVILLE_LICENSE,
+    MILTON_LICENSE,
+    SUDBURY_LICENSE,
+    BURNABY_LICENSE,
+    SASKATOON_LICENSE,
+    YORK_REGION_LICENSE,
+    MARKHAM_LICENSE,
+    NEWMARKET_LICENSE,
+    NIAGARA_FALLS_LICENSE,
+    WELLAND_LICENSE,
+    MONCTON_LICENSE,
+    GUELPH_LICENSE,
+    SAANICH_LICENSE,
+    BELLEVILLE_LICENSE,
+    YELLOWKNIFE_LICENSE,
+    BARRIE_LICENSE,
+    THUNDER_BAY_LICENSE,
+    CHATHAM_KENT_LICENSE,
+    KAWARTHA_LAKES_LICENSE,
+    SUMMERLAND_LICENSE,
+    NORFOLK_LICENSE,
+    HALDIMAND_LICENSE,
+    LETHBRIDGE_LICENSE,
+    MEDICINE_HAT_LICENSE,
+    AIRDRIE_LICENSE,
+    CANMORE_LICENSE,
+    PENTICTON_LICENSE,
+    LANGLEY_CITY_LICENSE,
+    HURON_LICENSE,
+    CUMBERLAND_LICENSE,
+    MISSISSAUGA_LICENSE,
+    CC_BY_4_LICENSE,
+    OGL_CANADA_LICENSE,
+    STATCAN_LICENSE,
+    PEEL_LICENSE,
+    ...EXPANSION_LICENSES
+};

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -1,850 +1,829 @@
-const { Client } = require('pg');
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+const { parse } = require('csv-parse/sync');
+const pool = require('../db/pool');
 const { fetchPublicBuffer } = require('../services/publicJson');
 
+const EN_URL = 'https://www.statcan.gc.ca/en/statistical-programs/document/sgc-cgt-2021-structure-eng.csv';
+const FR_URL = 'https://www.statcan.gc.ca/fr/programmes-statistiques/document/sgc-cgt-2021-structure-fra.csv';
 const PROVINCES = {
-    '10': 'NL', '11': 'PE', '12': 'NS', '13': 'NB', '24': 'QC',
-    '35': 'ON', '46': 'MB', '47': 'SK', '48': 'AB', '59': 'BC',
-    '60': 'YT', '61': 'NT', '62': 'NU'
+    '10': 'nl', '11': 'pe', '12': 'ns', '13': 'nb', '24': 'qc', '35': 'on',
+    '46': 'mb', '47': 'sk', '48': 'ab', '59': 'bc', '60': 'yt', '61': 'nt', '62': 'nu'
 };
-
-const PROVINCE_NAMES = {
-    '10': { en: 'Newfoundland and Labrador', fr: 'Terre-Neuve-et-Labrador' },
-    '11': { en: 'Prince Edward Island', fr: 'Île-du-Prince-Édouard' },
-    '12': { en: 'Nova Scotia', fr: 'Nouvelle-Écosse' },
-    '13': { en: 'New Brunswick', fr: 'Nouveau-Brunswick' },
-    '24': { en: 'Quebec', fr: 'Québec' },
-    '35': { en: 'Ontario', fr: 'Ontario' },
-    '46': { en: 'Manitoba', fr: 'Manitoba' },
-    '47': { en: 'Saskatchewan', fr: 'Saskatchewan' },
-    '48': { en: 'Alberta', fr: 'Alberta' },
-    '59': { en: 'British Columbia', fr: 'Colombie-Britannique' },
-    '60': { en: 'Yukon', fr: 'Yukon' },
-    '61': { en: 'Northwest Territories', fr: 'Territoires du Nord-Ouest' },
-    '62': { en: 'Nunavut', fr: 'Nunavut' }
-};
-
-const CSD_TYPES = {
-    'C': { en: 'City', fr: 'Cité / Ville' },
-    'CY': { en: 'City', fr: 'Cité / Ville' },
-    'V': { en: 'Ville', fr: 'Ville' },
-    'T': { en: 'Town', fr: 'Ville' },
-    'TP': { en: 'Township', fr: 'Canton' },
-    'M': { en: 'Municipality', fr: 'Municipalité' },
-    'MU': { en: 'Municipality', fr: 'Municipalité' },
-    'DM': { en: 'District municipality', fr: 'Municipalité de district' },
-    'VL': { en: 'Village', fr: 'Village' },
-    'RGM': { en: 'Regional municipality', fr: 'Municipalité régionale' },
-    'RM': { en: 'Rural municipality', fr: 'Municipalité rurale' },
-    'IM': { en: 'Island municipality', fr: 'Municipalité insulaire' },
-    'P': { en: 'Parish', fr: 'Paroisse' },
-    'PE': { en: 'Paroisse (municipalité de)', fr: 'Paroisse (municipalité de)' },
-    'CT': { en: 'Canton (municipalité de)', fr: 'Canton (municipalité de)' },
-    'CU': { en: 'Cantons unis (municipalité de)', fr: 'Cantons unis (municipalité de)' },
-    'NO': { en: 'Northern subdivision', fr: 'Subdivision nordique' },
-    'SV': { en: 'Summer village', fr: 'Village d\'été' },
-    'RG': { en: 'Region', fr: 'Région' },
-    'RD': { en: 'Regional district', fr: 'District régional' },
-    'DIV': { en: 'Division', fr: 'Division' },
-    'CDR': { en: 'Census division', fr: 'Division de recensement' }
-};
-
-const SGC_MUNICIPAL_TYPES = {
-    '1001519': { en: 'City', fr: 'Cité / Ville' },
-    '1102075': { en: 'City', fr: 'Cité / Ville' },
-    '1209034': { en: 'Regional municipality', fr: 'Municipalité régionale' },
-    '1301006': { en: 'City', fr: 'Cité / Ville' },
-    '1307019': { en: 'Parish', fr: 'Paroisse' },
-    '1307022': { en: 'City', fr: 'Cité / Ville' },
-    '1310032': { en: 'City', fr: 'Cité / Ville' },
-    '2410043': { en: 'Ville', fr: 'Ville' },
-    '2423027': { en: 'Ville', fr: 'Ville' },
-    '2425213': { en: 'Ville', fr: 'Ville' },
-    '2436033': { en: 'Ville', fr: 'Ville' },
-    '2437067': { en: 'Ville', fr: 'Ville' },
-    '2443027': { en: 'Ville', fr: 'Ville' },
-    '2458227': { en: 'Ville', fr: 'Ville' },
-    '2460013': { en: 'Ville', fr: 'Ville' },
-    '2466023': { en: 'Ville', fr: 'Ville' },
-    '2494068': { en: 'Ville', fr: 'Ville' },
-    '3506008': { en: 'City', fr: 'Cité / Ville' },
-    '3510010': { en: 'City', fr: 'Cité / Ville' },
-    '3512005': { en: 'City', fr: 'Cité / Ville' },
-    '3518001': { en: 'City', fr: 'Cité / Ville' },
-    '3518005': { en: 'Town', fr: 'Ville' },
-    '3518009': { en: 'Town', fr: 'Ville' },
-    '3518013': { en: 'City', fr: 'Cité / Ville' },
-    '3518017': { en: 'Municipality', fr: 'Municipalité' },
-    '3518020': { en: 'Township', fr: 'Canton' },
-    '3518029': { en: 'Township', fr: 'Canton' },
-    '3518039': { en: 'Township', fr: 'Canton' },
-    '3519036': { en: 'City', fr: 'Cité / Ville' },
-    '3519048': { en: 'Town', fr: 'Ville' },
-    '3520005': { en: 'City', fr: 'Cité / Ville' },
-    '3521005': { en: 'City', fr: 'Cité / Ville' },
-    '3521010': { en: 'City', fr: 'Cité / Ville' },
-    '3521024': { en: 'Town', fr: 'Ville' },
-    '3523008': { en: 'City', fr: 'Cité / Ville' },
-    '3524001': { en: 'Town', fr: 'Ville' },
-    '3524002': { en: 'City', fr: 'Cité / Ville' },
-    '3524009': { en: 'Town', fr: 'Ville' },
-    '3524015': { en: 'Town', fr: 'Ville' },
-    '3525005': { en: 'City', fr: 'Cité / Ville' },
-    '3526032': { en: 'City', fr: 'Cité / Ville' },
-    '3526043': { en: 'City', fr: 'Cité / Ville' },
-    '3528018': { en: 'City', fr: 'Cité / Ville' },
-    '3528052': { en: 'City', fr: 'Cité / Ville' },
-    '3530010': { en: 'City', fr: 'Cité / Ville' },
-    '3530013': { en: 'City', fr: 'Cité / Ville' },
-    '3530016': { en: 'City', fr: 'Cité / Ville' },
-    '3530020': { en: 'Township', fr: 'Canton' },
-    '3530027': { en: 'Township', fr: 'Canton' },
-    '3530035': { en: 'Township', fr: 'Canton' },
-    '3530042': { en: 'Township', fr: 'Canton' },
-    '3537039': { en: 'City', fr: 'Cité / Ville' },
-    '3539036': { en: 'City', fr: 'Cité / Ville' },
-    '3543042': { en: 'City', fr: 'Cité / Ville' },
-    '3553005': { en: 'City', fr: 'Cité / Ville' },
-    '3558004': { en: 'City', fr: 'Cité / Ville' },
-    '4611040': { en: 'City', fr: 'Cité / Ville' },
-    '4706027': { en: 'City', fr: 'Cité / Ville' },
-    '4711066': { en: 'City', fr: 'Cité / Ville' },
-    '4801006': { en: 'City', fr: 'Cité / Ville' },
-    '4802012': { en: 'City', fr: 'Cité / Ville' },
-    '4806016': { en: 'City', fr: 'Cité / Ville' },
-    '4806021': { en: 'City', fr: 'Cité / Ville' },
-    '4808011': { en: 'City', fr: 'Cité / Ville' },
-    '4811061': { en: 'City', fr: 'Cité / Ville' },
-    '4815023': { en: 'Town', fr: 'Ville' },
-    '5907035': { en: 'District municipality', fr: 'Municipalité de district' },
-    '5907041': { en: 'City', fr: 'Cité / Ville' },
-    '5909052': { en: 'City', fr: 'Cité / Ville' },
-    '5915001': { en: 'City', fr: 'Cité / Ville' },
-    '5915004': { en: 'City', fr: 'Cité / Ville' },
-    '5915022': { en: 'City', fr: 'Cité / Ville' },
-    '5915025': { en: 'City', fr: 'Cité / Ville' },
-    '5917021': { en: 'District municipality', fr: 'Municipalité de district' },
-    '5917034': { en: 'City', fr: 'Cité / Ville' },
-    '5921007': { en: 'City', fr: 'Cité / Ville' },
-    '5933042': { en: 'City', fr: 'Cité / Ville' },
-    '5935010': { en: 'City', fr: 'Cité / Ville' },
-    '6001009': { en: 'City', fr: 'Cité / Ville' },
-    '6106023': { en: 'City', fr: 'Cité / Ville' }
-};
-
-const SINGLE_TIER_CITY_CD = new Set(['3506', '3520', '3525', '3536', '3553', '2465']);
+const TERRITORIES = new Set(['60', '61', '62']);
 const SINGLE_TIER_CITY_CSD = {
     '3506008': 'sgc-cd-3506',
     '3520005': 'sgc-cd-3520',
     '3525005': 'sgc-cd-3525',
-    '3536020': 'sgc-cd-3536',
+    '2465005': 'sgc-cd-2465',
     '3553005': 'sgc-cd-3553',
-    '2465005': 'sgc-cd-2465'
+    '3516010': 'sgc-cd-3516',
+    '3536020': 'sgc-cd-3536'
+};
+const SINGLE_TIER_CITY_CD = new Set(['2465', '3506', '3520', '3525', '3553', '3516', '3536']);
+const FEATURED_PLACE_IDS = new Set([
+    'ca-on-durham',
+    'sgc-cd-3521',
+    'sgc-cd-3524',
+    'sgc-cd-3530',
+    'ca-on-oshawa',
+    'sgc-csd-3518005',
+    'sgc-csd-3518039',
+    'sgc-csd-3518017',
+    'sgc-csd-3518001',
+    'sgc-csd-3518020',
+    'sgc-csd-3518029',
+    'sgc-csd-3518009',
+    'sgc-csd-3521005',
+    'sgc-csd-3521010',
+    'sgc-csd-3521024',
+    'sgc-csd-3524001',
+    'sgc-csd-3524002',
+    'sgc-csd-3524009',
+    'sgc-csd-3524015',
+    'sgc-cd-2465',
+    'sgc-cd-3506',
+    'sgc-cd-3520',
+    'sgc-cd-3525',
+    'sgc-cd-3553',
+    'sgc-csd-1209034',
+    'sgc-csd-2423027',
+    'sgc-csd-2466023',
+    'sgc-csd-4611040',
+    'sgc-csd-4711066',
+    'sgc-csd-4806016',
+    'sgc-csd-4811061',
+    'sgc-csd-5915004',
+    'sgc-csd-5915022',
+    'sgc-csd-5915025',
+    'sgc-csd-5917034',
+    'sgc-csd-3530013',
+    'sgc-csd-3530016',
+    'sgc-csd-3530010',
+    'sgc-csd-3530035',
+    'sgc-csd-3530020',
+    'sgc-csd-3530027',
+    'sgc-csd-3530004',
+    'sgc-csd-3539036',
+    'sgc-csd-5935010',
+    'sgc-csd-1310032',
+    'sgc-cd-3519',
+    'sgc-csd-3519036',
+    'sgc-csd-3519048',
+    'sgc-csd-3519028',
+    'sgc-csd-3519038',
+    'sgc-csd-3519046',
+    'sgc-csd-3519044',
+    'sgc-csd-3519049',
+    'sgc-csd-3519054',
+    'sgc-csd-3519070',
+    'sgc-cd-3526',
+    'sgc-csd-3526043',
+    'sgc-csd-3526032',
+    'sgc-csd-3526053',
+    'sgc-csd-3526003',
+    'sgc-csd-3526011',
+    'sgc-csd-3526037',
+    'sgc-csd-3526047',
+    'sgc-csd-3526057',
+    'sgc-csd-3526065',
+    'sgc-csd-3526028',
+    'sgc-csd-3526021',
+    'sgc-csd-3526014',
+    'sgc-csd-1307022',
+    'sgc-csd-3523008',
+    'sgc-csd-5917021',
+    'sgc-csd-3512005',
+    'sgc-csd-6106023',
+    'sgc-csd-3543042',
+    'sgc-csd-3558004',
+    'sgc-cd-3536',
+    'sgc-cd-3516',
+    'sgc-csd-5907035',
+    'sgc-csd-3528052',
+    'sgc-csd-4802012',
+    'sgc-csd-4801006',
+    'sgc-csd-4806021',
+    'sgc-csd-4815023',
+    'sgc-csd-5907041',
+    'sgc-csd-5915001',
+    'sgc-cd-3540',
+    'sgc-cd-1211',
+    'sgc-csd-3528018',
+    'sgc-csd-2481017',
+    'sgc-csd-2437067',
+    'sgc-csd-2460013',
+    'sgc-csd-2458227',
+    'sgc-csd-2494068',
+    'sgc-csd-2410043',
+    'sgc-csd-2436033',
+    'sgc-csd-2425213',
+    'sgc-csd-2443027',
+    'sgc-csd-1301006',
+    'sgc-csd-6001009',
+    'sgc-csd-1001519',
+    'sgc-csd-1102075',
+    'sgc-csd-4706027',
+    'sgc-csd-3537039',
+    'sgc-csd-3510010',
+    'sgc-csd-4808011',
+    'sgc-csd-5933042',
+    'sgc-csd-5921007',
+    'sgc-csd-5909052',
+    'sgc-csd-5915034',
+    'sgc-csd-5953023',
+    'sgc-csd-5915029',
+    'sgc-csd-5915043',
+    'sgc-csd-5931006',
+    'sgc-csd-5915075',
+    'sgc-csd-5915039',
+    'sgc-csd-2454048'
+]);
+const MUNICIPAL_TYPES = {
+    '2423027': ['City', 'Ville'],
+    '2465005': ['City', 'Ville'],
+    '2466023': ['City', 'Ville'],
+    '3512005': ['City', 'Ville'],
+    '3514019': ['Township', 'Canton'],
+    '3518005': ['Town', 'Ville'],
+    '3518039': ['Township', 'Canton'],
+    '3518017': ['Municipality', 'Municipalité'],
+    '3518013': ['City', 'Ville'],
+    '3518001': ['City', 'Ville'],
+    '3518020': ['Township', 'Canton'],
+    '3518029': ['Township', 'Canton'],
+    '3518009': ['Town', 'Ville'],
+    '3519': ['Regional municipality', 'Municipalité régionale'],
+    '3519036': ['City', 'Ville'],
+    '3519048': ['Town', 'Ville'],
+    '3519028': ['City', 'Ville'],
+    '3519038': ['City', 'Ville'],
+    '3519046': ['Town', 'Ville'],
+    '3519044': ['Town', 'Ville'],
+    '3519049': ['Township', 'Canton'],
+    '3519054': ['Town', 'Ville'],
+    '3519070': ['Town', 'Ville'],
+    '3521005': ['City', 'Ville'],
+    '3521010': ['City', 'Ville'],
+    '3521024': ['Town', 'Ville'],
+    '3523008': ['City', 'Ville'],
+    '3524': ['Regional municipality', 'Municipalité régionale'],
+    '3524001': ['Town', 'Ville'],
+    '3524002': ['City', 'Ville'],
+    '3524009': ['Town', 'Ville'],
+    '3524015': ['Town', 'Ville'],
+    '3526': ['Regional municipality', 'Municipalité régionale'],
+    '3526043': ['City', 'Ville'],
+    '3526032': ['City', 'Ville'],
+    '3526053': ['City', 'Ville'],
+    '3526003': ['Town', 'Ville'],
+    '3526011': ['City', 'Ville'],
+    '3526037': ['City', 'Ville'],
+    '3526047': ['Town', 'Ville'],
+    '3526057': ['Town', 'Ville'],
+    '3526065': ['Town', 'Ville'],
+    '3526028': ['Town', 'Ville'],
+    '3526021': ['Township', 'Canton'],
+    '3526014': ['Township', 'Canton'],
+    '3530': ['Regional municipality', 'Municipalité régionale'],
+    '3530013': ['City', 'Ville'],
+    '3530016': ['City', 'Ville'],
+    '3530010': ['City', 'Ville'],
+    '3530035': ['Township', 'Canton'],
+    '3530020': ['Township', 'Canton'],
+    '3530027': ['Township', 'Canton'],
+    '3530004': ['Township', 'Canton'],
+    '3539036': ['City', 'Ville'],
+    '3553': ['City', 'Ville'],
+    '3553005': ['City', 'Ville'],
+    '5915022': ['City', 'Ville'],
+    '5915025': ['City', 'Ville'],
+    '5917021': ['District municipality', 'Municipalité de district'],
+    '5917034': ['City', 'Ville'],
+    '5935010': ['City', 'Ville'],
+    '4806016': ['City', 'Ville'],
+    '4811061': ['City', 'Ville'],
+    '4611040': ['City', 'Ville'],
+    '4711066': ['City', 'Ville'],
+    '1209034': ['Regional municipality', 'Municipalité régionale'],
+    '1307019': ['Parish', 'Paroisse'],
+    '1307022': ['City', 'Cité'],
+    '1310032': ['City', 'Ville'],
+    '5915004': ['City', 'Ville'],
+    '6106023': ['City', 'Ville'],
+    '3543042': ['City', 'Ville'],
+    '3558004': ['City', 'Ville'],
+    '3536': ['Municipality', 'Municipalité'],
+    '3516': ['City', 'Ville'],
+    '5907035': ['District municipality', 'Municipalité de district'],
+    '3528052': ['City', 'Ville'],
+    '4802012': ['City', 'Ville'],
+    '4801006': ['City', 'Ville'],
+    '4806021': ['City', 'Ville'],
+    '4815023': ['Town', 'Ville'],
+    '5907041': ['City', 'Ville'],
+    '5915001': ['City', 'Ville'],
+    '3540': ['County', 'Comté'],
+    '1211': ['County', 'Comté'],
+    '3528018': ['City', 'Ville'],
+    '2481017': ['City', 'Ville'],
+    '2437067': ['City', 'Ville'],
+    '2460013': ['City', 'Ville'],
+    '2458227': ['City', 'Ville'],
+    '2494068': ['City', 'Ville'],
+    '2410043': ['City', 'Ville'],
+    '2436033': ['City', 'Ville'],
+    '2425213': ['City', 'Ville'],
+    '2443027': ['City', 'Ville'],
+    '1301006': ['City', 'Cité'],
+    '6001009': ['City', 'Ville'],
+    '1001519': ['City', 'Ville'],
+    '1102075': ['City', 'Ville'],
+    '4706027': ['City', 'Ville'],
+    '3537039': ['City', 'Ville'],
+    '3510010': ['City', 'Ville'],
+    '4808011': ['City', 'Ville'],
+    '5933042': ['City', 'Ville'],
+    '5921007': ['City', 'Ville'],
+    '5909052': ['City', 'Ville'],
+    '5915034': ['City', 'Ville'],
+    '5953023': ['City', 'Ville'],
+    '5915029': ['City', 'Ville'],
+    '5915043': ['City', 'Ville'],
+    '5931006': ['District municipality', 'Municipalité de district'],
+    '5915075': ['City', 'Ville'],
+    '5915039': ['City', 'Ville'],
+    '2454048': ['City', 'Ville']
+};
+const PLACE_VIEWPORTS = {
+    '2423027': [46.8139, -71.208, 10],
+    '2465': [45.6066, -73.7124, 10],
+    '2466023': [45.5019, -73.5674, 10],
+    '3506': [45.4215, -75.6972, 9],
+    '3512005': [44.1628, -77.3832, 10],
+    '3525': [43.2557, -79.8711, 9],
+    '3518': [44.0569, -78.8570, 9],
+    '3518013': [43.8971, -78.8658, 11],
+    '3519': [44.0000, -79.4667, 9],
+    '3519036': [43.8561, -79.3370, 10],
+    '3519048': [44.0592, -79.4613, 10],
+    '3519028': [43.8563, -79.5085, 10],
+    '3519038': [43.8828, -79.4403, 10],
+    '3519046': [44.0000, -79.4667, 10],
+    '3519044': [43.9708, -79.2514, 9],
+    '3519049': [43.9500, -79.5833, 9],
+    '3519054': [44.1333, -79.4500, 9],
+    '3519070': [44.3000, -79.4333, 9],
+    '3520': [43.6532, -79.3832, 10],
+    '3521': [43.7500, -79.7800, 9],
+    '3521005': [43.5890, -79.6440, 10],
+    '3521010': [43.7315, -79.7624, 10],
+    '3521024': [43.8668, -79.8670, 9],
+    '3523008': [43.5448, -80.2482, 10],
+    '3524': [43.4900, -79.8800, 9],
+    '3524001': [43.4675, -79.6877, 10],
+    '3524002': [43.3255, -79.7990, 10],
+    '3524009': [43.5183, -79.8774, 10],
+    '3524015': [43.6300, -79.9500, 9],
+    '3526': [43.0600, -79.3100, 9],
+    '3526043': [43.0896, -79.0849, 10],
+    '3526032': [42.9922, -79.2483, 10],
+    '3526053': [43.1594, -79.2469, 10],
+    '3526003': [42.9000, -78.9333, 9],
+    '3526011': [42.8833, -79.2500, 10],
+    '3526037': [43.1167, -79.2000, 10],
+    '3526047': [43.2553, -79.0772, 10],
+    '3526057': [43.1667, -79.4333, 9],
+    '3526065': [43.1931, -79.5600, 10],
+    '3526028': [43.0500, -79.3333, 9],
+    '3526021': [43.0833, -79.5667, 9],
+    '3526014': [42.9167, -79.3667, 9],
+    '3530': [43.4643, -80.5204, 9],
+    '3530013': [43.4516, -80.4925, 10],
+    '3530016': [43.4643, -80.5204, 10],
+    '3530010': [43.3616, -80.3144, 10],
+    '3530035': [43.5650, -80.5500, 9],
+    '3530020': [43.4000, -80.6500, 9],
+    '3530027': [43.5500, -80.7667, 9],
+    '3530004': [43.3000, -80.3833, 9],
+    '3539036': [42.9849, -81.2453, 9],
+    '3553': [46.4900, -80.9900, 9],
+    '5915022': [49.2827, -123.1207, 10],
+    '5915025': [49.2488, -122.9805, 10],
+    '5917034': [48.4284, -123.3656, 10],
+    '5935010': [49.8880, -119.4960, 10],
+    '4806016': [51.0447, -114.0719, 9],
+    '4811061': [53.5461, -113.4938, 9],
+    '4611040': [49.8954, -97.1385, 9],
+    '4711066': [52.1332, -106.6700, 10],
+    '1209034': [44.6488, -63.5752, 8],
+    '1307019': [46.0878, -64.7782, 10],
+    '1307022': [46.0878, -64.7782, 10],
+    '1310032': [45.9636, -66.6431, 10],
+    '5915004': [49.1913, -122.8490, 10],
+    '5917021': [48.4841, -123.3822, 10],
+    '6106023': [62.4540, -114.3718, 10],
+    '3543042': [44.3894, -79.6903, 10],
+    '3558': [48.3809, -89.2477, 8],
+    '3558004': [48.3809, -89.2477, 10],
+    '3536': [42.4048, -82.1910, 9],
+    '3516': [44.3564, -78.7408, 9],
+    '5907035': [49.6006, -119.6778, 10],
+    '3528052': [42.8333, -80.3833, 9],
+    '4802012': [49.6956, -112.8451, 10],
+    '4801006': [50.0417, -110.6775, 10],
+    '4806021': [51.2917, -114.0144, 10],
+    '4815023': [51.0890, -115.3590, 10],
+    '5907041': [49.4991, -119.5937, 10],
+    '5915001': [49.1044, -122.6580, 10],
+    '3540': [43.5833, -81.5000, 9],
+    '1211': [45.7500, -64.0000, 8],
+    '3528018': [42.9333, -79.8667, 9],
+    '2481017': [45.4765, -75.7013, 10],
+    '2437067': [46.3432, -72.5421, 10],
+    '2460013': [45.7423, -73.4497, 10],
+    '2458227': [45.5312, -73.5181, 10],
+    '2494068': [48.4284, -71.0684, 10],
+    '2410043': [48.4488, -68.5240, 10],
+    '2436033': [46.5667, -72.7500, 10],
+    '2425213': [46.8033, -71.1779, 10],
+    '2443027': [45.4042, -71.8929, 10],
+    '1301006': [45.2733, -66.0633, 10],
+    '6001009': [60.7212, -135.0568, 10],
+    '1001519': [47.5615, -52.7126, 10],
+    '1102075': [46.2382, -63.1311, 10],
+    '4706027': [50.4452, -104.6189, 10],
+    '3537039': [42.3149, -83.0364, 10],
+    '3510010': [44.2312, -76.4860, 10],
+    '4808011': [52.2690, -113.8116, 10],
+    '5933042': [50.6745, -120.3273, 10],
+    '5921007': [49.1659, -123.9401, 10],
+    '5909052': [49.0504, -122.3045, 10],
+    '5915034': [49.2838, -122.7932, 10],
+    '5953023': [53.9171, -122.7497, 10],
+    '5915029': [49.2057, -122.9110, 11],
+    '5915043': [49.2838, -122.8317, 11],
+    '5931006': [49.7016, -123.1558, 10],
+    '5915075': [49.2193, -122.5984, 10],
+    '5915039': [49.2628, -122.7811, 11],
+    '2454048': [45.6307, -72.9569, 10]
 };
 
-const FEATURED_PLACES = {
-    'ca-on-toronto': {
-        slug: 'toronto',
-        bbox: [-79.639265, 43.580983, -79.115822, 43.855457],
-        center: [-79.383184, 43.653226],
-        zoom: 11
-    },
-    'sgc-cd-3520': {
-        slug: 'toronto',
-        bbox: [-79.639265, 43.580983, -79.115822, 43.855457],
-        center: [-79.383184, 43.653226],
-        zoom: 11
-    },
-    'ca-qc-montreal': {
-        slug: 'montreal',
-        bbox: [-73.974187, 45.410076, -73.473079, 45.704791],
-        center: [-73.567256, 45.501689],
-        zoom: 11
-    },
-    'sgc-csd-2466023': {
-        slug: 'montreal',
-        bbox: [-73.974187, 45.410076, -73.473079, 45.704791],
-        center: [-73.567256, 45.501689],
-        zoom: 11
-    },
-    'ca-on-ottawa': {
-        slug: 'ottawa',
-        bbox: [-76.353916, 44.962002, -75.246574, 45.537651],
-        center: [-75.697193, 45.42153],
-        zoom: 10
-    },
-    'sgc-cd-3506': {
-        slug: 'ottawa',
-        bbox: [-76.353916, 44.962002, -75.246574, 45.537651],
-        center: [-75.697193, 45.42153],
-        zoom: 10
-    },
-    'ca-ab-calgary': {
-        slug: 'calgary',
-        bbox: [-114.316035, 50.842822, -113.859892, 51.212425],
-        center: [-114.071889, 51.044733],
-        zoom: 11
-    },
-    'sgc-csd-4806016': {
-        slug: 'calgary',
-        bbox: [-114.316035, 50.842822, -113.859892, 51.212425],
-        center: [-114.071889, 51.044733],
-        zoom: 11
-    },
-    'ca-ab-edmonton': {
-        slug: 'edmonton',
-        bbox: [-113.713697, 53.395786, -113.271515, 53.654452],
-        center: [-113.493823, 53.546125],
-        zoom: 11
-    },
-    'sgc-csd-4811061': {
-        slug: 'edmonton',
-        bbox: [-113.713697, 53.395786, -113.271515, 53.654452],
-        center: [-113.493823, 53.546125],
-        zoom: 11
-    },
-    'ca-bc-vancouver': {
-        slug: 'vancouver',
-        bbox: [-123.224787, 49.198445, -123.023242, 49.316171],
-        center: [-123.120738, 49.282729],
-        zoom: 12
-    },
-    'sgc-csd-5915022': {
-        slug: 'vancouver',
-        bbox: [-123.224787, 49.198445, -123.023242, 49.316171],
-        center: [-123.120738, 49.282729],
-        zoom: 12
-    },
-    'ca-mb-winnipeg': {
-        slug: 'winnipeg',
-        bbox: [-97.353724, 49.765668, -96.953888, 49.992225],
-        center: [-97.138374, 49.895136],
-        zoom: 11
-    },
-    'sgc-csd-4611040': {
-        slug: 'winnipeg',
-        bbox: [-97.353724, 49.765668, -96.953888, 49.992225],
-        center: [-97.138374, 49.895136],
-        zoom: 11
-    },
-    'ca-qc-quebec': {
-        slug: 'quebec',
-        bbox: [-71.503417, 46.711822, -71.157837, 46.948218],
-        center: [-71.207981, 46.813878],
-        zoom: 11
-    },
-    'sgc-csd-2423027': {
-        slug: 'quebec',
-        bbox: [-71.503417, 46.711822, -71.157837, 46.948218],
-        center: [-71.207981, 46.813878],
-        zoom: 11
-    },
-    'ca-ns-halifax': {
-        slug: 'halifax',
-        bbox: [-64.120483, 44.400032, -62.155457, 45.185641],
-        center: [-63.575239, 44.648862],
-        zoom: 10
-    },
-    'sgc-csd-1209034': {
-        slug: 'halifax',
-        bbox: [-64.120483, 44.400032, -62.155457, 45.185641],
-        center: [-63.575239, 44.648862],
-        zoom: 10
-    },
-    'ca-bc-surrey': {
-        slug: 'surrey',
-        bbox: [-122.922134, 49.002243, -122.684124, 49.219818],
-        center: [-122.849014, 49.191345],
-        zoom: 11
-    },
-    'sgc-csd-5915004': {
-        slug: 'surrey',
-        bbox: [-122.922134, 49.002243, -122.684124, 49.219818],
-        center: [-122.849014, 49.191345],
-        zoom: 11
-    },
-    'ca-qc-laval': {
-        slug: 'laval',
-        bbox: [-73.89679, 45.500332, -73.541336, 45.696144],
-        center: [-73.71241, 45.569946],
-        zoom: 11
-    },
-    'sgc-cd-2465': {
-        slug: 'laval',
-        bbox: [-73.89679, 45.500332, -73.541336, 45.696144],
-        center: [-73.71241, 45.569946],
-        zoom: 11
-    },
-    'ca-on-hamilton': {
-        slug: 'hamilton',
-        bbox: [-80.117188, 43.140808, -79.544525, 43.344406],
-        center: [-79.8711, 43.2557],
-        zoom: 11
-    },
-    'sgc-cd-3525': {
-        slug: 'hamilton',
-        bbox: [-80.117188, 43.140808, -79.544525, 43.344406],
-        center: [-79.8711, 43.2557],
-        zoom: 11
-    },
-    'ca-on-durham': {
-        slug: 'durham-region',
-        bbox: [-79.337158, 43.78418, -78.474731, 44.577637],
-        center: [-78.8658, 44.0592],
-        zoom: 10
-    },
-    'ca-on-oshawa': {
-        slug: 'oshawa',
-        bbox: [-78.961182, 43.834229, -78.78479, 44.020386],
-        center: [-78.8658, 43.8971],
-        zoom: 12
-    },
-    'sgc-csd-3518013': {
-        slug: 'oshawa',
-        bbox: [-78.961182, 43.834229, -78.78479, 44.020386],
-        center: [-78.8658, 43.8971],
-        zoom: 12
-    },
-    'sgc-csd-3518005': {
-        slug: 'ajax',
-        bbox: [-79.091187, 43.811646, -78.986816, 43.918457],
-        center: [-79.0358, 43.8509],
-        zoom: 12
-    },
-    'sgc-csd-3518001': {
-        slug: 'pickering',
-        bbox: [-79.168701, 43.799438, -79.020996, 44.030762],
-        center: [-79.089, 43.8384],
-        zoom: 12
-    },
-    'sgc-csd-3518009': {
-        slug: 'whitby',
-        bbox: [-79.000244, 43.829346, -78.879395, 44.072266],
-        center: [-78.9386, 43.8975],
-        zoom: 12
-    },
-    'ca-on-peel': {
-        slug: 'peel-region',
-        bbox: [-80.050659, 43.504028, -79.544067, 43.996582],
-        center: [-79.7624, 43.6890],
-        zoom: 10
-    },
-    'sgc-cd-3521': {
-        slug: 'peel-region',
-        bbox: [-80.050659, 43.504028, -79.544067, 43.996582],
-        center: [-79.7624, 43.6890],
-        zoom: 10
-    },
-    'sgc-csd-3521005': {
-        slug: 'mississauga',
-        bbox: [-79.795532, 43.504028, -79.544067, 43.74939],
-        center: [-79.6441, 43.5890],
-        zoom: 11
-    },
-    'sgc-csd-3521010': {
-        slug: 'brampton',
-        bbox: [-79.882812, 43.619995, -79.620361, 43.829956],
-        center: [-79.7624, 43.7315],
-        zoom: 11
-    },
-    'sgc-csd-3521024': {
-        slug: 'caledon',
-        bbox: [-80.050659, 43.708496, -79.697876, 43.996582],
-        center: [-79.8653, 43.8690],
-        zoom: 11
-    },
-    'sgc-csd-5917034': {
-        slug: 'victoria',
-        bbox: [-123.407593, 48.406982, -123.310547, 48.460083],
-        center: [-123.3656, 48.4284],
-        zoom: 12
-    },
-    'sgc-cd-3530': {
-        slug: 'waterloo-region',
-        bbox: [-80.739746, 43.303833, -80.220947, 43.666992],
-        center: [-80.4831, 43.4675],
-        zoom: 10
-    },
-    'sgc-csd-3530013': {
-        slug: 'kitchener',
-        bbox: [-80.579834, 43.376465, -80.401001, 43.498535],
-        center: [-80.4925, 43.4516],
-        zoom: 12
-    },
-    'sgc-csd-3530016': {
-        slug: 'waterloo',
-        bbox: [-80.596924, 43.447876, -80.470581, 43.539429],
-        center: [-80.5204, 43.4643],
-        zoom: 12
-    },
-    'sgc-csd-3530010': {
-        slug: 'cambridge',
-        bbox: [-80.395508, 43.336182, -80.26001, 43.460083],
-        center: [-80.3144, 43.3616],
-        zoom: 12
-    },
-    'sgc-csd-3539036': {
-        slug: 'london',
-        bbox: [-81.391602, 42.871704, -81.12793, 43.080444],
-        center: [-81.2453, 42.9849],
-        zoom: 11
-    },
-    'sgc-csd-5935010': {
-        slug: 'kelowna',
-        bbox: [-119.558716, 49.805298, -119.349976, 50.010986],
-        center: [-119.4960, 49.8880],
-        zoom: 11
-    },
-    'sgc-csd-1310032': {
-        slug: 'fredericton',
-        bbox: [-66.741943, 45.890503, -66.568604, 46.002808],
-        center: [-66.6431, 45.9636],
-        zoom: 12
-    },
-    'sgc-cd-3524': {
-        slug: 'halton-region',
-        bbox: [-80.128784, 43.307495, -79.684448, 43.642578],
-        center: [-79.8500, 43.4800],
-        zoom: 10
-    },
-    'sgc-csd-3524001': {
-        slug: 'oakville',
-        bbox: [-79.799805, 43.38501, -79.645386, 43.535156],
-        center: [-79.6877, 43.4501],
-        zoom: 12
-    },
-    'sgc-csd-3524002': {
-        slug: 'burlington',
-        bbox: [-79.914551, 43.307495, -79.742432, 43.469238],
-        center: [-79.7990, 43.3255],
-        zoom: 12
-    },
-    'sgc-csd-3524009': {
-        slug: 'milton',
-        bbox: [-80.084839, 43.425903, -79.799805, 43.597412],
-        center: [-79.8833, 43.5183],
-        zoom: 12
-    },
-    'sgc-csd-3524015': {
-        slug: 'halton-hills',
-        bbox: [-80.128784, 43.54187, -79.829102, 43.701172],
-        center: [-79.9500, 43.6300],
-        zoom: 12
-    },
-    'sgc-cd-3553': {
-        slug: 'greater-sudbury',
-        bbox: [-81.650391, 46.257324, -80.536499, 46.852417],
-        center: [-80.9930, 46.4900],
-        zoom: 10
-    },
-    'sgc-csd-5915025': {
-        slug: 'burnaby',
-        bbox: [-123.023682, 49.199829, -122.880859, 49.299316],
-        center: [-122.9805, 49.2488],
-        zoom: 12
-    },
-    'sgc-csd-4711066': {
-        slug: 'saskatoon',
-        bbox: [-106.779785, 52.071533, -106.533203, 52.215576],
-        center: [-106.6702, 52.1332],
-        zoom: 11
-    },
-    'sgc-cd-3519': {
-        slug: 'york-region',
-        bbox: [-79.664307, 43.78418, -79.208984, 44.408569],
-        center: [-79.4360, 44.0000],
-        zoom: 10
-    },
-    'sgc-csd-3519036': {
-        slug: 'markham',
-        bbox: [-79.438477, 43.799438, -79.208984, 43.955078],
-        center: [-79.3370, 43.8561],
-        zoom: 12
-    },
-    'sgc-csd-3519048': {
-        slug: 'newmarket',
-        bbox: [-79.512939, 44.020386, -79.400635, 44.090576],
-        center: [-79.4600, 44.0500],
-        zoom: 12
-    },
-    'sgc-cd-3526': {
-        slug: 'niagara-region',
-        bbox: [-80.009766, 42.843628, -78.914795, 43.275146],
-        center: [-79.2500, 43.0500],
-        zoom: 10
-    },
-    'sgc-csd-3526043': {
-        slug: 'niagara-falls',
-        bbox: [-79.198608, 42.996216, -79.033813, 43.151855],
-        center: [-79.0849, 43.0896],
-        zoom: 12
-    },
-    'sgc-csd-3526032': {
-        slug: 'welland',
-        bbox: [-79.308472, 42.946167, -79.198608, 43.045654],
-        center: [-79.2483, 42.9922],
-        zoom: 12
-    },
-    'sgc-csd-1307022': {
-        slug: 'moncton',
-        bbox: [-64.919434, 46.046753, -64.718018, 46.160889],
-        center: [-64.7782, 46.0878],
-        zoom: 12
-    },
-    'sgc-csd-3523008': {
-        slug: 'guelph',
-        bbox: [-80.339966, 43.486328, -80.175171, 43.590698],
-        center: [-80.2482, 43.5448],
-        zoom: 12
-    },
-    'sgc-csd-5917021': {
-        slug: 'saanich',
-        bbox: [-123.476562, 48.434448, -123.310547, 48.566895],
-        center: [-123.3833, 48.4833],
-        zoom: 12
-    },
-    'sgc-csd-3512005': {
-        slug: 'belleville',
-        bbox: [-77.453613, 44.110107, -77.299805, 44.274902],
-        center: [-77.3833, 44.1667],
-        zoom: 12
-    },
-    'sgc-csd-6106023': {
-        slug: 'yellowknife',
-        bbox: [-114.477539, 62.409668, -114.301758, 62.508545],
-        center: [-114.3718, 62.4540],
-        zoom: 12
-    },
-    'sgc-csd-3543042': {
-        slug: 'barrie',
-        bbox: [-79.763184, 44.329834, -79.620361, 44.439697],
-        center: [-79.6903, 44.3894],
-        zoom: 12
-    },
-    'sgc-csd-3558004': {
-        slug: 'thunder-bay',
-        bbox: [-89.379883, 48.339844, -89.171143, 48.490601],
-        center: [-89.2477, 48.3809],
-        zoom: 12
-    },
-    'sgc-cd-3536': {
-        slug: 'chatham-kent',
-        bbox: [-82.529297, 42.147827, -81.793213, 42.666016],
-        center: [-82.1890, 42.4048],
-        zoom: 10
-    },
-    'sgc-cd-3516': {
-        slug: 'kawartha-lakes',
-        bbox: [-79.088135, 44.110107, -78.419189, 44.788818],
-        center: [-78.7400, 44.3500],
-        zoom: 10
-    },
-    'sgc-csd-5907035': {
-        slug: 'summerland',
-        bbox: [-119.742432, 49.563599, -119.610596, 49.646606],
-        center: [-119.6760, 49.6006],
-        zoom: 12
-    },
-    'sgc-csd-3528052': {
-        slug: 'norfolk-county',
-        bbox: [-80.704346, 42.564697, -80.050659, 43.030396],
-        center: [-80.3000, 42.8400],
-        zoom: 10
-    },
-    'sgc-csd-3528018': {
-        slug: 'haldimand-county',
-        bbox: [-80.128784, 42.779541, -79.522095, 43.140869],
-        center: [-79.8800, 42.9700],
-        zoom: 10
-    },
-    'sgc-csd-2481017': {
-        slug: 'gatineau',
-        bbox: [-75.923462, 45.405884, -75.462036, 45.567627],
-        center: [-75.7013, 45.4765],
-        zoom: 11
-    },
-    'sgc-csd-2437067': {
-        slug: 'trois-rivieres',
-        bbox: [-72.684937, 46.307373, -72.487183, 46.417236],
-        center: [-72.5477, 46.3432],
-        zoom: 12
-    },
-    'sgc-csd-2460013': {
-        slug: 'repentigny',
-        bbox: [-73.52478, 45.719604, -73.403931, 45.796509],
-        center: [-73.4500, 45.7500],
-        zoom: 12
-    },
-    'sgc-csd-2458227': {
-        slug: 'longueuil',
-        bbox: [-73.54126, 45.474854, -73.376465, 45.584717],
-        center: [-73.5090, 45.5312],
-        zoom: 12
-    },
-    'sgc-csd-2494068': {
-        slug: 'saguenay',
-        bbox: [-71.378174, 48.334351, -70.751953, 48.510132],
-        center: [-71.0700, 48.4200],
-        zoom: 11
-    },
-    'sgc-csd-2410043': {
-        slug: 'rimouski',
-        bbox: [-68.648071, 48.395996, -68.428345, 48.494873],
-        center: [-68.5239, 48.4488],
-        zoom: 12
-    },
-    'sgc-csd-2436033': {
-        slug: 'shawinigan',
-        bbox: [-72.827759, 46.505127, -72.630005, 46.61499],
-        center: [-72.7481, 46.5574],
-        zoom: 12
-    },
-    'sgc-csd-2425213': {
-        slug: 'levis',
-        bbox: [-71.367188, 46.689453, -71.092529, 46.854248],
-        center: [-71.1833, 46.8000],
-        zoom: 12
-    },
-    'sgc-csd-2443027': {
-        slug: 'sherbrooke',
-        bbox: [-72.03186, 45.340576, -71.801147, 45.450439],
-        center: [-71.8929, 45.4042],
-        zoom: 12
-    },
-    'sgc-csd-1301006': {
-        slug: 'saint-john',
-        bbox: [-66.195679, 45.228882, -65.986938, 45.349731],
-        center: [-66.0633, 45.2733],
-        zoom: 12
-    },
-    'sgc-csd-6001009': {
-        slug: 'whitehorse',
-        bbox: [-135.20874, 60.651855, -134.956055, 60.783691],
-        center: [-135.0568, 60.7212],
-        zoom: 12
-    },
-    'sgc-csd-1001519': {
-        slug: 'st-johns',
-        bbox: [-77.607422, 47.457886, -52.657471, 47.644653],
-        center: [-52.7126, 47.5615],
-        zoom: 12
-    },
-    'sgc-csd-1102075': {
-        slug: 'charlottetown',
-        bbox: [-63.193359, 46.225586, -63.083496, 46.291504],
-        center: [-63.1311, 46.2382],
-        zoom: 12
-    },
-    'sgc-csd-4706027': {
-        slug: 'regina',
-        bbox: [-104.732666, 50.394287, -104.534912, 50.515137],
-        center: [-104.6189, 50.4452],
-        zoom: 12
-    },
-    'sgc-csd-3537039': {
-        slug: 'windsor',
-        bbox: [-83.085938, 42.25769, -82.888184, 42.345581],
-        center: [-83.0364, 42.3149],
-        zoom: 12
-    },
-    'sgc-csd-3510010': {
-        slug: 'kingston',
-        bbox: [-76.673584, 44.208984, -76.409912, 44.34082],
-        center: [-76.4860, 44.2312],
-        zoom: 12
-    },
-    'sgc-csd-4808011': {
-        slug: 'red-deer',
-        bbox: [-113.884277, 52.229004, -113.730469, 52.327881],
-        center: [-113.8115, 52.2681],
-        zoom: 12
-    },
-    'sgc-csd-5933042': {
-        slug: 'kamloops',
-        bbox: [-120.476074, 50.628662, -120.212402, 50.760498],
-        center: [-120.3273, 50.6745],
-        zoom: 12
-    },
-    'sgc-csd-5921007': {
-        slug: 'nanaimo',
-        bbox: [-124.035645, 49.119873, -123.881836, 49.251709],
-        center: [-123.9401, 49.1659],
-        zoom: 12
-    },
-    'sgc-csd-5909052': {
-        slug: 'abbotsford',
-        bbox: [-122.420654, 49.002243, -122.189941, 49.123093],
-        center: [-122.3294, 49.0504],
-        zoom: 12
-    }
+const EXPANSION_SLUGS = {
+    '2481': 'gatineau-region-qc',
+    '2481017': 'gatineau-qc',
+    '2437': 'trois-rivieres-region-qc',
+    '2437067': 'trois-rivieres-qc',
+    '2460': 'lassomption-qc',
+    '2460013': 'repentigny-qc',
+    '2458': 'longueuil-region-qc',
+    '2458227': 'longueuil-qc',
+    '2494': 'le-saguenay-et-son-fjord-qc',
+    '2494068': 'saguenay-qc',
+    '2410': 'rimouski-neigette-qc',
+    '2410043': 'rimouski-qc',
+    '2436': 'shawinigan-region-qc',
+    '2436033': 'shawinigan-qc',
+    '2425': 'levis-region-qc',
+    '2425213': 'levis-qc',
+    '2443': 'sherbrooke-region-qc',
+    '2443027': 'sherbrooke-qc',
+    '1301': 'saint-john-county-nb',
+    '1301006': 'saint-john-nb',
+    '6001': 'yukon-cd-yt',
+    '6001009': 'whitehorse-yt',
+    '1001': 'division-no-1-nl',
+    '1001519': 'st-johns-nl',
+    '1102': 'queens-pe',
+    '1102075': 'charlottetown-pe',
+    '4706': 'division-no-6-sk',
+    '4706027': 'regina-sk',
+    '3537': 'essex-county-on',
+    '3537039': 'windsor-on',
+    '3510': 'frontenac-county-on',
+    '3510010': 'kingston-on',
+    '4808': 'division-no-8-ab',
+    '4808011': 'red-deer-ab',
+    '5933': 'thompson-nicola-bc',
+    '5933042': 'kamloops-bc',
+    '5921': 'nanaimo-region-bc',
+    '5921007': 'nanaimo-bc',
+    '5909': 'fraser-valley-bc',
+    '5909052': 'abbotsford-bc',
+    '5915034': 'coquitlam-bc',
+    '5953023': 'prince-george-bc',
+    '5915029': 'new-westminster-bc',
+    '5915043': 'port-moody-bc',
+    '5931006': 'squamish-bc',
+    '5915075': 'maple-ridge-bc',
+    '5915039': 'port-coquitlam-bc',
+    '2454048': 'saint-hyacinthe-qc'
 };
 
-function slugify(text) {
-    return text.toString().toLowerCase().trim()
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, '')
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-+|-+$/g, '');
+function slugify(value) {
+    return String(value || '')
+        .normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
+        .replace(/['’]/g, '')
+        .toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 }
 
-function parseSgcHierarchy(csvContent) {
-    const lines = csvContent.split(/\r?\n/);
-    const places = [];
-    const identifiers = [];
+function normalize(enRows, frRows) {
+    const frByCode = new Map(frRows.map(row => [String(row.Code), row]));
+    const usedSlugs = new Set(['canada']);
+    const places = [{
+        id: 'ca',
+        slug: 'canada',
+        kind: 'country',
+        nameEn: 'Canada',
+        nameFr: 'Canada',
+        typeEn: 'Country',
+        typeFr: 'Pays',
+        parentId: null,
+        featured: false
+    }];
+    const identifiers = [{
+        placeId: 'ca',
+        scheme: 'sgc',
+        vintage: '2021',
+        value: '01'
+    }];
 
-    for (let i = 1; i < lines.length; i++) {
-        const line = lines[i].trim();
-        if (!line) continue;
+    for (const row of enRows) {
+        const level = Number(row.Level);
+        const code = String(row.Code || '').trim();
+        if (![2, 3, 4].includes(level) || !code) continue;
 
-        const cols = [];
-        let current = '';
-        let inQuotes = false;
-        for (let j = 0; j < line.length; j++) {
-            const char = line[j];
-            if (char === '"') {
-                inQuotes = !inQuotes;
-            } else if (char === ',' && !inQuotes) {
-                cols.push(current.trim());
-                current = '';
-            } else {
-                current += char;
-            }
-        }
-        cols.push(current.trim());
+        const provinceCode = code.slice(0, 2);
+        const provinceAbbr = PROVINCES[provinceCode];
+        if (!provinceAbbr) continue;
 
-        const level = cols[0];
-        const code = cols[1];
-        const nameEn = cols[2];
-        const nameFr = cols[3];
-        const typeCode = cols[4];
+        const fr = frByCode.get(code) || {};
+        let nameEn = String(row['Class title'] || '').trim();
+        let nameFr = String(fr['Titres de classes'] || nameEn).trim();
 
-        let placeId = null;
-        let kind = null;
-        let parentId = null;
-        let typeEn = null;
-        let typeFr = null;
-
-        if (level === '1') {
-            kind = 'country';
-            placeId = 'ca';
-            typeEn = 'Country';
-            typeFr = 'Pays';
-        } else if (level === '2') {
-            kind = 'province';
-            const provAbbr = PROVINCES[code] || code;
-            placeId = 'ca-' + provAbbr.toLowerCase();
-            parentId = 'ca';
-            typeEn = 'Province';
-            typeFr = 'Province';
-        } else if (level === '3') {
-            kind = 'region';
-            const provCode = code.slice(0, 2);
-            parentId = 'ca-' + (PROVINCES[provCode] || provCode).toLowerCase();
-            placeId = code === '3518'
-                ? 'ca-on-durham'
-                : 'sgc-cd-' + code;
-            const provCodeCd = code.slice(0, 2);
-            const provinceAbbr = PROVINCES[provCodeCd] || provCodeCd;
-            typeEn = 'Census division';
-            typeFr = 'Division de recensement';
-            if (CSD_TYPES[typeCode]) {
-                typeEn = CSD_TYPES[typeCode].en;
-                typeFr = CSD_TYPES[typeCode].fr;
-            }
-        } else if (level === '4') {
-            kind = 'municipality';
-            const cdCode = code.slice(0, 4);
-            parentId = cdCode === '3518'
-                ? 'ca-on-durham'
-                : (SINGLE_TIER_CITY_CD.has(cdCode) && SINGLE_TIER_CITY_CSD[code]
-                    ? 'ca-on'
-                    : 'sgc-cd-' + cdCode);
-            const provCode = code.slice(0, 2);
-            const provinceAbbr = PROVINCES[provCode] || provCode;
-            typeEn = 'Census subdivision';
-            typeFr = 'Subdivision de recensement';
-            if (SGC_MUNICIPAL_TYPES[code]) {
-                typeEn = SGC_MUNICIPAL_TYPES[code].en;
-                typeFr = SGC_MUNICIPAL_TYPES[code].fr;
-            } else if (CSD_TYPES[typeCode]) {
-                typeEn = CSD_TYPES[typeCode].en;
-                typeFr = CSD_TYPES[typeCode].fr;
-            }
-            placeId = code === '3518013'
-                ? 'ca-on-oshawa'
-                : 'sgc-csd-' + code;
-        }
-
-        if (!placeId) continue;
-
-        const provCodeForPlace = code.slice(0, 2);
-        const provinceAbbr = PROVINCES[provCodeForPlace] || (kind === 'province' ? PROVINCES[code] : null);
-
-        let slug = slugify(nameEn || nameFr);
-        if (kind === 'province' && provinceAbbr) {
-            slug = provinceAbbr.toLowerCase();
-        } else if (kind === 'country') {
-            slug = 'canada';
-        }
-
-        const featured = FEATURED_PLACES[placeId];
-        let isFeatured = false;
-        let bbox = null;
-        let center = null;
-        let defaultZoom = null;
-
-        if (featured) {
-            isFeatured = true;
-            slug = featured.slug;
-            bbox = featured.bbox;
-            center = featured.center;
-            defaultZoom = featured.zoom;
-        }
-
-        if (SINGLE_TIER_CITY_CSD[code]) {
+        if (level === 4 && SINGLE_TIER_CITY_CSD[code]) {
+            const placeId = SINGLE_TIER_CITY_CSD[code];
             identifiers.push({
-                place_id: SINGLE_TIER_CITY_CSD[code],
-                scheme: 'sgc_csd',
-                identifier: code
+                placeId,
+                scheme: 'sgc-csd',
+                vintage: '2021',
+                value: code
             });
             continue;
         }
 
-        places.push({
-            id: placeId,
-            kind: kind,
-            parent_id: parentId,
-            slug: slug,
-            name_en: nameEn || nameFr,
-            name_fr: nameFr || nameEn,
-            province_abbr: provinceAbbr,
-            type_en: typeEn,
-            type_fr: typeFr,
-            is_featured: isFeatured,
-            bbox: bbox,
-            center: center,
-            default_zoom: defaultZoom
-        });
+        let id;
+        let kind;
+        let parentId;
+        let scheme;
+        let typeEn;
+        let typeFr;
+        let baseSlug;
 
-        if (level === '2') {
-            identifiers.push({ place_id: placeId, scheme: 'sgc_p', identifier: code });
-        } else if (level === '3') {
-            identifiers.push({ place_id: placeId, scheme: 'sgc_cd', identifier: code });
-        } else if (level === '4') {
-            identifiers.push({ place_id: placeId, scheme: 'sgc_csd', identifier: code });
+        if (level === 2) {
+            id = 'sgc-pr-' + code;
+            kind = TERRITORIES.has(code) ? 'territory' : 'province';
+            parentId = 'ca';
+            scheme = 'sgc-pr';
+            typeEn = kind === 'territory' ? 'Territory' : 'Province';
+            typeFr = kind === 'territory' ? 'Territoire' : 'Province';
+            baseSlug = slugify(nameEn);
+        } else if (level === 3) {
+            id = code === '3518' ? 'ca-on-durham' : 'sgc-cd-' + code;
+            kind = SINGLE_TIER_CITY_CD.has(code) ? 'municipality' : 'region';
+            parentId = code.slice(0, 2) === '35' ? 'ca-on' : 'sgc-pr-' + code.slice(0, 2);
+            scheme = 'sgc-cd';
+            typeEn = SINGLE_TIER_CITY_CD.has(code) ? 'City' : 'Census division';
+            typeFr = SINGLE_TIER_CITY_CD.has(code) ? 'Ville' : 'Division de recensement';
+            baseSlug = slugify(nameEn) + '-' + provinceAbbr;
+        } else {
+            id = code === '3518013' ? 'ca-on-oshawa' : 'sgc-csd-' + code;
+            kind = 'municipality';
+            parentId = code.slice(0, 4) === '3518' ? 'ca-on-durham' : 'sgc-cd-' + code.slice(0, 4);
+            scheme = 'sgc-csd';
+            typeEn = 'Municipality';
+            typeFr = 'Municipalité';
+            baseSlug = slugify(nameEn) + '-' + provinceAbbr;
         }
+
+        if (code === '35') id = 'ca-on';
+        if (code === '35') parentId = 'ca';
+        if (code === '35') baseSlug = 'ontario';
+
+        let slug = baseSlug;
+        if (code === '1209') slug = 'halifax-region-ns';
+        if (code === '1209034') slug = 'halifax-ns';
+        if (code === '1307019') slug = 'moncton-parish-nb';
+        if (code === '1307022') slug = 'moncton-nb';
+        if (code === '3518') slug = 'durham-on';
+        if (code === '2423') slug = 'quebec-region-qc';
+        if (code === '2423027') slug = 'quebec-qc';
+        if (code === '2466') slug = 'montreal-region-qc';
+        if (code === '2466023') slug = 'montreal-qc';
+        if (code === '2465') slug = 'laval-qc';
+        if (code === '3506') slug = 'ottawa-on';
+        if (code === '3514019') slug = 'hamilton-township-on';
+        if (code === '3519') slug = 'york-region-on';
+        if (code === '3520') slug = 'toronto-on';
+        if (code === '3524') slug = 'halton-region-on';
+        if (code === '3525') slug = 'hamilton-on';
+        if (code === '3526') slug = 'niagara-region-on';
+        if (code === '3530') slug = 'waterloo-region-on';
+        if (code === '3530016') slug = 'waterloo-on';
+        if (code === '3553') slug = 'greater-sudbury-on';
+        if (code === '3518013') slug = 'oshawa-on';
+        if (code === '3558') slug = 'thunder-bay-district-on';
+        if (code === '3558004') slug = 'thunder-bay-on';
+        if (code === '3516') slug = 'kawartha-lakes-on';
+        if (code === '3536') slug = 'chatham-kent-on';
+        if (code === '3543') slug = 'simcoe-county-on';
+        if (code === '3543042') slug = 'barrie-on';
+        if (code === '5907') slug = 'okanagan-similkameen-bc';
+        if (code === '5907035') slug = 'summerland-bc';
+        if (code === '3528') slug = 'haldimand-norfolk-on';
+        if (code === '3528052') slug = 'norfolk-county-on';
+        if (code === '4802012') slug = 'lethbridge-ab';
+        if (code === '4801006') slug = 'medicine-hat-ab';
+        if (code === '4806021') slug = 'airdrie-ab';
+        if (code === '4815023') slug = 'canmore-ab';
+        if (code === '5907041') slug = 'penticton-bc';
+        if (code === '5915001') slug = 'langley-bc';
+        if (code === '3540') slug = 'huron-county-on';
+        if (code === '1211') slug = 'cumberland-county-ns';
+        if (code === '3528018') slug = 'haldimand-county-on';
+        if (code === '6106023') slug = 'yellowknife-nt';
+        if (EXPANSION_SLUGS[code]) slug = EXPANSION_SLUGS[code];
+        if (code === '3518') {
+            typeEn = 'Regional municipality';
+            typeFr = 'Municipalité régionale';
+        }
+        if (code === '3519') {
+            typeEn = 'Regional municipality';
+            typeFr = 'Municipalité régionale';
+        }
+        if (code === '3521') {
+            typeEn = 'Regional municipality';
+            typeFr = 'Municipalité régionale';
+        }
+        if (code === '3524') {
+            typeEn = 'Regional municipality';
+            typeFr = 'Municipalité régionale';
+        }
+        if (code === '3526') {
+            typeEn = 'Regional municipality';
+            typeFr = 'Municipalité régionale';
+        }
+        if (code === '3530') {
+            typeEn = 'Regional municipality';
+            typeFr = 'Municipalité régionale';
+        }
+        if (MUNICIPAL_TYPES[code]) [typeEn, typeFr] = MUNICIPAL_TYPES[code];
+
+        if (usedSlugs.has(slug)) {
+            slug += '-' + code;
+        }
+        usedSlugs.add(slug);
+
+        const viewport = PLACE_VIEWPORTS[code] || [];
+        places.push({
+            id,
+            slug,
+            kind,
+            nameEn,
+            nameFr,
+            typeEn,
+            typeFr,
+            parentId,
+            featured: FEATURED_PLACE_IDS.has(id),
+            latitude: viewport[0] ?? null,
+            longitude: viewport[1] ?? null,
+            defaultZoom: viewport[2] ?? null
+        });
+        identifiers.push({
+            placeId: id,
+            scheme,
+            vintage: '2021',
+            value: code
+        });
     }
 
     return { places, identifiers };
 }
 
+function planAliases(existingPlaces, canonicalPlaces, existingAliases) {
+    const canonicalBySlug = new Map(canonicalPlaces.map(place => [place.slug, place]));
+    const aliasBySlug = new Map(existingAliases.map(alias => [alias.slug, alias]));
+    const existingById = new Map(existingPlaces.map(place => [place.id, place]));
+    const aliasesToAdd = [];
+    const conflicts = [];
+
+    for (const canonical of canonicalPlaces) {
+        const current = existingById.get(canonical.id);
+        if (!current || !current.slug || current.slug === canonical.slug) continue;
+
+        const formerSlug = current.slug;
+        const canonicalOwner = canonicalBySlug.get(formerSlug);
+        if (canonicalOwner && canonicalOwner.id !== canonical.id) {
+            conflicts.push({
+                slug: formerSlug,
+                expectedPlaceId: canonical.id,
+                existingPlaceId: canonicalOwner.id,
+                reason: 'former slug matches another canonical place'
+            });
+            continue;
+        }
+
+        const aliasOwner = aliasBySlug.get(formerSlug);
+        if (aliasOwner && aliasOwner.placeId !== canonical.id) {
+            conflicts.push({
+                slug: formerSlug,
+                expectedPlaceId: canonical.id,
+                existingPlaceId: aliasOwner.placeId,
+                reason: 'former slug already mapped to another place'
+            });
+            continue;
+        }
+
+        if (!aliasOwner) {
+            aliasesToAdd.push({
+                slug: formerSlug,
+                placeId: canonical.id
+            });
+        }
+    }
+
+    return { aliasesToAdd, conflicts };
+}
+
+function rowsFrom(buffer, encoding = 'utf-8') {
+    const text = new TextDecoder(encoding).decode(buffer);
+    if (text.includes('\uFFFD')) {
+        throw new Error('Statistics Canada SGC input contains undecodable replacement characters');
+    }
+    return parse(text, {
+        columns: true,
+        skip_empty_lines: true,
+        relax_column_count: true
+    });
+}
+
+async function run() {
+    console.log('Fetching official 2021 SGC structures...');
+    const [enBuf, frBuf] = await Promise.all([
+        fetchPublicBuffer(EN_URL),
+        fetchPublicBuffer(FR_URL)
+    ]);
+
+    const { places, identifiers } = normalize(
+        rowsFrom(enBuf, 'windows-1252'),
+        rowsFrom(frBuf, 'windows-1252')
+    );
+
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+
+        const [existingPlacesRes, existingAliasesRes] = await Promise.all([
+            client.query('SELECT id, slug, name_en, name_fr FROM places'),
+            client.query('SELECT slug, place_id FROM place_aliases')
+        ]);
+
+        const existingPlaces = existingPlacesRes.rows;
+        const existingAliases = existingAliasesRes.rows.map(row => ({
+            slug: row.slug,
+            placeId: row.place_id
+        }));
+
+        const { aliasesToAdd, conflicts } = planAliases(existingPlaces, places, existingAliases);
+        if (conflicts.length > 0) {
+            throw new Error('Refusing to sync places due to alias conflicts:\n' + JSON.stringify(conflicts, null, 2));
+        }
+
+        const existingPlaceById = new Map(existingPlaces.map(p => [p.id, p]));
+        let nameChanges = 0;
+        let slugChanges = 0;
+
+        for (const place of places) {
+            const existing = existingPlaceById.get(place.id);
+            if (existing) {
+                if (existing.name_en !== place.nameEn || existing.name_fr !== place.nameFr) {
+                    nameChanges++;
+                }
+                if (existing.slug !== place.slug) {
+                    slugChanges++;
+                }
+            }
+        }
+
+        for (let i = 0; i < places.length; i += 200) {
+            const batch = places.slice(i, i + 200);
+            const params = [];
+            const values = [];
+            let p = 1;
+
+            for (const place of batch) {
+                values.push(
+                    `($${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, $${p++}, true, $${p++}, now())`
+                );
+                params.push(
+                    place.id,
+                    place.slug,
+                    place.kind,
+                    place.nameEn,
+                    place.nameFr,
+                    place.typeEn,
+                    place.typeFr,
+                    place.parentId,
+                    place.latitude,
+                    place.longitude,
+                    place.defaultZoom,
+                    place.featured
+                );
+            }
+
+            await client.query(`
+                INSERT INTO places (
+                    id, slug, kind, name_en, name_fr, type_en, type_fr,
+                    parent_id, latitude, longitude, default_zoom, enabled, featured, updated_at
+                )
+                VALUES ${values.join(', ')}
+                ON CONFLICT (id) DO UPDATE SET
+                    slug = EXCLUDED.slug,
+                    kind = EXCLUDED.kind,
+                    name_en = EXCLUDED.name_en,
+                    name_fr = EXCLUDED.name_fr,
+                    type_en = EXCLUDED.type_en,
+                    type_fr = EXCLUDED.type_fr,
+                    parent_id = EXCLUDED.parent_id,
+                    latitude = EXCLUDED.latitude,
+                    longitude = EXCLUDED.longitude,
+                    default_zoom = EXCLUDED.default_zoom,
+                    featured = EXCLUDED.featured,
+                    enabled = true,
+                    updated_at = now()
+            `, params);
+        }
+
+        for (let i = 0; i < identifiers.length; i += 200) {
+            const batch = identifiers.slice(i, i + 200);
+            const params = [];
+            const values = [];
+            let p = 1;
+
+            for (const identifier of batch) {
+                values.push(`($${p++}, $${p++}, $${p++}, $${p++})`);
+                params.push(
+                    identifier.placeId,
+                    identifier.scheme,
+                    identifier.vintage,
+                    identifier.value
+                );
+            }
+
+            await client.query(`
+                INSERT INTO place_identifiers (place_id, scheme, vintage, value)
+                VALUES ${values.join(', ')}
+                ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+                    place_id = EXCLUDED.place_id
+            `, params);
+        }
+
+        for (const alias of aliasesToAdd) {
+            await client.query(`
+                INSERT INTO place_aliases (slug, place_id, created_at)
+                VALUES ($1, $2, now())
+                ON CONFLICT (slug) DO UPDATE SET
+                    place_id = EXCLUDED.place_id
+            `, [alias.slug, alias.placeId]);
+        }
+
+        await client.query('COMMIT');
+        console.log(JSON.stringify({
+            places: places.length,
+            identifiers: identifiers.length,
+            name_changes: nameChanges,
+            slug_changes: slugChanges,
+            aliases_to_add: aliasesToAdd.length,
+            alias_conflicts: conflicts.length
+        }));
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('Place sync failed:', err);
+        process.exit(1);
+    } finally {
+        client.release();
+        await pool.end();
+    }
+}
+
 module.exports = {
-    PROVINCES,
-    PROVINCE_NAMES,
-    CSD_TYPES,
-    SGC_MUNICIPAL_TYPES,
-    SINGLE_TIER_CITY_CD,
-    SINGLE_TIER_CITY_CSD,
-    FEATURED_PLACES,
-    slugify,
-    parseSgcHierarchy
+    normalize,
+    planAliases,
+    rowsFrom,
+    run,
+    EN_URL,
+    FR_URL
 };
+
+if (require.main === module) {
+    run();
+}

--- a/server/services/arcgisHubAdapter.js
+++ b/server/services/arcgisHubAdapter.js
@@ -1,253 +1,384 @@
-const { normalizeCatalogLicense } = require('./catalogWrite');
-const { getSource } = require('../config/catalogSources');
+const { fetchPublicJson } = require('./publicJson');
 
-function patternMatches(value, pattern) {
-    if (!value || !pattern) {
-        return false;
+const ITEM_RE = /[?&]id=([0-9a-f]{32})(?:&|$)/i;
+const LAYER_RE = /[?&](?:sublayer|layers)=([0-9]+)(?:&|$)/i;
+const GEO_TYPES = {
+    esriGeometryPoint: 'point',
+    esriGeometryMultipoint: 'multipoint',
+    esriGeometryPolyline: 'polyline',
+    esriGeometryPolygon: 'polygon'
+};
+
+function collapse(value) {
+    return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+}
+
+function isPlaceholder(value) {
+    const text = collapse(value);
+    return !text || /^\{\{[^}]+\}\}$/.test(text) || /^\$\{[^}]+\}$/.test(text);
+}
+
+function timestamp(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const numeric = typeof value === 'number' || /^\d{11,}$/.test(String(value))
+        ? Number(value)
+        : null;
+    const date = new Date(numeric == null ? value : numeric);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function decodeEntities(value) {
+    return value
+        .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
+        .replace(/&#x([0-9a-f]+);/gi, (_, n) => String.fromCodePoint(parseInt(n, 16)))
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&amp;/gi, '&')
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;|&apos;/gi, "'");
+}
+
+function htmlToText(value) {
+    const text = String(value == null ? '' : value)
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+        .replace(/<br\s*\/?>|<\/p>|<\/div>|<\/li>/gi, '\n')
+        .replace(/<[^>]+>/g, ' ');
+    return decodeEntities(text).replace(/[ \t]+/g, ' ').replace(/\s*\n\s*/g, '\n').trim();
+}
+
+function array(value) {
+    if (Array.isArray(value)) return value;
+    return value == null ? [] : [value];
+}
+
+function distribution(record, format) {
+    return array(record.distribution).find(item => collapse(item && item.format).toLowerCase() === format.toLowerCase()) || null;
+}
+
+function namespaceFor(record) {
+    const landing = collapse(record.landingPage);
+    const match = landing.match(/\/datasets\/([^/:]+)::/i);
+    return match ? match[1].toLowerCase() : null;
+}
+
+function identityFor(record) {
+    const identifier = collapse(record.identifier);
+    const itemMatch = identifier.match(ITEM_RE);
+    if (!itemMatch) return null;
+    const layerMatch = identifier.match(LAYER_RE);
+    return { itemId: itemMatch[1].toLowerCase(), layerId: layerMatch ? Number(layerMatch[1]) : null };
+}
+
+function canonicalKey(identity) {
+    return identity.itemId + ':' + (identity.layerId == null ? 'item' : identity.layerId);
+}
+
+function idsFor(identity) {
+    const suffix = identity.layerId == null ? 'item' : String(identity.layerId);
+    return {
+        datasetId: 'arcgis-' + identity.itemId + '-' + suffix,
+        resourceId: 'arcgis-' + identity.itemId + '-' + suffix + '-data'
+    };
+}
+
+function parseSpatial(value) {
+    const parts = String(value || '').split(',').map(Number);
+    if (parts.length !== 4 || parts.some(number => !Number.isFinite(number))) return null;
+    const [west, south, east, north] = parts;
+    if (west < -180 || east > 180 || south < -90 || north > 90 || west >= east || south >= north) return null;
+    return [west, south, east, north];
+}
+
+function mercatorToLonLat(x, y) {
+    const longitude = x / 20037508.34 * 180;
+    const latitude = Math.atan(Math.exp(y / 20037508.34 * Math.PI)) * 360 / Math.PI - 90;
+    return [Math.max(-180, Math.min(180, longitude)), Math.max(-90, Math.min(90, latitude))];
+}
+
+function extentFrom(metadata, record) {
+    const dcat = parseSpatial(record.spatial);
+    if (dcat) return dcat;
+    const extent = metadata && metadata.extent;
+    if (!extent) return null;
+    const values = [extent.xmin, extent.ymin, extent.xmax, extent.ymax].map(Number);
+    if (values.some(number => !Number.isFinite(number))) return null;
+    const wkid = Number(extent.spatialReference && (extent.spatialReference.latestWkid || extent.spatialReference.wkid));
+    if (wkid === 4326) return values;
+    if ([3857, 102100, 102113].includes(wkid)) {
+        const sw = mercatorToLonLat(values[0], values[1]);
+        const ne = mercatorToLonLat(values[2], values[3]);
+        return [sw[0], sw[1], ne[0], ne[1]];
     }
+    return null;
+}
+
+function patternMatches(pattern, value) {
+    if (!pattern) return true;
     if (pattern instanceof RegExp) {
+        pattern.lastIndex = 0;
         return pattern.test(value);
     }
     return String(value).toLowerCase().includes(String(pattern).toLowerCase());
 }
 
-function canonicalPublisher(source, value) {
-    if (!value) {
+function canonicalPublisher(value, source) {
+    const publisher = collapse(value) || 'Government publisher';
+    const alias = (source.publisherAliases || []).find(rule => patternMatches(rule.publisher, publisher));
+    return alias ? alias.name : publisher;
+}
+
+function configuredPlaceholderPublisher(source) {
+    const configured = collapse(source && source.placeholderPublisher);
+    const expectedHost = collapse(source && source.upstreamHost).toLowerCase();
+    if (!configured || !expectedHost) return null;
+    try {
+        const catalog = new URL(source.catalogUrl);
+        if (catalog.protocol !== 'https:' || catalog.hostname.toLowerCase() !== expectedHost) return null;
+        return configured;
+    } catch {
         return null;
     }
-    const aliases = source.publisherAliases || [];
-    for (const alias of aliases) {
-        if (patternMatches(value, alias.publisher)) {
-            return alias.name;
+}
+
+function publisherName(record, item, source) {
+    const supplied = collapse(record.publisher && record.publisher.name);
+    const fallback = collapse(item && item.owner) || collapse(item && item.orgId);
+    const placeholder = isPlaceholder(supplied) ? configuredPlaceholderPublisher(source) : null;
+    return canonicalPublisher(isPlaceholder(supplied) ? (placeholder || fallback) : supplied, source);
+}
+
+function ruleMatches(rule, namespace, publisher, licenseEvidence = '') {
+    if (rule.namespace && rule.namespace !== namespace) return false;
+    if (rule.publisher && !patternMatches(rule.publisher, publisher)) return false;
+    if (rule.licensePattern && !patternMatches(rule.licensePattern, licenseEvidence)) return false;
+    return true;
+}
+
+function matchRule(rules, namespace, publisher, licenseEvidence = '') {
+    return (rules || []).find(rule => ruleMatches(rule, namespace, publisher, licenseEvidence)) || null;
+}
+
+function resolveLicense(value, source, namespace, publisher) {
+    const evidence = array(value).map(entry => collapse(entry) + ' ' + htmlToText(entry)).join(' ').trim();
+    if ((source.restrictedLicensePatterns || []).some(pattern => patternMatches(pattern, evidence))) {
+        return { status: 'restricted-license', license: null };
+    }
+    const rule = matchRule(source.licenseRules, namespace, publisher, evidence);
+    if (rule) return { status: 'recognized', license: rule.license };
+    if (source.licenseMode !== 'record-explicit') {
+        const raw = collapse(htmlToText(value));
+        if (source.allowUnrecognizedLicenseUrl && /^https?:\/\//i.test(raw)) {
+            return {
+                status: 'recognized',
+                license: { titleEn: 'Licence supplied by the publisher', titleFr: 'Licence fournie par l’éditeur', url: raw }
+            };
         }
     }
-    return String(value).trim();
+    return { status: 'unlicensed', license: null };
 }
 
-function publisherName(source, dataset) {
-    const rawPublisher = dataset.publisher && dataset.publisher.name
-        ? dataset.publisher.name
-        : (dataset.attributes && (dataset.attributes.source || dataset.attributes.owner || dataset.attributes.orgName)) || null;
-
-    if (!rawPublisher) {
-        return null;
-    }
-    return canonicalPublisher(source, rawPublisher);
-}
-
-function ruleMatches(value, rulePattern) {
-    if (!rulePattern) {
-        return true;
-    }
-    return patternMatches(value, rulePattern);
-}
-
-function matchRule(rules, publisher, candidateLicenseText) {
-    if (!rules || rules.length === 0) {
-        return null;
-    }
-    for (const rule of rules) {
-        const matchesPublisher = ruleMatches(publisher, rule.publisher);
-        const matchesLicense = !rule.licensePattern || (candidateLicenseText && patternMatches(candidateLicenseText, rule.licensePattern));
-        if (matchesPublisher && matchesLicense) {
-            return rule;
-        }
-    }
-    return null;
+function knownLicense(value, source, namespace, publisher) {
+    return resolveLicense(value, source, namespace, publisher).license;
 }
 
 function authoritativePublisher(source, publisher) {
-    if (!publisher) {
-        return false;
-    }
-    const rules = source.authoritativePublishers || [];
-    if (rules.length === 0) {
-        return true;
-    }
-    for (const rule of rules) {
-        if (ruleMatches(publisher, rule.publisher)) {
-            return true;
-        }
-    }
-    return false;
+    if (!Array.isArray(source.authoritativePublishers)) return true;
+    return source.authoritativePublishers.some(rule => patternMatches(rule.publisher, publisher));
 }
 
-function isRestrictedLicense(source, candidateText) {
-    if (!candidateText) {
-        return false;
-    }
-    const patterns = source.restrictedLicensePatterns || [];
-    for (const pattern of patterns) {
-        if (patternMatches(candidateText, pattern)) {
-            return true;
-        }
-    }
-    return false;
+function slugKey(value) {
+    return collapse(value).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 100);
 }
 
-function resolveLicense(source, publisher, candidateText) {
-    if (isRestrictedLicense(source, candidateText)) {
-        return null;
+function selectedFields(metadata) {
+    const fields = array(metadata && metadata.fields)
+        .filter(field => field && field.name && !/geometry|blob|raster/i.test(field.type || ''))
+        .filter(field => !/^shape(__)?(area|length)$/i.test(field.name))
+        .map(field => ({ name: field.name, alias: collapse(field.alias) || field.name, type: field.type || 'text' }));
+    const wanted = [];
+    const add = (name) => {
+        const field = fields.find(candidate => candidate.name === name);
+        if (field && !wanted.some(candidate => candidate.name === field.name)) wanted.push(field);
+    };
+    add(metadata && metadata.objectIdField);
+    add(metadata && metadata.displayField);
+    for (const field of fields) {
+        if (wanted.length >= 20) break;
+        add(field.name);
     }
-    const matchedRule = matchRule(source.licenseRules, publisher, candidateText);
-    if (matchedRule && matchedRule.license) {
-        return normalizeCatalogLicense(matchedRule.license);
-    }
-    if (candidateText) {
-        const known = normalizeCatalogLicense(candidateText);
-        if (known && known.url) {
-            return known;
-        }
-    }
+    return wanted;
+}
+
+function serviceIsLeaf(metadata) {
+    const type = collapse(metadata && metadata.type).toLowerCase();
+    if (type.includes('group layer') || type.includes('annotation')) return false;
+    return Boolean(GEO_TYPES[metadata && metadata.geometryType]) || type === 'table';
+}
+
+function formatForDirectItem(record, item) {
+    const formats = array(record.distribution).map(entry => collapse(entry && entry.format).toUpperCase());
+    if (formats.includes('XLSX') || /excel/i.test(item && item.type)) return 'XLSX';
+    if (formats.includes('CSV') || /^csv$/i.test(item && item.type)) return 'CSV';
+    if (/\.xlsx(?:$|\?)/i.test(item && item.url)) return 'XLSX';
+    if (/\.csv(?:$|\?)/i.test(item && item.url)) return 'CSV';
     return null;
 }
 
-function resolvePlaceAssignments(source, publisher) {
-    const rules = source.placeRules || [];
-    const assignments = [];
-    for (const rule of rules) {
-        if (ruleMatches(publisher, rule.publisher)) {
-            assignments.push({
-                placeId: rule.placeId,
-                relationship: rule.relationship || 'direct'
-            });
-        }
+function directUrl(identity, format, item, record) {
+    if (format === 'CSV' && /^csv$/i.test(item && item.type)) {
+        return 'https://www.arcgis.com/sharing/rest/content/items/' + identity.itemId + '/data';
     }
-    return assignments;
+    const dist = distribution(record, format);
+    return collapse(dist && (dist.downloadURL || dist.accessURL)) || collapse(item && item.url) || null;
 }
 
-class ArcgisHubAdapter {
-    constructor(source) {
-        this.source = source;
+async function enrichRecord(record, source, options = {}) {
+    const identity = identityFor(record);
+    if (!identity) return { status: 'excluded', reason: 'missing-item-id' };
+    const itemUrl = 'https://www.arcgis.com/sharing/rest/content/items/' + identity.itemId + '?f=json';
+    const item = await (options.fetchJson || fetchPublicJson)(itemUrl, options.http);
+    const namespace = namespaceFor(record);
+    const suppliedPublisher = collapse(record.publisher && record.publisher.name);
+    const publisher = publisherName(record, item, source);
+    const licenseResult = resolveLicense(
+        [record.license, record.rights, item.licenseInfo].filter(value => value != null),
+        source,
+        namespace,
+        publisher
+    );
+    if (!licenseResult.license || !licenseResult.license.url) {
+        return { status: 'excluded', reason: licenseResult.status, externalId: canonicalKey(identity) };
+    }
+    const licence = licenseResult.license;
+    const geo = distribution(record, 'ArcGIS GeoServices REST API');
+    const serviceUrl = collapse(geo && geo.accessURL);
+    if (serviceUrl && (source.unavailableServicePatterns || []).some(pattern => patternMatches(pattern, serviceUrl))) {
+        return { status: 'excluded', reason: 'unavailable-service', externalId: canonicalKey(identity) };
+    }
+    let metadata = null;
+    if (serviceUrl && identity.layerId != null) {
+        metadata = await (options.fetchJson || fetchPublicJson)(serviceUrl + (serviceUrl.includes('?') ? '&' : '?') + 'f=json', options.http);
+        if (!serviceIsLeaf(metadata)) return { status: 'excluded', reason: 'non-leaf-layer', externalId: canonicalKey(identity) };
     }
 
-    normalizeDataset(dataset) {
-        const attrs = dataset.attributes || dataset;
-        const id = dataset.id || attrs.id;
-        const titleEn = attrs.name || attrs.title || null;
-        if (!id || !titleEn) {
-            return null;
-        }
+    let format = serviceUrl ? 'CSV' : formatForDirectItem(record, item);
+    if (!format) return { status: 'excluded', reason: 'not-loadable', externalId: canonicalKey(identity) };
+    if (format === 'XLSX' && Number(item.size) > 20 * 1024 * 1024) {
+        return { status: 'excluded', reason: 'xlsx-too-large', externalId: canonicalKey(identity) };
+    }
 
-        const publisher = publisherName(this.source, dataset);
-        if (!authoritativePublisher(this.source, publisher)) {
-            return null;
-        }
+    const placeRule = matchRule(source.placeRules, namespace, publisher);
+    const ids = idsFor(identity);
+    const title = collapse(record.title) || collapse(metadata && metadata.name) || collapse(item.title) || ids.datasetId;
+    const description = htmlToText(record.description || item.description || item.snippet || '');
+    const keywords = Array.from(new Set(array(record.keyword).concat(array(item.tags)).map(collapse).filter(Boolean)));
+    const orgId = 'arcgis-publisher-' + (slugKey(publisher) || 'government-publisher');
+    const geometryType = GEO_TYPES[metadata && metadata.geometryType] || null;
+    const resourceUrl = serviceUrl
+        ? 'https://hub.arcgis.com/api/download/v1/items/' + identity.itemId + '/csv?layers=' + identity.layerId
+        : directUrl(identity, format, item, record);
+    if (!resourceUrl) return { status: 'excluded', reason: 'missing-download', externalId: canonicalKey(identity) };
 
-        const licenseCandidate = attrs.license || attrs.licenseTitle || attrs.licenseUrl || null;
-        const license = resolveLicense(this.source, publisher, licenseCandidate);
-        if (!license) {
-            return null;
-        }
-
-        const rawUrl = attrs.url || (this.source.homepageUrl ? this.source.homepageUrl.replace(/\/$/, '') + '/datasets/' + id : null);
-        const resources = [];
-
-        if (rawUrl) {
-            resources.push({
-                id: id + '-csv',
-                format: 'csv',
-                url: rawUrl + '.csv',
-                titleEn: 'CSV'
-            });
-            resources.push({
-                id: id + '-geojson',
-                format: 'geojson',
-                url: rawUrl + '.geojson',
-                titleEn: 'GeoJSON'
-            });
-        }
-
-        return {
-            id: id,
-            titleEn: titleEn,
+    const normalized = {
+        externalId: canonicalKey(identity),
+        organization: {
+            id: orgId,
+            name: orgId,
+            titleEn: publisher,
             titleFr: null,
-            descriptionEn: attrs.description || null,
-            descriptionFr: null,
-            organizationName: publisher || this.source.nameEn,
-            organizationTitleEn: publisher || this.source.nameEn,
-            organizationTitleFr: null,
-            licenseTitleEn: license.titleEn,
-            licenseTitleFr: license.titleFr,
-            licenseUrl: license.url,
-            licenseAttributionEn: license.attributionEn,
-            licenseAttributionFr: license.attributionFr,
-            sourceId: this.source.id,
-            catalogUrl: rawUrl,
-            tags: attrs.tags || [],
-            categories: attrs.categories || [],
-            placeAssignments: resolvePlaceAssignments(this.source, publisher),
-            resources: resources
-        };
-    }
-
-    normalizeDcatUsDataset(dataset) {
-        const id = dataset.identifier || dataset.id;
-        const titleEn = dataset.title || null;
-        if (!id || !titleEn) {
-            return null;
-        }
-
-        const publisher = publisherName(this.source, dataset);
-        if (!authoritativePublisher(this.source, publisher)) {
-            return null;
-        }
-
-        const licenseCandidate = dataset.license || null;
-        const license = resolveLicense(this.source, publisher, licenseCandidate);
-        if (!license) {
-            return null;
-        }
-
-        const distributions = dataset.distribution || [];
-        const resources = distributions.map((dist, idx) => {
-            const rawFormat = (dist.format || '').toLowerCase();
-            let format = rawFormat;
-            if (rawFormat.includes('csv')) format = 'csv';
-            else if (rawFormat.includes('geo+json') || rawFormat.includes('geojson')) format = 'geojson';
-            else if (rawFormat.includes('zip') || rawFormat.includes('shapefile')) format = 'zip';
-
-            return {
-                id: id + '-' + idx,
-                format: format || 'unknown',
-                url: dist.downloadURL || dist.accessURL,
-                titleEn: dist.title || format.toUpperCase()
-            };
-        });
-
-        return {
-            id: id,
-            titleEn: titleEn,
+            placeId: placeRule ? placeRule.placeId : null
+        },
+        dataset: {
+            id: ids.datasetId,
+            name: ids.datasetId,
+            titleEn: title,
             titleFr: null,
-            descriptionEn: dataset.description || null,
-            descriptionFr: null,
-            organizationName: publisher || this.source.nameEn,
-            organizationTitleEn: publisher || this.source.nameEn,
-            organizationTitleFr: null,
-            licenseTitleEn: license.titleEn,
-            licenseTitleFr: license.titleFr,
-            licenseUrl: license.url,
-            licenseAttributionEn: license.attributionEn,
-            licenseAttributionFr: license.attributionFr,
-            sourceId: this.source.id,
-            catalogUrl: dataset.landingPage || dataset.accessURL || null,
-            tags: dataset.keyword || [],
-            categories: dataset.theme || [],
-            placeAssignments: resolvePlaceAssignments(this.source, publisher),
-            resources: resources
-        };
+            notesEn: description || null,
+            notesFr: null,
+            orgId,
+            keywordsEn: keywords,
+            keywordsFr: [],
+            metadataModified: timestamp(record.modified || item.modified),
+            raw: { provider: 'arcgis', item_id: identity.itemId, layer_id: identity.layerId }
+        },
+        source: {
+            sourceId: source.id,
+            externalId: canonicalKey(identity),
+            datasetId: ids.datasetId,
+            landingUrl: collapse(record.landingPage) || collapse(record.identifier),
+            licenseTitleEn: licence.titleEn,
+            licenseTitleFr: licence.titleFr || null,
+            licenseUrl: licence.url,
+            attributionEn: licence.attributionEn || null,
+            attributionFr: licence.attributionFr || null,
+            isAuthoritative: authoritativePublisher(source, publisher),
+            raw: {
+                identifier: record.identifier,
+                namespace,
+                publisher,
+                supplied_publisher: isPlaceholder(suppliedPublisher) ? null : suppliedPublisher
+            }
+        },
+        resource: {
+            id: ids.resourceId,
+            datasetId: ids.datasetId,
+            nameEn: title,
+            nameFr: null,
+            format,
+            url: resourceUrl,
+            sizeBytes: serviceUrl ? null : (Number.isFinite(Number(item.size)) ? Number(item.size) : null),
+            datastoreActive: false,
+            language: 'en',
+            lastModified: timestamp(record.modified || item.modified),
+            raw: { provider: 'arcgis', item_id: identity.itemId, layer_id: identity.layerId }
+        },
+        places: placeRule ? [{
+            datasetId: ids.datasetId,
+            placeId: placeRule.placeId,
+            relationship: placeRule.relationship,
+            includesDescendants: placeRule.includesDescendants,
+            assignmentMethod: 'source'
+        }] : [],
+        map: geometryType ? {
+            resourceId: ids.resourceId,
+            serviceUrl,
+            geometryType,
+            extent: extentFrom(metadata, record),
+            objectIdField: metadata.objectIdField || null,
+            displayField: metadata.displayField || null,
+            fields: selectedFields(metadata),
+            maxRecordCount: Number(metadata.maxRecordCount) || null
+        } : null
+    };
+    return { status: 'included', value: normalized };
+}
+
+async function discover(source, options = {}) {
+    const feed = await (options.fetchJson || fetchPublicJson)(source.catalogUrl, options.http);
+    if (!feed || !Array.isArray(feed.dataset) || feed.dataset.length === 0) {
+        throw new Error('ArcGIS Hub returned an empty or invalid DCAT feed');
     }
+    return feed.dataset;
 }
 
 module.exports = {
-    ArcgisHubAdapter,
-    patternMatches,
-    canonicalPublisher,
-    publisherName,
-    ruleMatches,
-    matchRule,
-    authoritativePublisher,
-    isRestrictedLicense,
+    discover,
+    enrichRecord,
+    identityFor,
+    canonicalKey,
+    htmlToText,
+    parseSpatial,
+    extentFrom,
+    selectedFields,
+    serviceIsLeaf,
+    knownLicense,
     resolveLicense,
-    resolvePlaceAssignments
+    publisherName,
+    canonicalPublisher,
+    authoritativePublisher,
+    configuredPlaceholderPublisher,
+    isPlaceholder,
+    timestamp
 };

--- a/server/services/redDeerAdapter.js
+++ b/server/services/redDeerAdapter.js
@@ -1,0 +1,197 @@
+const { fetchPublicJson } = require('./publicJson');
+
+const DOWNLOAD_FORMATS = new Map([
+    ['CSV', { format: 'CSV', endpoint: 'csv' }],
+    ['EXCEL', { format: 'XLSX', endpoint: 'excel' }],
+    ['JSON', { format: 'JSON', endpoint: 'json' }],
+    ['SHAPEFILE', { format: 'ZIP', endpoint: 'shapefile' }],
+    ['KMZ', { format: 'KMZ', endpoint: 'kmz' }],
+    ['ZIP', { format: 'ZIP', endpoint: 'zip' }],
+    ['XML', { format: 'XML', endpoint: 'xml' }]
+]);
+
+function clean(value) {
+    return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+}
+
+function timestamp(value) {
+    if (value == null || value === '') return null;
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+}
+
+function identityFor(record) {
+    try {
+        const url = new URL(clean(record && record.dataUrl));
+        const match = url.pathname.match(/^\/api\/datasets\/([a-z0-9-]+)\/?$/i);
+        return match ? match[1].toLowerCase() : null;
+    } catch {
+        return null;
+    }
+}
+
+function canonicalKey(identity) {
+    return clean(identity).toLowerCase();
+}
+
+function pageSlug(record) {
+    return clean(record && record.name).toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function listedFormats(record) {
+    const seen = new Set();
+    return clean(record && record.formats)
+        .split(',')
+        .map(value => clean(value).toUpperCase())
+        .map(value => DOWNLOAD_FORMATS.get(value))
+        .filter(Boolean)
+        .filter(value => {
+            if (seen.has(value.endpoint)) return false;
+            seen.add(value.endpoint);
+            return true;
+        });
+}
+
+function keywords(record) {
+    return Array.from(new Set(clean(record && record.keywords)
+        .split(',')
+        .map(clean)
+        .filter(Boolean)));
+}
+
+async function discover(source, options = {}) {
+    const body = await (options.fetchJson || fetchPublicJson)(source.catalogUrl, options.http);
+    const datasets = body && body.datasets;
+    const total = Number(body && body.totalCount);
+    if (!Array.isArray(datasets) || !Number.isInteger(total) || total <= 0 || datasets.length !== total) {
+        throw new Error('Red Deer returned an invalid or incomplete catalogue');
+    }
+
+    const expectedHost = clean(source.upstreamHost).toLowerCase();
+    const identities = new Set();
+    for (const record of datasets) {
+        const identity = identityFor(record);
+        let url;
+        try {
+            url = new URL(clean(record && record.dataUrl));
+        } catch {
+            throw new Error('Red Deer returned a dataset with an invalid data URL');
+        }
+        if (!identity || url.protocol !== 'https:' || url.hostname.toLowerCase() !== expectedHost) {
+            throw new Error('Red Deer returned a dataset outside its configured HTTPS host');
+        }
+        if (identities.has(identity)) throw new Error('Red Deer returned a duplicate dataset identity');
+        identities.add(identity);
+    }
+    return datasets;
+}
+
+async function enrichRecord(record, source) {
+    const externalId = identityFor(record);
+    const title = clean(record && record.name);
+    const compactSlug = pageSlug(record);
+    const license = source.license;
+    if (!externalId || !title || !compactSlug) {
+        return { status: 'excluded', reason: 'invalid-dataset', externalId };
+    }
+    if (!license || !clean(license.url)) {
+        return { status: 'excluded', reason: 'unlicensed', externalId: canonicalKey(externalId) };
+    }
+
+    const available = listedFormats(record);
+    if (available.length === 0) {
+        return { status: 'excluded', reason: 'not-loadable', externalId: canonicalKey(externalId) };
+    }
+
+    const datasetId = 'red-deer-' + canonicalKey(externalId);
+    const publisher = clean(source.publisher) || 'The City of Red Deer';
+    const orgId = 'red-deer-publisher-city-of-red-deer';
+    const modified = timestamp(record.lastUpdateDate || record.metaDataLastUpdate);
+    const baseUrl = 'https://' + source.upstreamHost + '/datasets/' + compactSlug + '/download/';
+    const resources = available.map(item => ({
+        id: datasetId + '-' + item.endpoint,
+        datasetId,
+        nameEn: title + ' – ' + item.format,
+        nameFr: null,
+        format: item.format,
+        url: baseUrl + item.endpoint,
+        sizeBytes: null,
+        datastoreActive: false,
+        language: 'en',
+        lastModified: modified,
+        raw: {
+            provider: 'red-deer',
+            source_id: source.id,
+            upstream_dataset_id: externalId,
+            download_format: item.endpoint
+        }
+    }));
+
+    return {
+        status: 'included',
+        value: {
+            externalId: canonicalKey(externalId),
+            organization: {
+                id: orgId,
+                name: 'city-of-red-deer',
+                titleEn: publisher,
+                titleFr: 'Ville de Red Deer',
+                placeId: source.placeId
+            },
+            dataset: {
+                id: datasetId,
+                name: datasetId,
+                titleEn: title,
+                titleFr: null,
+                notesEn: clean(record.description) || null,
+                notesFr: null,
+                orgId,
+                keywordsEn: keywords(record),
+                keywordsFr: [],
+                metadataModified: modified,
+                raw: {
+                    provider: 'red-deer',
+                    source_id: source.id,
+                    upstream_dataset_id: externalId,
+                    category: clean(record.category) || null,
+                    owner: clean(record.owner) || null
+                }
+            },
+            source: {
+                sourceId: source.id,
+                externalId: canonicalKey(externalId),
+                datasetId,
+                landingUrl: 'https://' + source.upstreamHost + '/' + compactSlug,
+                licenseTitleEn: license.titleEn || null,
+                licenseTitleFr: license.titleFr || null,
+                licenseUrl: license.url,
+                attributionEn: license.attributionEn || null,
+                attributionFr: license.attributionFr || null,
+                isAuthoritative: true,
+                raw: { upstream_dataset_id: externalId, publisher }
+            },
+            resources,
+            places: [{
+                datasetId,
+                placeId: source.placeId,
+                relationship: 'direct',
+                includesDescendants: false,
+                assignmentMethod: 'source'
+            }],
+            maps: [],
+            manageMaps: false,
+            mapCandidates: [],
+            manageMapCandidates: true
+        }
+    };
+}
+
+module.exports = {
+    discover,
+    enrichRecord,
+    identityFor,
+    canonicalKey,
+    listedFormats,
+    pageSlug,
+    timestamp
+};

--- a/server/services/sourceAdapters.js
+++ b/server/services/sourceAdapters.js
@@ -2,12 +2,14 @@ const arcgisHub = require('./arcgisHubAdapter');
 const ckanSource = require('./ckanSourceAdapter');
 const opendatasoft = require('./opendatasoftAdapter');
 const socrata = require('./socrataAdapter');
+const redDeer = require('./redDeerAdapter');
 
 const adapters = new Map([
     ['arcgis-hub', arcgisHub],
     ['ckan', ckanSource],
     ['opendatasoft', opendatasoft],
-    ['socrata', socrata]
+    ['socrata', socrata],
+    ['red-deer', redDeer]
 ]);
 
 function getSourceAdapter(kind) {

--- a/server/sql/migrations/029_recovery_and_high_volume_places.sql
+++ b/server/sql/migrations/029_recovery_and_high_volume_places.sql
@@ -1,0 +1,173 @@
+-- Migration 029: recover the v33/v34 canonical place state, repair known
+-- Unicode damage, and add the v35 Northwest Territories / BC / Quebec wave.
+-- Migrations 001-028 are intentionally immutable; this migration is additive
+-- and safe on both fresh databases and partially deployed v34 databases.
+
+DELETE FROM place_aliases
+WHERE slug IN (
+    'coquitlam-bc',
+    'prince-george-bc',
+    'new-westminster-bc',
+    'port-moody-bc',
+    'squamish-bc',
+    'maple-ridge-bc',
+    'port-coquitlam-bc',
+    'saint-hyacinthe-qc',
+    'coquitlam-city-bc',
+    'prince-george-city-bc',
+    'new-westminster-city-bc',
+    'port-moody-city-bc',
+    'squamish-district-bc',
+    'maple-ridge-city-bc',
+    'port-coquitlam-city-bc',
+    'saint-hyacinthe-city-qc'
+);
+
+-- Provinces and territory required by the new ancestry. These upserts also
+-- repair the most visible mojibake left by an earlier UTF-8 decode attempt.
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('sgc-pr-24', 'quebec', 'province', 'Quebec', 'Québec', 'Province', 'Province', 'ca', NULL, NULL, NULL, true, false),
+    ('sgc-pr-59', 'british-columbia', 'province', 'British Columbia', 'Colombie-Britannique', 'Province', 'Province', 'ca', NULL, NULL, NULL, true, false),
+    ('sgc-pr-61', 'northwest-territories', 'territory', 'Northwest Territories', 'Territoires du Nord-Ouest', 'Territory', 'Territoire', 'ca', NULL, NULL, NULL, true, false)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+-- Census divisions / regional districts for the v35 municipalities.
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('sgc-cd-2454', 'les-maskoutains-qc', 'region', 'Les Maskoutains', 'Les Maskoutains', 'Census division', 'Division de recensement', 'sgc-pr-24', NULL, NULL, NULL, true, false),
+    ('sgc-cd-5915', 'greater-vancouver-bc', 'region', 'Greater Vancouver', 'Greater Vancouver', 'Regional district', 'District régional', 'sgc-pr-59', NULL, NULL, NULL, true, false),
+    ('sgc-cd-5931', 'squamish-lillooet-bc', 'region', 'Squamish-Lillooet', 'Squamish-Lillooet', 'Regional district', 'District régional', 'sgc-pr-59', NULL, NULL, NULL, true, false),
+    ('sgc-cd-5953', 'fraser-fort-george-bc', 'region', 'Fraser-Fort George', 'Fraser-Fort George', 'Regional district', 'District régional', 'sgc-pr-59', NULL, NULL, NULL, true, false)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    enabled = true,
+    featured = false,
+    updated_at = now();
+
+-- Featured v35 municipalities. The Northwest Territories source is assigned
+-- to sgc-pr-61 directly and does not make the territory a featured destination.
+INSERT INTO places (
+    id, slug, kind, name_en, name_fr, type_en, type_fr, parent_id,
+    latitude, longitude, default_zoom, enabled, featured
+) VALUES
+    ('sgc-csd-5915034', 'coquitlam-bc', 'municipality', 'Coquitlam', 'Coquitlam', 'City', 'Ville', 'sgc-cd-5915', 49.2838, -122.7932, 10, true, true),
+    ('sgc-csd-5953023', 'prince-george-bc', 'municipality', 'Prince George', 'Prince George', 'City', 'Ville', 'sgc-cd-5953', 53.9171, -122.7497, 10, true, true),
+    ('sgc-csd-5915029', 'new-westminster-bc', 'municipality', 'New Westminster', 'New Westminster', 'City', 'Ville', 'sgc-cd-5915', 49.2057, -122.9110, 11, true, true),
+    ('sgc-csd-5915043', 'port-moody-bc', 'municipality', 'Port Moody', 'Port Moody', 'City', 'Ville', 'sgc-cd-5915', 49.2838, -122.8317, 11, true, true),
+    ('sgc-csd-5931006', 'squamish-bc', 'municipality', 'Squamish', 'Squamish', 'District municipality', 'Municipalité de district', 'sgc-cd-5931', 49.7016, -123.1558, 10, true, true),
+    ('sgc-csd-5915075', 'maple-ridge-bc', 'municipality', 'Maple Ridge', 'Maple Ridge', 'City', 'Ville', 'sgc-cd-5915', 49.2193, -122.5984, 10, true, true),
+    ('sgc-csd-5915039', 'port-coquitlam-bc', 'municipality', 'Port Coquitlam', 'Port Coquitlam', 'City', 'Ville', 'sgc-cd-5915', 49.2628, -122.7811, 11, true, true),
+    ('sgc-csd-2454048', 'saint-hyacinthe-qc', 'municipality', 'Saint-Hyacinthe', 'Saint-Hyacinthe', 'City', 'Ville', 'sgc-cd-2454', 45.6307, -72.9569, 10, true, true)
+ON CONFLICT (id) DO UPDATE SET
+    slug = EXCLUDED.slug,
+    kind = EXCLUDED.kind,
+    name_en = EXCLUDED.name_en,
+    name_fr = EXCLUDED.name_fr,
+    type_en = EXCLUDED.type_en,
+    type_fr = EXCLUDED.type_fr,
+    parent_id = EXCLUDED.parent_id,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    default_zoom = EXCLUDED.default_zoom,
+    enabled = true,
+    featured = true,
+    updated_at = now();
+
+-- Explicitly repair known accented canonical rows before sync:places performs
+-- the complete Windows-1252-backed SGC reconciliation.
+UPDATE places SET name_en = 'Quebec', name_fr = 'Québec', updated_at = now()
+WHERE id = 'sgc-pr-24';
+UPDATE places SET name_en = 'Nova Scotia', name_fr = 'Nouvelle-Écosse', updated_at = now()
+WHERE id = 'sgc-pr-12';
+UPDATE places SET name_en = 'Prince Edward Island', name_fr = 'Île-du-Prince-Édouard', updated_at = now()
+WHERE id = 'sgc-pr-11';
+UPDATE places SET name_en = 'Newfoundland and Labrador', name_fr = 'Terre-Neuve-et-Labrador', updated_at = now()
+WHERE id = 'sgc-pr-10';
+UPDATE places SET name_en = 'Montréal', name_fr = 'Montréal', updated_at = now()
+WHERE id = 'sgc-cd-2466';
+UPDATE places SET name_en = 'Montréal', name_fr = 'Montréal', updated_at = now()
+WHERE id = 'sgc-csd-2466023';
+UPDATE places SET name_en = 'Québec', name_fr = 'Québec', updated_at = now()
+WHERE id = 'sgc-csd-2423027';
+UPDATE places SET name_en = 'Trois-Rivières', name_fr = 'Trois-Rivières', updated_at = now()
+WHERE id = 'sgc-csd-2437067';
+UPDATE places SET name_en = 'Lévis', name_fr = 'Lévis', updated_at = now()
+WHERE id = 'sgc-csd-2425213';
+
+INSERT INTO place_identifiers (place_id, scheme, vintage, value) VALUES
+    ('sgc-pr-24', 'sgc-pr', '2021', '24'),
+    ('sgc-pr-59', 'sgc-pr', '2021', '59'),
+    ('sgc-pr-61', 'sgc-pr', '2021', '61'),
+    ('sgc-cd-2454', 'sgc-cd', '2021', '2454'),
+    ('sgc-cd-5915', 'sgc-cd', '2021', '5915'),
+    ('sgc-cd-5931', 'sgc-cd', '2021', '5931'),
+    ('sgc-cd-5953', 'sgc-cd', '2021', '5953'),
+    ('sgc-csd-5915034', 'sgc-csd', '2021', '5915034'),
+    ('sgc-csd-5953023', 'sgc-csd', '2021', '5953023'),
+    ('sgc-csd-5915029', 'sgc-csd', '2021', '5915029'),
+    ('sgc-csd-5915043', 'sgc-csd', '2021', '5915043'),
+    ('sgc-csd-5931006', 'sgc-csd', '2021', '5931006'),
+    ('sgc-csd-5915075', 'sgc-csd', '2021', '5915075'),
+    ('sgc-csd-5915039', 'sgc-csd', '2021', '5915039'),
+    ('sgc-csd-2454048', 'sgc-csd', '2021', '2454048')
+ON CONFLICT (scheme, vintage, value) DO UPDATE SET
+    place_id = EXCLUDED.place_id;
+
+INSERT INTO place_aliases (slug, place_id) VALUES
+    ('coquitlam-city-bc', 'sgc-csd-5915034'),
+    ('prince-george-city-bc', 'sgc-csd-5953023'),
+    ('new-westminster-city-bc', 'sgc-csd-5915029'),
+    ('port-moody-city-bc', 'sgc-csd-5915043'),
+    ('squamish-district-bc', 'sgc-csd-5931006'),
+    ('maple-ridge-city-bc', 'sgc-csd-5915075'),
+    ('port-coquitlam-city-bc', 'sgc-csd-5915039'),
+    ('saint-hyacinthe-city-qc', 'sgc-csd-2454048')
+ON CONFLICT (slug) DO UPDATE SET
+    place_id = EXCLUDED.place_id;
+
+-- Reassert durable v33/v34 aliases so a partial earlier rollout converges to
+-- the same state as a fresh installation.
+INSERT INTO place_aliases (slug, place_id) VALUES
+    ('gatineau-city-qc', 'sgc-csd-2481017'),
+    ('trois-rivieres-city-qc', 'sgc-csd-2437067'),
+    ('repentigny-city-qc', 'sgc-csd-2460013'),
+    ('longueuil-city-qc', 'sgc-csd-2458227'),
+    ('saguenay-city-qc', 'sgc-csd-2494068'),
+    ('rimouski-city-qc', 'sgc-csd-2410043'),
+    ('shawinigan-city-qc', 'sgc-csd-2436033'),
+    ('levis-city-qc', 'sgc-csd-2425213'),
+    ('sherbrooke-city-qc', 'sgc-csd-2443027'),
+    ('saint-john-city-nb', 'sgc-csd-1301006'),
+    ('whitehorse-city-yt', 'sgc-csd-6001009'),
+    ('st-johns-city-nl', 'sgc-csd-1001519'),
+    ('charlottetown-city-pe', 'sgc-csd-1102075'),
+    ('regina-city-sk', 'sgc-csd-4706027'),
+    ('windsor-city-on', 'sgc-csd-3537039'),
+    ('kingston-city-on', 'sgc-csd-3510010'),
+    ('red-deer-city-ab', 'sgc-csd-4808011'),
+    ('kamloops-city-bc', 'sgc-csd-5933042'),
+    ('nanaimo-city-bc', 'sgc-csd-5921007'),
+    ('abbotsford-city-bc', 'sgc-csd-5909052')
+ON CONFLICT (slug) DO UPDATE SET
+    place_id = EXCLUDED.place_id;


### PR DESCRIPTION
## What & why

The v34 source expansion landed with an incomplete runtime baseline: the source registry self-required, place synchronization had encoding/canonicalization regressions, and `/api/v1/ops` failed while building configured-source jobs. This change restores the stable v32 base, makes v33-v35 expansion additive, and launches the verified high-volume wave without trusting unavailable municipal feeds.

- Restores the complete source registry and hardens ArcGIS/CKAN source admission.
- Adds the Red Deer catalogue adapter and ten active v35 sources across NWT, BC, and Quebec.
- Retains Whitehorse, St. John's, and Charlottetown identities disabled/fail-closed because their documented machine-readable feeds cannot currently be verified.
- Adds additive/idempotent migration 029 and Windows-1252-safe SGC place synchronization.
- Makes featured-place clients follow cursor pagination so all 116 featured destinations render.
- Adds a canary-first production runbook with zero-deletion assertions, a single map-worker owner, and bounded rollback procedures.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any — no new strings
- [x] No secrets, credentials, or production-specific details added

## Notes

- Registry: 85 local definitions, 82 enabled; 83 active catalogues including the federal mirror.
- Live upstream dry-runs across the 27 recovered/new sources: 4,855 discovered, 4,361 admitted, 494 excluded, 2,080 mappable, zero failed.
- Verification: 58 server suites / 472 tests, 27 client suites / 109 tests, both ESLint passes, Vite production build, and `git diff --check`.
- Migrations 001-029 and all 12 spatial integration tests also passed against disposable PostgreSQL 16/PostGIS 3.5.
- GitHub's targeted secret scanner was unavailable because Advanced Security is disabled; pinned Gitleaks 8.30.1 scanned the exact 23-file/430,857-byte release manifest with no findings.
- Migration 029 is additive and idempotent; already-applied migrations 001-028 remain immutable.
- Production is intentionally not claimed here. Deployment remains an operator-gated SSH rollout using `deploy/RELEASE_RUNBOOK_v35.md`.
