### PR TITLE
fix: support legacy place alias schema

### DIFF
--- a/server/__tests__/syncPlaces.test.js
+++ b/server/__tests__/syncPlaces.test.js
@@ -1,6 +1,11 @@
-const { normalize, rowsFrom } = require('../scripts/sync-places');
+const { normalize, rowsFrom, PLACE_ALIAS_UPSERT_SQL } = require('../scripts/sync-places');
 
 describe('Statistics Canada SGC place normalization', () => {
+    test('upserts aliases against the migration 006 schema', () => {
+        expect(PLACE_ALIAS_UPSERT_SQL).toContain('INSERT INTO place_aliases (slug, place_id)');
+        expect(PLACE_ALIAS_UPSERT_SQL).not.toContain('created_at');
+    });
+
     test('builds stable province, region and municipality ancestry', () => {
         const en = [
             { Level: '2', Code: '35', 'Class title': 'Ontario' },

--- a/server/scripts/sync-places.js
+++ b/server/scripts/sync-places.js
@@ -5,6 +5,12 @@ const { fetchPublicBuffer } = require('../services/publicJson');
 
 const EN_URL = 'https://www.statcan.gc.ca/en/statistical-programs/document/sgc-cgt-2021-structure-eng.csv';
 const FR_URL = 'https://www.statcan.gc.ca/fr/programmes-statistiques/document/sgc-cgt-2021-structure-fra.csv';
+const PLACE_ALIAS_UPSERT_SQL = `
+    INSERT INTO place_aliases (slug, place_id)
+    VALUES ($1, $2)
+    ON CONFLICT (slug) DO UPDATE SET
+        place_id = EXCLUDED.place_id
+`;
 const PROVINCES = {
     '10': 'nl', '11': 'pe', '12': 'ns', '13': 'nb', '24': 'qc', '35': 'on',
     '46': 'mb', '47': 'sk', '48': 'ab', '59': 'bc', '60': 'yt', '61': 'nt', '62': 'nu'
@@ -788,12 +794,7 @@ async function run() {
         }
 
         for (const alias of aliasesToAdd) {
-            await client.query(`
-                INSERT INTO place_aliases (slug, place_id, created_at)
-                VALUES ($1, $2, now())
-                ON CONFLICT (slug) DO UPDATE SET
-                    place_id = EXCLUDED.place_id
-            `, [alias.slug, alias.placeId]);
+            await client.query(PLACE_ALIAS_UPSERT_SQL, [alias.slug, alias.placeId]);
         }
 
         await client.query('COMMIT');
@@ -821,7 +822,8 @@ module.exports = {
     rowsFrom,
     run,
     EN_URL,
-    FR_URL
+    FR_URL,
+    PLACE_ALIAS_UPSERT_SQL
 };
 
 if (require.main === module) {


### PR DESCRIPTION
## What & why

The v35 production place refresh exposed a schema mismatch in the alias upsert: migration 006 defines `place_aliases(slug, place_id)`, while the refresh attempted to insert a nonexistent `created_at` column.

This removes that column from the upsert and exports the SQL for a regression test. The production refresh failed inside its transaction and rolled back before any source syncs or service restarts.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any — not applicable
- [x] No secrets, credentials, or production-specific details added

## Notes

- Targeted regression suite: 28 tests passed.
- Full release verification: 473 server tests and 109 client tests passed; both linters and the production build are clean.
- The two-file diff passed Gitleaks 8.30.1.
- Migration 029 remains safely applied; rerunning migrations will skip it before the corrected place refresh.