### PR TITLE
fix: harden v35 map queue retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ psql canquery -c "CREATE EXTENSION IF NOT EXISTS unaccent;"
 cd server
 npm install
 cp .env.example .env              # set DATABASE_URL (and optional S3_* for PMTiles)
-npm run migrate                   # apply migrations (runs 001..029)
+npm run migrate                   # apply migrations (runs 001..030)
 npm run sync:places               # populate the 2021 SGC hierarchy
 
 # sync the federal catalogue (batched harvest, chunks of 50)
@@ -96,6 +96,8 @@ npm run sync:source -- --source=durham-hub --dry-run
 npm run sync:source -- --source=peel-hub --dry-run
 npm run sync:municipal                    # sync every enabled local source
 npm run maps:drain                        # build all queued local map indexes
+npm run maps:retry-source -- --source=<source-id>  # inspect failed maps (read-only)
+npm run maps:retry-source -- --source=<source-id> --apply  # requeue after a verified probe
 npm run dev                   # API on :3100
 
 # 3. Client (separate terminal)

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -147,6 +147,9 @@ sudo -u canquery node /home/canquery/canquery/server/scripts/catalog-sync.js    
 sudo -u canquery npm run sync:places --prefix /home/canquery/canquery/server
 sudo -u canquery npm run sync:municipal --prefix /home/canquery/canquery/server
 sudo -u canquery npm run maps:drain --prefix /home/canquery/canquery/server
+# Inspect failed map jobs for one source; add --apply only after its upstream
+# endpoint has been verified from the production host.
+sudo -u canquery npm run maps:retry-source --prefix /home/canquery/canquery/server -- --source=<source-id>
 ```
 
 Use `npm run sync:source -- --source=<source-id> --dry-run` before enabling a new

--- a/deploy/RELEASE_RUNBOOK_v35.md
+++ b/deploy/RELEASE_RUNBOOK_v35.md
@@ -4,8 +4,9 @@ Status: release candidate validated locally on August 30, 2026. This document
 does not claim that v35 has been deployed to production.
 
 This release repairs the incomplete v34 implementation, activates the live v33
-and v34 catalogues that can still be verified, adds ten v35 sources, and applies
-migration `029_recovery_and_high_volume_places.sql`. The source registry contains
+and v34 catalogues that can still be verified, adds ten v35 sources, applies
+migrations `029_recovery_and_high_volume_places.sql` and
+`030_map_queue_resilience.sql`, and hardens local map retries. The source registry contains
 85 local definitions: 82 enabled and three retained but disabled fail-closed.
 Including the federal mirror, the application exposes 83 active catalogue
 sources. `/api/v1/ops` registers 82 `source:*` jobs; the federal mirror is
@@ -17,12 +18,17 @@ The following are live upstream dry-run observations, not permanent count
 assertions. Repeat the dry-runs immediately before deployment because upstream
 catalogues can change.
 
-| Wave | Active sources | Discovered | Admitted | Excluded | Mappable | Failed |
+| Wave | Active sources | Discovered | Admitted | Excluded | Mappable (raw dry-run) | Failed |
 |---|---:|---:|---:|---:|---:|---:|
 | v33 Quebec and Saint John | 10 | 869 | 647 | 222 | 532 | 0 |
 | v34 currently available catalogues | 7 | 2,566 | 2,438 | 128 | 841 | 0 |
 | v35 NWT, BC, and Quebec | 10 | 1,420 | 1,276 | 144 | 707 | 0 |
 | Total | 27 | 4,855 | 4,361 | 494 | 2,080 | 0 |
+
+The raw mappable total includes the 19 Shawinigan and 26 Saint-Hyacinthe
+GeoJSON candidates that are deliberately fail-closed in the production
+source configuration; the production queue must therefore exclude those 45
+candidates until a reviewed probe confirms recovery.
 
 The v35 source-level snapshot is:
 
@@ -37,13 +43,18 @@ The v35 source-level snapshot is:
 | `maple-ridge-hub` | 67 | 64 | 3 | 48 |
 | `port-coquitlam-hub` | 62 | 59 | 3 | 41 |
 | `sherbrooke-geomatics-open-data` | 30 | 30 | 0 | 30 |
-| `saint-hyacinthe-open-data` | 27 | 27 | 0 | 26 |
+| `saint-hyacinthe-open-data` | 27 | 27 | 0 | 0 (fail-closed) |
 
 `whitehorse-hub`, `st-johns-hub`, and `charlottetown-hub` are intentionally
 disabled. Their documented ArcGIS feeds are unavailable, and no equivalent
 machine-readable municipal catalogue with verified open-data terms was found.
 Do not enable them merely to make the configured count match an older release
 document.
+
+Shawinigan and Saint-Hyacinthe remain catalogue-enabled, but direct-file map
+admission is fail-closed because their advertised map hosts timed out from the
+production VPS during the v35 closeout. Their datasets and resources remain
+available as download-only records until a reviewed probe confirms recovery.
 
 Abbotsford intentionally excludes 28 records whose advertised service URLs are
 under the inaccessible `maps.abbotsford.ca/arcgis/rest/services/GeocortexExt/`
@@ -62,7 +73,7 @@ npm --prefix server run verify
 git diff --check
 ```
 
-The August 30 release candidate passed 58 server suites (472 tests), 27 client
+The August 30 release candidate passed 59 server suites (481 tests), 27 client
 suites (109 tests), both ESLint passes, and the Vite production build. The normal
 Jest run skips the PostGIS integration suite unless a database is supplied, so
 also validate all migrations against a disposable PostgreSQL 16/PostGIS 3.5
@@ -74,9 +85,10 @@ SPATIAL_TEST_DATABASE_URL=<disposable-postgis-url> \
   npm --prefix server test -- --runInBand __tests__/spatialIntegration.test.js
 ```
 
-Migration `029` is additive and idempotent. It repairs partial v33/v34 place
+Migrations `029` and `030` are additive and idempotent. Migration `029` repairs partial v33/v34 place
 state and damaged Unicode, then adds the v35 ancestry, identifiers, aliases, and
-featured municipalities. Do not rewrite already-applied migrations `001`–`028`.
+featured municipalities. Migration `030` adds durable map retry scheduling and
+typed source-failure state. Do not rewrite already-applied migrations `001`–`029`.
 
 ## 3. Repeat upstream dry-runs
 
@@ -302,13 +314,17 @@ sudo systemctl status opencanada-map-worker --no-pager
 sudo journalctl -u opencanada-map-worker --since '10 minutes ago' --no-pager
 
 psql -d opencanada -c \
-  "SELECT status, count(*) AS jobs, coalesce(sum(feature_count), 0) AS features
+  "SELECT status, count(*) AS jobs, coalesce(sum(feature_count), 0) AS features,
+          count(*) FILTER (WHERE status = 'pending' AND next_attempt_at > now()) AS deferred
    FROM map_index_jobs GROUP BY status ORDER BY status;"
 ```
 
 Continue monitoring the service journal, local disk, PostgreSQL, private-R2
-budget, and the queue counts until `pending` and `running` reach zero. Review
-every new `failed` or unexpected `skipped` job. If map processing regresses,
+budget, and the queue counts until `pending` and `running` reach zero. A
+temporary export response (`202`) is retried with bounded job-local backoff;
+source connectivity failures defer only that source while unrelated sources
+continue. Review every new `failed` or unexpected `skipped` job. If map
+processing regresses,
 follow the map-only rollback boundary in section 10; the catalogue and API can
 remain live.
 
@@ -345,8 +361,9 @@ deployed database.
 
 ## 10. Rollback boundaries
 
-Migration `029` is additive and compatible with the pre-release application, so
-leave it applied during any code rollback. Never reverse it with ad hoc SQL.
+Migrations `029` and `030` are additive and compatible with the pre-release
+application, so leave them applied during any code rollback. Never reverse them
+with ad hoc SQL.
 
 ### Before the first source write
 
@@ -394,3 +411,12 @@ Keep the API and successfully written catalogue live. The queue is durable; fix
 the map regression, review `running`, `pending`, `failed`, and `skipped` rows,
 then restart exactly one systemd map worker. Do not launch `maps:drain` alongside
 the service.
+
+When an upstream source has recovered, inspect its failed map rows before using
+the explicit recovery command. The command is read-only unless `--apply` is
+present:
+
+```bash
+npm run maps:retry-source -- --source=<source-id>
+npm run maps:retry-source -- --source=<source-id> --apply
+```

--- a/server/__tests__/catalogSources.test.js
+++ b/server/__tests__/catalogSources.test.js
@@ -657,9 +657,10 @@ describe('configured municipal catalogue sources', () => {
 
         for (const [id, organization, placeId] of expected) {
             const source = getSource(id);
+            const directMaps = !['shawinigan-open-data', 'saint-hyacinthe-open-data'].includes(id);
             expect(source).toEqual(expect.objectContaining({
                 kind: 'ckan', enabled: true, metadataLanguage: 'fr',
-                catalogOrganization: organization, directGeoJsonMaps: true,
+                catalogOrganization: organization, directGeoJsonMaps: directMaps,
                 licenseMode: 'record-explicit', upstreamHost: 'www.donneesquebec.ca'
             }));
             expect(source.licenseRules).toEqual([expect.objectContaining({

--- a/server/__tests__/ingestCaps.test.js
+++ b/server/__tests__/ingestCaps.test.js
@@ -84,6 +84,22 @@ describe('ingestion caps', () => {
         });
     });
 
+    it('treats an asynchronous export response as retryable work', async () => {
+        const pendingFetch = async () => ({
+            status: 202,
+            headers: { get: name => name === 'retry-after' ? '3' : null },
+            body: new ReadableStream({ start(controller) { controller.close(); } })
+        });
+        await expect(downloadToTempFile('https://example.org/export.geojson', {
+            maxFileBytes: 1024,
+            fetchImpl: pendingFetch
+        })).rejects.toMatchObject({
+            code: 'DOWNLOAD_PENDING',
+            retryAfterMs: 3000,
+            message: 'download is still being prepared (HTTP 202)'
+        });
+    });
+
     it('a stalled download is aborted instead of hanging the worker', async () => {
         // Sends one chunk then never closes - mirrors an upstream that accepts
         // the socket and then goes silent. Without the stall guard this read

--- a/server/__tests__/mapIndexQueries.test.js
+++ b/server/__tests__/mapIndexQueries.test.js
@@ -5,6 +5,7 @@ const {
     claimJob,
     finishJob,
     requeueJob,
+    failPendingSourceJobs,
     upsertMapCandidates
 } = require('../db/mapIndexQueries');
 
@@ -52,6 +53,8 @@ describe('versioned map-index queue', () => {
         expect(db.query.mock.calls[1][0]).toContain("candidate->>'expectedBytes'");
         expect(db.query.mock.calls[1][0]).toContain("candidate->>'expectedRows'");
         expect(db.query.mock.calls[1][0]).toContain('NULLS LAST');
+        expect(db.query.mock.calls[1][0]).toContain('next_attempt_at <= now()');
+        expect(db.query.mock.calls[1][0]).toContain('blocker.failure_code');
     });
 
     test('terminal and retry transitions are lease and version guarded', async () => {
@@ -63,5 +66,12 @@ describe('versioned map-index queue', () => {
         await expect(requeueJob(db, job, 'worker', 'temporary')).resolves.toBe(true);
         expect(db.query.mock.calls[0][0]).toContain("desired_version <> $3");
         expect(db.query.mock.calls[1][0]).toContain('desired_version = $3');
+    });
+
+    test('bulk-fails pending jobs for one unavailable source', async () => {
+        const db = { query: jest.fn().mockResolvedValue({ rowCount: 4 }) };
+        await expect(failPendingSourceJobs(db, 'source-a', 'MAP_SOURCE_UNAVAILABLE: timeout')).resolves.toBe(4);
+        expect(db.query.mock.calls[0][0]).toContain("r.raw->>'source_id' = $1");
+        expect(db.query.mock.calls[0][0]).toContain("status = 'failed'");
     });
 });

--- a/server/__tests__/mapWorker.test.js
+++ b/server/__tests__/mapWorker.test.js
@@ -16,7 +16,7 @@ jest.mock('../db/mapIndexQueries', () => ({
     acquireWorkerLock: jest.fn(), releaseWorkerLock: jest.fn(),
     recoverOrphanedJobs: jest.fn(), reconcileMissingFeatures: jest.fn(),
     claimJob: jest.fn(), heartbeatJob: jest.fn().mockResolvedValue(true),
-    finishJob: jest.fn(), requeueJob: jest.fn(), getReadyMapState: jest.fn(),
+    finishJob: jest.fn(), requeueJob: jest.fn(), failPendingSourceJobs: jest.fn(), getReadyMapState: jest.fn(),
     listPmtilesMapObjects: jest.fn(), deletePmtilesMapMetadata: jest.fn(),
     requeueMissingPmtilesMaps: jest.fn()
 }));
@@ -178,12 +178,53 @@ describe('map worker transitions', () => {
             probeGeometry: async () => { throw new Error('temporary upstream failure'); }
         };
         await processJob(job, '00000000-0000-4000-8000-000000000001', options);
-        expect(mapQueries.requeueJob).toHaveBeenCalledWith(pool, job, expect.any(String), 'temporary upstream failure');
+        expect(mapQueries.requeueJob).toHaveBeenCalledWith(
+            pool, job, expect.any(String), 'temporary upstream failure', expect.any(Date), null
+        );
 
         const finalJob = { ...job, attempts: 3 };
         await processJob(finalJob, '00000000-0000-4000-8000-000000000001', options);
         expect(mapQueries.finishJob).toHaveBeenCalledWith(
             pool, finalJob, expect.any(String), 'failed', {}, 'temporary upstream failure'
+        );
+    });
+
+    test('isolates an unavailable source and bulk-fails its queue after the probe limit', async () => {
+        const error = Object.assign(new Error('connection stalled'), { code: 'DOWNLOAD_RESPONSE_STALL' });
+        const options = {
+            getResourceById: async () => resource,
+            probeGeometry: async () => { throw error; }
+        };
+        await processJob(job, '00000000-0000-4000-8000-000000000001', options);
+        expect(mapQueries.requeueJob).toHaveBeenCalledWith(
+            pool, job, expect.any(String), expect.stringContaining('DOWNLOAD_RESPONSE_STALL'),
+            expect.any(Date), 'MAP_SOURCE_UNAVAILABLE'
+        );
+
+        const finalJob = { ...job, attempts: 3 };
+        mapQueries.finishJob.mockResolvedValue({ status: 'failed' });
+        await processJob(finalJob, '00000000-0000-4000-8000-000000000001', options);
+        expect(mapQueries.finishJob).toHaveBeenCalledWith(
+            pool, finalJob, expect.any(String), 'failed', {},
+            'DOWNLOAD_RESPONSE_STALL: connection stalled', 'MAP_SOURCE_UNAVAILABLE'
+        );
+        expect(mapQueries.failPendingSourceJobs).toHaveBeenCalledWith(
+            pool, 'toronto-open-data', 'DOWNLOAD_RESPONSE_STALL: connection stalled', 'MAP_SOURCE_UNAVAILABLE'
+        );
+    });
+
+    test('retries asynchronous exports without blocking the source', async () => {
+        const error = Object.assign(new Error('export pending'), {
+            code: 'DOWNLOAD_PENDING', retryAfterMs: 3000
+        });
+        await processJob(job, '00000000-0000-4000-8000-000000000001', {
+            getResourceById: async () => resource,
+            probeGeometry: async () => ({ total: 1, fields: [{ id: 'geometry' }] }),
+            indexMapResource: async () => { throw error; }
+        });
+        expect(mapQueries.requeueJob).toHaveBeenCalledWith(
+            pool, job, expect.any(String), 'DOWNLOAD_PENDING: export pending',
+            expect.any(Date), 'DOWNLOAD_PENDING'
         );
     });
 

--- a/server/__tests__/opsApi.test.js
+++ b/server/__tests__/opsApi.test.js
@@ -113,4 +113,21 @@ describe('ops API', () => {
             ready: 180, skipped: 7, status: 'stale'
         }));
     });
+
+    it('exposes deferred retries and source circuits as degraded map health', async () => {
+        const now = new Date();
+        catalogReadQueries.getJobHealth.mockResolvedValue({
+            syncRows: [], evictLastOkAt: null,
+            mapQueue: {
+                pending: 3, deferred: 3, running: 0, ready: 180, skipped: 7, failed: 0,
+                retrying_sources: 1, next_retry_at: new Date(Date.now() + 60_000).toISOString(),
+                last_indexed_at: now.toISOString()
+            }
+        });
+        const res = await request(app).get('/api/v1/ops');
+        expect(res.status).toBe(503);
+        expect(res.body.data.maps).toEqual(expect.objectContaining({
+            deferred: 3, retrying_sources: 1, status: 'degraded'
+        }));
+    });
 });

--- a/server/__tests__/retryMapSource.test.js
+++ b/server/__tests__/retryMapSource.test.js
@@ -1,0 +1,33 @@
+jest.mock('../db/pool', () => ({ query: jest.fn(), end: jest.fn() }));
+
+const pool = require('../db/pool');
+const { retryMapSource } = require('../scripts/retry-map-source');
+
+describe('map source recovery command', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    test('defaults to a read-only failed-job count', async () => {
+        pool.query.mockResolvedValueOnce({ rows: [{ failed: '4' }] });
+        await expect(retryMapSource(pool, 'shawinigan-open-data')).resolves.toEqual({
+            source_id: 'shawinigan-open-data', failed: 4, apply: false
+        });
+        expect(pool.query).toHaveBeenCalledTimes(1);
+        expect(pool.query.mock.calls[0][0]).toContain("j.status = 'failed'");
+    });
+
+    test('apply only requeues failed jobs for the requested source', async () => {
+        pool.query
+            .mockResolvedValueOnce({ rows: [{ failed: '4' }] })
+            .mockResolvedValueOnce({ rowCount: 4, rows: [] });
+        await expect(retryMapSource(pool, 'shawinigan-open-data', true)).resolves.toEqual({
+            source_id: 'shawinigan-open-data', failed: 4, requeued: 4, apply: true
+        });
+        expect(pool.query.mock.calls[1][0]).toContain("r.raw->>'source_id' = $1");
+        expect(pool.query.mock.calls[1][0]).toContain("status = 'pending'");
+    });
+
+    test('rejects an unknown source before querying the database', async () => {
+        await expect(retryMapSource(pool, 'missing-source')).rejects.toThrow(/unknown or missing/);
+        expect(pool.query).not.toHaveBeenCalled();
+    });
+});

--- a/server/config/catalogSourceExpansions.js
+++ b/server/config/catalogSourceExpansions.js
@@ -143,7 +143,10 @@ function exactPattern(value) {
     return new RegExp('^' + escaped + '$', 'i');
 }
 
-function donneesQuebecSource({ id, organization, cityEn, cityFr, publisherPattern, placeId }) {
+function donneesQuebecSource({
+    id, organization, cityEn, cityFr, publisherPattern, placeId,
+    directGeoJsonMaps = true, directGeoJsonMapsDisabledReason = null
+}) {
     return {
         id,
         kind: 'ckan',
@@ -158,7 +161,8 @@ function donneesQuebecSource({ id, organization, cityEn, cityFr, publisherPatter
         syncIntervalHours: 24,
         maxDeleteFraction: 0.1,
         metadataLanguage: 'fr',
-        directGeoJsonMaps: true,
+        directGeoJsonMaps,
+        ...(directGeoJsonMapsDisabledReason ? { directGeoJsonMapsDisabledReason } : {}),
         defaultOrganizationId: organization,
         defaultOrganizationName: organization,
         defaultOrganizationTitleEn: cityEn,
@@ -318,7 +322,13 @@ function buildExpansionSources({ ccBy4License }) {
         dq({ id: 'longueuil-open-data', organization: 'ville-de-longueuil', cityEn: 'City of Longueuil', cityFr: 'la Ville de Longueuil', publisherPattern: /^ville de longueuil$/i, placeId: 'sgc-csd-2458227' }),
         dq({ id: 'saguenay-open-data', organization: 'ville-de-saguenay', cityEn: 'City of Saguenay', cityFr: 'la Ville de Saguenay', publisherPattern: /^ville de saguenay$/i, placeId: 'sgc-csd-2494068' }),
         dq({ id: 'rimouski-open-data', organization: 'ville-de-rimouski', cityEn: 'City of Rimouski', cityFr: 'la Ville de Rimouski', publisherPattern: /^ville de rimouski$/i, placeId: 'sgc-csd-2410043' }),
-        dq({ id: 'shawinigan-open-data', organization: 'ville-de-shawinigan', cityEn: 'City of Shawinigan', cityFr: 'la Ville de Shawinigan', publisherPattern: /^ville de shawinigan$/i, placeId: 'sgc-csd-2436033' }),
+        dq({
+            id: 'shawinigan-open-data', organization: 'ville-de-shawinigan',
+            cityEn: 'City of Shawinigan', cityFr: 'la Ville de Shawinigan',
+            publisherPattern: /^ville de shawinigan$/i, placeId: 'sgc-csd-2436033',
+            directGeoJsonMaps: false,
+            directGeoJsonMapsDisabledReason: 'Map service timed out from production during v35 closeout'
+        }),
         dq({ id: 'levis-open-data', organization: 'ville-de-levis', cityEn: 'City of Lévis', cityFr: 'la Ville de Lévis', publisherPattern: /^ville de l[eé]vis$/i, placeId: 'sgc-csd-2425213' }),
         dq({ id: 'sherbrooke-open-data', organization: 'ville-de-sherbrooke', cityEn: 'City of Sherbrooke', cityFr: 'la Ville de Sherbrooke', publisherPattern: /^ville de sherbrooke$/i, placeId: 'sgc-csd-2443027' }),
         arcgisMunicipalSource({ id: 'saint-john-hub', cityEn: 'City of Saint John', cityFr: 'la Ville de Saint John', host: 'catalogue-saintjohn.opendata.arcgis.com', placeId: 'sgc-csd-1301006', license: EXPANSION_LICENSES.SAINT_JOHN_LICENSE, publisherPatterns: [/^the city of saint john$/i, /^city of saint john$/i] }),
@@ -348,7 +358,13 @@ function buildExpansionSources({ ccBy4License }) {
         arcgisMunicipalSource({ id: 'maple-ridge-hub', cityEn: 'City of Maple Ridge', cityFr: 'la Ville de Maple Ridge', host: 'opengov.mapleridge.ca', placeId: 'sgc-csd-5915075', license: EXPANSION_LICENSES.MAPLE_RIDGE_LICENSE, publisherPatterns: [/^(?:city of )?maple ridge$/i], restrictedLicensePatterns: [/translink/i] }),
         arcgisMunicipalSource({ id: 'port-coquitlam-hub', cityEn: 'City of Port Coquitlam', cityFr: 'la Ville de Port Coquitlam', host: 'data-poco.hub.arcgis.com', placeId: 'sgc-csd-5915039', license: EXPANSION_LICENSES.PORT_COQUITLAM_LICENSE, publisherPatterns: [/^city of port coquitlam$/i], restrictedLicensePatterns: [/pocomap/i, /internal business and personal purpose/i] }),
         dq({ id: 'sherbrooke-geomatics-open-data', organization: 'ville-de-sherbrooke-donnees-geomatiques', cityEn: 'City of Sherbrooke Geomatics', cityFr: 'la Ville de Sherbrooke – données géomatiques', publisherPattern: /^ville de sherbrooke - donn[eé]es g[eé]omatiques$/i, placeId: 'sgc-csd-2443027' }),
-        dq({ id: 'saint-hyacinthe-open-data', organization: 'ville-de-saint-hyacinthe', cityEn: 'City of Saint-Hyacinthe', cityFr: 'la Ville de Saint-Hyacinthe', publisherPattern: /^ville de saint-hyacinthe$/i, placeId: 'sgc-csd-2454048' })
+        dq({
+            id: 'saint-hyacinthe-open-data', organization: 'ville-de-saint-hyacinthe',
+            cityEn: 'City of Saint-Hyacinthe', cityFr: 'la Ville de Saint-Hyacinthe',
+            publisherPattern: /^ville de saint-hyacinthe$/i, placeId: 'sgc-csd-2454048',
+            directGeoJsonMaps: false,
+            directGeoJsonMapsDisabledReason: 'Map service timed out from production during v35 closeout'
+        })
     ];
 }
 

--- a/server/db/catalogReadQueries.js
+++ b/server/db/catalogReadQueries.js
@@ -486,15 +486,25 @@ async function getJobHealth() {
     `);
     const evictResult = await pool.query("SELECT max(finished_at) AS last_ok_at FROM ingest_runs WHERE ok AND error LIKE 'evict:%'");
     const mapResult = await pool.query(`
-        SELECT count(*) FILTER (WHERE status = 'pending')::int AS pending,
-               count(*) FILTER (WHERE status = 'running')::int AS running,
-               count(*) FILTER (WHERE status = 'ready')::int AS ready,
-               count(*) FILTER (WHERE status = 'skipped')::int AS skipped,
-               count(*) FILTER (WHERE status = 'failed')::int AS failed,
-               min(updated_at) FILTER (WHERE status = 'pending') AS oldest_pending_at,
-               min(heartbeat_at) FILTER (WHERE status = 'running') AS oldest_running_at,
-               max(finished_at) FILTER (WHERE status = 'ready') AS last_indexed_at
-        FROM map_index_jobs
+        SELECT count(*) FILTER (WHERE j.status = 'pending')::int AS pending,
+               count(*) FILTER (WHERE j.status = 'pending' AND j.next_attempt_at > now())::int AS deferred,
+               count(*) FILTER (WHERE j.status = 'running')::int AS running,
+               count(*) FILTER (WHERE j.status = 'ready')::int AS ready,
+               count(*) FILTER (WHERE j.status = 'skipped')::int AS skipped,
+               count(*) FILTER (WHERE j.status = 'failed')::int AS failed,
+               count(DISTINCT r.raw->>'source_id') FILTER (
+                   WHERE j.status = 'pending' AND j.failure_code = 'MAP_SOURCE_UNAVAILABLE'
+               )::int AS retrying_sources,
+               min(j.updated_at) FILTER (
+                   WHERE j.status = 'pending' AND j.next_attempt_at <= now()
+               ) AS oldest_pending_at,
+               min(j.next_attempt_at) FILTER (
+                   WHERE j.status = 'pending' AND j.next_attempt_at > now()
+               ) AS next_retry_at,
+               min(j.heartbeat_at) FILTER (WHERE j.status = 'running') AS oldest_running_at,
+               max(j.finished_at) FILTER (WHERE j.status = 'ready') AS last_indexed_at
+        FROM map_index_jobs j
+        LEFT JOIN resources r ON r.id = j.resource_id
     `);
     return {
         syncRows: syncResult.rows,

--- a/server/db/mapIndexQueries.js
+++ b/server/db/mapIndexQueries.js
@@ -1,4 +1,5 @@
 const WORKER_LOCK_KEYS = [1667329649, 1835102829]; // "canq" / "maps"
+const SOURCE_RETRY_CODE = 'MAP_SOURCE_UNAVAILABLE';
 
 async function upsertMapCandidates(db, candidatesRaw) {
     const candidates = Array.from(new Map((candidatesRaw || []).map(row => [row.resourceId, row])).values());
@@ -51,6 +52,16 @@ async function upsertMapCandidates(db, candidatesRaw) {
                         THEN map_index_jobs.error
                     ELSE NULL
                 END,
+                next_attempt_at = CASE
+                    WHEN map_index_jobs.desired_version = EXCLUDED.desired_version
+                        THEN map_index_jobs.next_attempt_at
+                    ELSE now()
+                END,
+                failure_code = CASE
+                    WHEN map_index_jobs.desired_version = EXCLUDED.desired_version
+                        THEN map_index_jobs.failure_code
+                    ELSE NULL
+                END,
                 updated_at = now()
         `, values);
     }
@@ -96,6 +107,8 @@ async function recoverOrphanedJobs(db, maxAttempts = 3) {
                     THEN 'map worker terminated during indexing after ' || attempts || ' attempts'
                 ELSE 'requeued after map worker restart'
             END,
+            next_attempt_at = now(),
+            failure_code = NULL,
             updated_at = now()
         WHERE status = 'running'
         RETURNING resource_id, status
@@ -121,6 +134,7 @@ async function reconcileMissingFeatures(db) {
                 SET status = 'pending', indexed_version = NULL, attempts = 0,
                     worker_id = NULL, claimed_at = NULL, heartbeat_at = NULL,
                     finished_at = NULL, error = 'map data absent after restore; queued for rebuild',
+                    next_attempt_at = now(), failure_code = NULL,
                     updated_at = now()
                 WHERE resource_id = ANY($1::text[])
             `, [ids]);
@@ -140,28 +154,41 @@ async function claimJob(db, workerId, resourceId = null) {
         UPDATE map_index_jobs
         SET status = 'running', attempts = attempts + 1, worker_id = $1,
             claimed_at = now(), heartbeat_at = now(), finished_at = NULL,
-            error = NULL, updated_at = now()
+            error = NULL, failure_code = NULL, next_attempt_at = now(), updated_at = now()
         WHERE resource_id = (
-            SELECT resource_id FROM map_index_jobs
-            WHERE status = 'pending'
-              AND ($2::text IS NULL OR resource_id = $2)
+            SELECT j.resource_id FROM map_index_jobs j
+            JOIN resources candidate_resource ON candidate_resource.id = j.resource_id
+            WHERE j.status = 'pending'
+              AND j.next_attempt_at <= now()
+              AND ($2::text IS NULL OR j.resource_id = $2)
+              AND (
+                  j.failure_code = $3
+                  OR NOT EXISTS (
+                      SELECT 1
+                      FROM map_index_jobs blocker
+                      JOIN resources blocker_resource ON blocker_resource.id = blocker.resource_id
+                      WHERE blocker.status = 'pending'
+                        AND blocker.failure_code = $3
+                        AND blocker_resource.raw->>'source_id' = candidate_resource.raw->>'source_id'
+                  )
+              )
             ORDER BY
                 CASE
-                    WHEN candidate->>'expectedBytes' ~ '^[0-9]+$'
-                        THEN (candidate->>'expectedBytes')::numeric
+                    WHEN j.candidate->>'expectedBytes' ~ '^[0-9]+$'
+                        THEN (j.candidate->>'expectedBytes')::numeric
                     ELSE NULL
                 END NULLS LAST,
                 CASE
-                    WHEN candidate->>'expectedRows' ~ '^[0-9]+$'
-                        THEN (candidate->>'expectedRows')::numeric
+                    WHEN j.candidate->>'expectedRows' ~ '^[0-9]+$'
+                        THEN (j.candidate->>'expectedRows')::numeric
                     ELSE NULL
                 END NULLS LAST,
-                updated_at, resource_id
+                j.updated_at, j.resource_id
             LIMIT 1 FOR UPDATE SKIP LOCKED
         )
         RETURNING resource_id, desired_version AS claimed_version,
                   candidate, attempts
-    `, [workerId, resourceId]);
+    `, [workerId, resourceId, SOURCE_RETRY_CODE]);
     return result.rows[0] || null;
 }
 
@@ -173,7 +200,7 @@ async function heartbeatJob(db, resourceId, workerId) {
     return result.rowCount === 1;
 }
 
-async function finishJob(db, job, workerId, status, metrics = {}, error = null) {
+async function finishJob(db, job, workerId, status, metrics = {}, error = null, failureCode = null) {
     const result = await db.query(`
         UPDATE map_index_jobs
         SET status = CASE
@@ -186,6 +213,8 @@ async function finishJob(db, job, workerId, status, metrics = {}, error = null) 
             error = CASE WHEN desired_version <> $3 AND $4 = 'ready'
                          THEN 'source changed during indexing; queued latest version'
                          ELSE $5 END,
+            next_attempt_at = now(),
+            failure_code = CASE WHEN desired_version <> $3 AND $4 = 'ready' THEN NULL ELSE $9 END,
             feature_count = $6, vertex_count = $7, downloaded_bytes = $8,
             updated_at = now()
         WHERE resource_id = $1 AND status = 'running' AND worker_id = $2
@@ -194,34 +223,62 @@ async function finishJob(db, job, workerId, status, metrics = {}, error = null) 
         job.resource_id, workerId, job.claimed_version, status, error,
         metrics.featureCount == null ? null : metrics.featureCount,
         metrics.vertexCount == null ? null : metrics.vertexCount,
-        metrics.downloadedBytes == null ? null : metrics.downloadedBytes
+        metrics.downloadedBytes == null ? null : metrics.downloadedBytes,
+        failureCode
     ]);
     return result.rows[0] || null;
 }
 
-async function requeueJob(db, job, workerId, error) {
+async function requeueJob(db, job, workerId, error, nextAttemptAt = null, failureCode = null) {
     const result = await db.query(`
         UPDATE map_index_jobs
         SET status = 'pending', worker_id = NULL, claimed_at = NULL,
-            heartbeat_at = NULL, finished_at = NULL, error = $4, updated_at = now()
+            heartbeat_at = NULL, finished_at = NULL, error = $4,
+            next_attempt_at = COALESCE($5::timestamptz, now()), failure_code = $6,
+            updated_at = now()
         WHERE resource_id = $1 AND status = 'running' AND worker_id = $2
           AND desired_version = $3
-    `, [job.resource_id, workerId, job.claimed_version, error]);
+    `, [job.resource_id, workerId, job.claimed_version, error, nextAttemptAt, failureCode]);
     return result.rowCount === 1;
+}
+
+async function failPendingSourceJobs(db, sourceId, error, failureCode = SOURCE_RETRY_CODE) {
+    if (!sourceId) return 0;
+    const result = await db.query(`
+        UPDATE map_index_jobs j
+        SET status = 'failed', worker_id = NULL, claimed_at = NULL, heartbeat_at = NULL,
+            finished_at = now(), error = $2, failure_code = $3,
+            next_attempt_at = now(), updated_at = now()
+        FROM resources r
+        WHERE j.resource_id = r.id
+          AND j.status = 'pending'
+          AND r.raw->>'source_id' = $1
+    `, [sourceId, error, failureCode]);
+    return result.rowCount;
 }
 
 async function getMapQueueHealth(db) {
     const result = await db.query(`
-        SELECT count(*) FILTER (WHERE status = 'pending')::int AS pending,
-               count(*) FILTER (WHERE status = 'running')::int AS running,
-               count(*) FILTER (WHERE status = 'ready')::int AS ready,
-               count(*) FILTER (WHERE status = 'skipped')::int AS skipped,
-               count(*) FILTER (WHERE status = 'failed')::int AS failed,
-               min(updated_at) FILTER (WHERE status = 'pending') AS oldest_pending_at,
-               min(heartbeat_at) FILTER (WHERE status = 'running') AS oldest_running_at,
-               max(finished_at) FILTER (WHERE status = 'ready') AS last_indexed_at
-        FROM map_index_jobs
-    `);
+        SELECT count(*) FILTER (WHERE j.status = 'pending')::int AS pending,
+               count(*) FILTER (WHERE j.status = 'pending' AND j.next_attempt_at > now())::int AS deferred,
+               count(*) FILTER (WHERE j.status = 'running')::int AS running,
+               count(*) FILTER (WHERE j.status = 'ready')::int AS ready,
+               count(*) FILTER (WHERE j.status = 'skipped')::int AS skipped,
+               count(*) FILTER (WHERE j.status = 'failed')::int AS failed,
+               count(DISTINCT r.raw->>'source_id') FILTER (
+                   WHERE j.status = 'pending' AND j.failure_code = $1
+               )::int AS retrying_sources,
+               min(j.updated_at) FILTER (
+                   WHERE j.status = 'pending' AND j.next_attempt_at <= now()
+               ) AS oldest_pending_at,
+               min(j.next_attempt_at) FILTER (
+                   WHERE j.status = 'pending' AND j.next_attempt_at > now()
+               ) AS next_retry_at,
+               min(j.heartbeat_at) FILTER (WHERE j.status = 'running') AS oldest_running_at,
+               max(j.finished_at) FILTER (WHERE j.status = 'ready') AS last_indexed_at
+        FROM map_index_jobs j
+        LEFT JOIN resources r ON r.id = j.resource_id
+    `, [SOURCE_RETRY_CODE]);
     return result.rows[0];
 }
 
@@ -272,7 +329,8 @@ async function requeueMissingPmtilesMaps(db, resourceIds) {
                 SET status = 'pending', indexed_version = NULL, attempts = 0,
                     worker_id = NULL, claimed_at = NULL, heartbeat_at = NULL,
                     finished_at = NULL,
-                    error = 'PMTiles object absent; queued for rebuild', updated_at = now()
+                    error = 'PMTiles object absent; queued for rebuild',
+                    next_attempt_at = now(), failure_code = NULL, updated_at = now()
                 WHERE resource_id = ANY($1::text[])
             `, [ids]);
         }
@@ -315,6 +373,7 @@ async function queryLocalMap(db, { resourceId, bbox, tolerance, limit }) {
 
 module.exports = {
     WORKER_LOCK_KEYS,
+    SOURCE_RETRY_CODE,
     upsertMapCandidates,
     sweepMapCandidates,
     acquireWorkerLock,
@@ -325,6 +384,7 @@ module.exports = {
     heartbeatJob,
     finishJob,
     requeueJob,
+    failPendingSourceJobs,
     getMapQueueHealth,
     getReadyMapState,
     listPmtilesMapObjects,

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
         "maps:once": "node scripts/map-worker.js --once",
         "maps:drain": "node scripts/map-worker.js --drain",
         "maps:prune": "node scripts/prune-map-objects.js",
+        "maps:retry-source": "node scripts/retry-map-source.js",
         "gsc:authorize": "node scripts/authorize-search-console.js",
         "gsc:sync": "node scripts/sync-search-console.js",
         "gsc:report": "node scripts/build-search-growth-report.js",

--- a/server/scripts/map-worker.js
+++ b/server/scripts/map-worker.js
@@ -25,11 +25,15 @@ const {
     heartbeatJob,
     finishJob,
     requeueJob,
+    failPendingSourceJobs,
+    SOURCE_RETRY_CODE,
     getReadyMapState,
     listPmtilesMapObjects,
     deletePmtilesMapMetadata,
     requeueMissingPmtilesMaps
 } = require('../db/mapIndexQueries');
+
+const SOURCE_FAILURE_CODE = SOURCE_RETRY_CODE || 'MAP_SOURCE_UNAVAILABLE';
 
 const onceMode = process.argv.includes('--once');
 const drainMode = process.argv.includes('--drain');
@@ -38,6 +42,10 @@ const resourceTarget = resourceArg ? resourceArg.slice('--resource='.length).tri
 const POLL_MS = Number(process.env.MAP_INDEX_POLL_MS) || 3000;
 const HEARTBEAT_MS = Math.max(1000, Number(process.env.MAP_INDEX_HEARTBEAT_MS) || 15000);
 const MAX_ATTEMPTS = 3;
+const MAX_PENDING_ATTEMPTS = 5;
+const SOURCE_BACKOFF_MS = [5 * 60 * 1000, 30 * 60 * 1000];
+const PENDING_BACKOFF_MS = [15 * 1000, 30 * 1000, 60 * 1000, 3 * 60 * 1000];
+const RETRY_BACKOFF_MS = [60 * 1000, 5 * 60 * 1000];
 let stopRequested = false;
 let wakePoll = null;
 
@@ -51,6 +59,41 @@ function requestStop(signal) {
 
 function isPermanentMissingDownload(error) {
     return error && error.code === 'DOWNLOAD_HTTP' && [404, 410].includes(Number(error.httpStatus));
+}
+
+function sourceIdFor(resource) {
+    const raw = resource && resource.raw && typeof resource.raw === 'object' ? resource.raw : {};
+    return typeof raw.source_id === 'string' && raw.source_id ? raw.source_id : null;
+}
+
+function isSourceRetryable(error) {
+    if (!error) return false;
+    if (['DOWNLOAD_RESPONSE_STALL', 'DOWNLOAD_BODY_STALL', 'DOWNLOAD_NETWORK'].includes(error.code)) return true;
+    if (error.code === 'DOWNLOAD_HTTP' && [408, 425, 429, 500, 502, 503, 504].includes(Number(error.httpStatus))) {
+        return true;
+    }
+    const networkCodes = ['ECONNRESET', 'ECONNREFUSED', 'ECONNABORTED', 'ENETUNREACH',
+        'EHOSTUNREACH', 'EAI_AGAIN', 'ENOTFOUND', 'ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT'];
+    return networkCodes.includes(error.code) || networkCodes.includes(error.cause && error.cause.code);
+}
+
+function retryLimit(error) {
+    return error && error.code === 'DOWNLOAD_PENDING' ? MAX_PENDING_ATTEMPTS : MAX_ATTEMPTS;
+}
+
+function retryDelayMs(error, attempts) {
+    const retryAfter = Number(error && error.retryAfterMs);
+    if (Number.isFinite(retryAfter) && retryAfter > 0) {
+        return Math.min(Math.max(retryAfter, 5 * 1000), 30 * 60 * 1000);
+    }
+    const schedule = error && error.code === 'DOWNLOAD_PENDING'
+        ? PENDING_BACKOFF_MS
+        : isSourceRetryable(error) ? SOURCE_BACKOFF_MS : RETRY_BACKOFF_MS;
+    return schedule[Math.min(Math.max(attempts - 1, 0), schedule.length - 1)];
+}
+
+function retryAt(error, attempts, now = Date.now()) {
+    return new Date(now + retryDelayMs(error, attempts));
 }
 
 function waitForPoll() {
@@ -120,11 +163,12 @@ async function probeGeometry(resource) {
 
 async function processJob(job, workerId, options = {}) {
     let heartbeatBusy = false;
+    let processFinished = false;
     const heartbeat = setInterval(async () => {
         if (heartbeatBusy) return;
         heartbeatBusy = true;
         try {
-            if (!await heartbeatJob(pool, job.resource_id, workerId)) {
+            if (!await heartbeatJob(pool, job.resource_id, workerId) && !processFinished) {
                 console.error('[map ' + job.resource_id + '] worker lease was lost');
             }
         } catch (error) {
@@ -134,8 +178,9 @@ async function processJob(job, workerId, options = {}) {
         }
     }, HEARTBEAT_MS);
     heartbeat.unref();
+    let resource = null;
     try {
-        const resource = await (options.getResourceById || getResourceById)(job.resource_id);
+        resource = await (options.getResourceById || getResourceById)(job.resource_id);
         if (!resource) throw new MapSkipError('resource vanished from catalogue', 'MAP_SOURCE');
         const ready = await (options.getReadyMapState || getReadyMapState)(pool, job.resource_id, job.claimed_version);
         if (ready && ready.provider === 'pmtiles') {
@@ -194,13 +239,28 @@ async function processJob(job, workerId, options = {}) {
         console.error('[map ' + job.resource_id + '] ' + (skipped ? 'skipped' : 'failed') + ': ' + detail);
         if (skipped) {
             await finishJob(pool, job, workerId, 'skipped', {}, detail);
-        } else if (job.attempts >= MAX_ATTEMPTS) {
-            await finishJob(pool, job, workerId, 'failed', {}, detail);
+        } else if (job.attempts >= retryLimit(error)) {
+            const sourceRetry = isSourceRetryable(error) && sourceIdFor(resource);
+            const finished = sourceRetry
+                ? await finishJob(pool, job, workerId, 'failed', {}, detail, SOURCE_FAILURE_CODE)
+                : await finishJob(pool, job, workerId, 'failed', {}, detail);
+            if (sourceRetry && finished) {
+                await (options.failPendingSourceJobs || failPendingSourceJobs)(
+                    pool, sourceIdFor(resource), detail, SOURCE_FAILURE_CODE
+                );
+            }
         } else {
-            await requeueJob(pool, job, workerId, detail);
+            const failureCode = isSourceRetryable(error) && sourceIdFor(resource)
+                ? SOURCE_FAILURE_CODE : error && error.code === 'DOWNLOAD_PENDING'
+                    ? 'DOWNLOAD_PENDING' : null;
+            await requeueJob(
+                pool, job, workerId, detail,
+                retryAt(error, job.attempts), failureCode
+            );
         }
         return { error, skipped };
     } finally {
+        processFinished = true;
         clearInterval(heartbeat);
     }
 }
@@ -282,5 +342,6 @@ if (require.main === module) {
 
 module.exports = {
     main, processJob, probeGeometry, ckanTarget, validateDirectGeoJson,
-    reconcileMissingPmtiles, requestStop, waitForPoll
+    reconcileMissingPmtiles, requestStop, waitForPoll,
+    isSourceRetryable, retryLimit, retryDelayMs, retryAt, sourceIdFor
 };

--- a/server/scripts/retry-map-source.js
+++ b/server/scripts/retry-map-source.js
@@ -1,0 +1,59 @@
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+
+const pool = require('../db/pool');
+const { getSource } = require('../config/catalogSources');
+
+const args = process.argv.slice(2);
+function value(name) {
+    const exact = args.indexOf(name);
+    if (exact !== -1) return args[exact + 1];
+    const pair = args.find(arg => arg.startsWith(name + '='));
+    return pair ? pair.slice(name.length + 1) : null;
+}
+
+async function retryMapSource(db, sourceId, apply = false) {
+    const source = getSource(sourceId);
+    if (!source) throw new Error('unknown or missing --source');
+    const result = await db.query(`
+        SELECT count(*)::int AS failed
+        FROM map_index_jobs j
+        JOIN resources r ON r.id = j.resource_id
+        WHERE j.status = 'failed' AND r.raw->>'source_id' = $1
+    `, [source.id]);
+    const failed = Number(result.rows[0].failed) || 0;
+    if (!apply) {
+        return { source_id: source.id, failed, apply: false };
+    }
+    const updated = await db.query(`
+        UPDATE map_index_jobs j
+        SET status = 'pending', indexed_version = NULL, attempts = 0,
+            worker_id = NULL, claimed_at = NULL, heartbeat_at = NULL,
+            finished_at = NULL, error = 'map jobs manually requeued after source probe',
+            next_attempt_at = now(), failure_code = NULL, updated_at = now()
+        FROM resources r
+        WHERE j.resource_id = r.id
+          AND j.status = 'failed'
+          AND r.raw->>'source_id' = $1
+        RETURNING j.resource_id
+    `, [source.id]);
+    return { source_id: source.id, failed, requeued: updated.rowCount, apply: true };
+}
+
+async function main() {
+    const sourceId = value('--source');
+    const summary = await retryMapSource(pool, sourceId, args.includes('--apply'));
+    console.log(JSON.stringify(summary, null, 2));
+}
+
+if (require.main === module) {
+    main()
+        .then(() => pool.end())
+        .then(() => process.exit(0))
+        .catch(async error => {
+            console.error(error);
+            try { await pool.end(); } catch {}
+            process.exit(1);
+        });
+}
+
+module.exports = { retryMapSource, main };

--- a/server/services/catalogService.js
+++ b/server/services/catalogService.js
@@ -466,17 +466,24 @@ const opsStatus = async () => {
     const mapStale = oldestPendingMs > 48 * 3600 * 1000 || oldestRunningMs > 10 * 60 * 1000;
     const maps = {
         pending: Number(rawMaps.pending) || 0,
+        deferred: Number(rawMaps.deferred) || 0,
         running: Number(rawMaps.running) || 0,
         ready: Number(rawMaps.ready) || 0,
         skipped: Number(rawMaps.skipped) || 0,
         failed: Number(rawMaps.failed) || 0,
+        retrying_sources: Number(rawMaps.retrying_sources) || 0,
         oldest_pending_at: rawMaps.oldest_pending_at || null,
+        next_retry_at: rawMaps.next_retry_at || null,
         oldest_running_at: rawMaps.oldest_running_at || null,
         last_indexed_at: rawMaps.last_indexed_at || null,
-        status: mapStale ? 'stale' : Number(rawMaps.failed) > 0 ? 'degraded' : 'ok'
+        status: mapStale || Number(rawMaps.failed) > 0 || Number(rawMaps.retrying_sources) > 0
+            ? (mapStale ? 'stale' : 'degraded') : 'ok'
     };
     const anyStale = Object.values(jobs).some(j => j.status === 'stale');
-    return { ok: !anyStale && !mapStale && maps.failed === 0, jobs, maps };
+    return {
+        ok: !anyStale && !mapStale && maps.failed === 0 && maps.retrying_sources === 0,
+        jobs, maps
+    };
 };
 
 module.exports = {

--- a/server/services/csvDownload.js
+++ b/server/services/csvDownload.js
@@ -175,6 +175,15 @@ function responseHeader(response, name) {
     return Array.isArray(value) ? value[0] : value;
 }
 
+function retryAfterMs(value, now = Date.now()) {
+    if (value == null || value === '') return null;
+    const text = String(value).trim();
+    if (/^\d+$/.test(text)) return Number(text) * 1000;
+    const timestamp = Date.parse(text);
+    if (!Number.isFinite(timestamp)) return null;
+    return Math.max(0, timestamp - now);
+}
+
 function destroyResponse(response) {
     if (response && typeof response.destroy === 'function') response.destroy();
     else if (response && response.body && typeof response.body.cancel === 'function') {
@@ -359,16 +368,33 @@ async function downloadToTempFile(url, {
         res = opened.response;
     } catch (err) {
         disarm();
-        if (stalled) throw new Error('download stalled (no response within ' + stallMs + 'ms)', { cause: err });
+        if (stalled) {
+            const stalledError = downloadError(
+                'download stalled (no response within ' + stallMs + 'ms)',
+                'DOWNLOAD_RESPONSE_STALL'
+            );
+            stalledError.cause = err;
+            throw stalledError;
+        }
         throw err;
     }
     const status = Number(injectedFetch ? res.status : res.statusCode);
     const responseBody = injectedFetch ? res.body : res;
+    if (status === 202) {
+        const retryAfter = retryAfterMs(responseHeader(res, 'retry-after'));
+        disarm();
+        destroyResponse(res);
+        const err = downloadError('download is still being prepared (HTTP 202)', 'DOWNLOAD_PENDING');
+        err.retryAfterMs = retryAfter;
+        throw err;
+    }
     if (status < 200 || status >= 300 || !responseBody) {
+        const retryAfter = retryAfterMs(responseHeader(res, 'retry-after'));
         disarm();
         destroyResponse(res);
         const err = downloadError('download failed: HTTP ' + status, 'DOWNLOAD_HTTP');
         err.httpStatus = status;
+        err.retryAfterMs = retryAfter;
         throw err;
     }
     const contentLength = Number(responseHeader(res, 'content-length'));
@@ -418,7 +444,12 @@ async function downloadToTempFile(url, {
             // ignore
         }
         if (stalled && err && err.code !== 'CAP_FILE') {
-            throw new Error('download stalled (no data within ' + stallMs + 'ms)', { cause: err });
+            const stalledError = downloadError(
+                'download stalled (no data within ' + stallMs + 'ms)',
+                'DOWNLOAD_BODY_STALL'
+            );
+            stalledError.cause = err;
+            throw stalledError;
         }
         throw err;
     }
@@ -478,5 +509,6 @@ module.exports = {
     validateDownloadUrl,
     isPublicAddress,
     resolvePublicTarget,
-    openValidatedResponse
+    openValidatedResponse,
+    retryAfterMs
 };

--- a/server/services/mapIndexPipeline.js
+++ b/server/services/mapIndexPipeline.js
@@ -579,6 +579,7 @@ async function indexMapResource(resource, job, workerId, capsRaw = {}, options =
                     finished_at = CASE WHEN desired_version = $3 THEN now() ELSE NULL END,
                     error = CASE WHEN desired_version = $3 THEN NULL
                                  ELSE 'source changed during indexing; queued latest version' END,
+                    next_attempt_at = now(), failure_code = NULL,
                     feature_count = $4, vertex_count = $5, downloaded_bytes = $6,
                     updated_at = now()
                 WHERE resource_id = $1 AND status = 'running' AND worker_id = $2

--- a/server/services/municipalSyncService.js
+++ b/server/services/municipalSyncService.js
@@ -151,7 +151,9 @@ async function syncMunicipalSource(source, {
             await replaceDatasetPlaces(client, source.id, datasetIds, places);
             await replaceResourceMaps(client, managedMapResourceIds, maps);
             await upsertMapCandidates(client, mapCandidates);
-            await sweepMapCandidates(client, candidateDatasetIds, mapCandidates.map(candidate => candidate.resourceId));
+            summary.map_sweep = await sweepMapCandidates(
+                client, candidateDatasetIds, mapCandidates.map(candidate => candidate.resourceId)
+            );
             if (limit == null) {
                 summary.sweep = await sweepMissingDatasets(client, keepExternalIds, {
                     sourceId: source.id,

--- a/server/services/pmtilesMapPipeline.js
+++ b/server/services/pmtilesMapPipeline.js
@@ -343,6 +343,7 @@ async function commitPmtilesMap({ db, resource, job, workerId, result, archive, 
                 finished_at = CASE WHEN desired_version = $3 THEN now() ELSE NULL END,
                 error = CASE WHEN desired_version = $3 THEN NULL
                              ELSE 'source changed during indexing; queued latest version' END,
+                next_attempt_at = now(), failure_code = NULL,
                 feature_count = $4, vertex_count = $5, downloaded_bytes = $6,
                 updated_at = now()
             WHERE resource_id = $1 AND status = 'running' AND worker_id = $2

--- a/server/sql/migrations/030_map_queue_resilience.sql
+++ b/server/sql/migrations/030_map_queue_resilience.sql
@@ -1,0 +1,9 @@
+-- Durable retry scheduling for the map worker. A failed download must not
+-- monopolize the single queue owner while healthy sources are waiting.
+ALTER TABLE map_index_jobs
+    ADD COLUMN IF NOT EXISTS next_attempt_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS failure_code text;
+
+CREATE INDEX IF NOT EXISTS idx_map_index_jobs_claimable
+    ON map_index_jobs(next_attempt_at, updated_at, resource_id)
+    WHERE status = 'pending';


### PR DESCRIPTION
## What & why

Closes the v35 release-candidate map queue failure mode observed on production: one unavailable municipal map host could consume the single worker's retry budget while healthy sources waited indefinitely. This change adds durable retry scheduling, source-scoped circuit breaking, typed download stalls/HTTP 202 handling, fail-closed direct-map admission for the two timed-out Québec hosts, and an operator-safe source retry command.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

- Adds additive migration `030_map_queue_resilience.sql`.
- Release gate: 59 server suites/481 tests (12 expected skips), 27 client suites/109 tests.
- The v35 runbook records the two source probes and the production drain procedure.