### PR TITLE
fix: classify exhausted map exports as retryable skips

### DIFF
--- a/deploy/RELEASE_RUNBOOK_v35.md
+++ b/deploy/RELEASE_RUNBOOK_v35.md
@@ -322,8 +322,10 @@ psql -d opencanada -c \
 Continue monitoring the service journal, local disk, PostgreSQL, private-R2
 budget, and the queue counts until `pending` and `running` reach zero. A
 temporary export response (`202`) is retried with bounded job-local backoff;
-source connectivity failures defer only that source while unrelated sources
-continue. Review every new `failed` or unexpected `skipped` job. If map
+if it remains pending at the five-attempt limit it becomes a retryable
+`skipped` job (inspect and requeue it with `maps:retry-source --apply` after a
+probe). Source connectivity failures defer only that source while unrelated
+sources continue. Review every new `failed` or unexpected `skipped` job. If map
 processing regresses,
 follow the map-only rollback boundary in section 10; the catalogue and API can
 remain live.

--- a/server/__tests__/mapWorker.test.js
+++ b/server/__tests__/mapWorker.test.js
@@ -228,6 +228,23 @@ describe('map worker transitions', () => {
         );
     });
 
+    test('marks an export still pending at its limit as a retryable skip', async () => {
+        const error = Object.assign(new Error('export pending'), {
+            code: 'DOWNLOAD_PENDING'
+        });
+        const finalJob = { ...job, attempts: 5 };
+        await processJob(finalJob, '00000000-0000-4000-8000-000000000001', {
+            getResourceById: async () => resource,
+            probeGeometry: async () => ({ total: 1, fields: [{ id: 'geometry' }] }),
+            indexMapResource: async () => { throw error; }
+        });
+        expect(mapQueries.finishJob).toHaveBeenCalledWith(
+            pool, finalJob, expect.any(String), 'skipped', {},
+            'DOWNLOAD_PENDING: export pending', 'DOWNLOAD_PENDING'
+        );
+        expect(mapQueries.requeueJob).not.toHaveBeenCalled();
+    });
+
     test('skips a permanently missing catalogued download without retrying', async () => {
         const error = Object.assign(new Error('download failed: HTTP 404'), {
             code: 'DOWNLOAD_HTTP', httpStatus: 404

--- a/server/__tests__/retryMapSource.test.js
+++ b/server/__tests__/retryMapSource.test.js
@@ -7,9 +7,9 @@ describe('map source recovery command', () => {
     beforeEach(() => jest.clearAllMocks());
 
     test('defaults to a read-only failed-job count', async () => {
-        pool.query.mockResolvedValueOnce({ rows: [{ failed: '4' }] });
+        pool.query.mockResolvedValueOnce({ rows: [{ failed: '4', retryable_skipped: '2' }] });
         await expect(retryMapSource(pool, 'shawinigan-open-data')).resolves.toEqual({
-            source_id: 'shawinigan-open-data', failed: 4, apply: false
+            source_id: 'shawinigan-open-data', failed: 4, retryable_skipped: 2, apply: false
         });
         expect(pool.query).toHaveBeenCalledTimes(1);
         expect(pool.query.mock.calls[0][0]).toContain("j.status = 'failed'");
@@ -17,13 +17,15 @@ describe('map source recovery command', () => {
 
     test('apply only requeues failed jobs for the requested source', async () => {
         pool.query
-            .mockResolvedValueOnce({ rows: [{ failed: '4' }] })
+            .mockResolvedValueOnce({ rows: [{ failed: '4', retryable_skipped: '2' }] })
             .mockResolvedValueOnce({ rowCount: 4, rows: [] });
         await expect(retryMapSource(pool, 'shawinigan-open-data', true)).resolves.toEqual({
-            source_id: 'shawinigan-open-data', failed: 4, requeued: 4, apply: true
+            source_id: 'shawinigan-open-data', failed: 4, retryable_skipped: 2,
+            requeued: 4, apply: true
         });
         expect(pool.query.mock.calls[1][0]).toContain("r.raw->>'source_id' = $1");
-        expect(pool.query.mock.calls[1][0]).toContain("status = 'pending'");
+        expect(pool.query.mock.calls[1][0]).toContain("j.status = 'failed'");
+        expect(pool.query.mock.calls[1][0]).toContain("j.failure_code = 'DOWNLOAD_PENDING'");
     });
 
     test('rejects an unknown source before querying the database', async () => {

--- a/server/scripts/map-worker.js
+++ b/server/scripts/map-worker.js
@@ -81,6 +81,10 @@ function retryLimit(error) {
     return error && error.code === 'DOWNLOAD_PENDING' ? MAX_PENDING_ATTEMPTS : MAX_ATTEMPTS;
 }
 
+function isExhaustedPending(error, attempts) {
+    return error && error.code === 'DOWNLOAD_PENDING' && attempts >= retryLimit(error);
+}
+
 function retryDelayMs(error, attempts) {
     const retryAfter = Number(error && error.retryAfterMs);
     if (Number.isFinite(retryAfter) && retryAfter > 0) {
@@ -233,12 +237,17 @@ async function processJob(job, workerId, options = {}) {
             ' features, ' + result.vertexCount + ' vertices');
         return result;
     } catch (error) {
-        const skipped = error instanceof MapSkipError || ['CAP_FILE'].includes(error && error.code)
+        const pendingExhausted = isExhaustedPending(error, job.attempts);
+        const skipped = pendingExhausted || error instanceof MapSkipError || ['CAP_FILE'].includes(error && error.code)
             || isPermanentMissingDownload(error);
         const detail = error && error.code ? error.code + ': ' + error.message : error.message;
         console.error('[map ' + job.resource_id + '] ' + (skipped ? 'skipped' : 'failed') + ': ' + detail);
         if (skipped) {
-            await finishJob(pool, job, workerId, 'skipped', {}, detail);
+            if (pendingExhausted) {
+                await finishJob(pool, job, workerId, 'skipped', {}, detail, 'DOWNLOAD_PENDING');
+            } else {
+                await finishJob(pool, job, workerId, 'skipped', {}, detail);
+            }
         } else if (job.attempts >= retryLimit(error)) {
             const sourceRetry = isSourceRetryable(error) && sourceIdFor(resource);
             const finished = sourceRetry
@@ -343,5 +352,5 @@ if (require.main === module) {
 module.exports = {
     main, processJob, probeGeometry, ckanTarget, validateDirectGeoJson,
     reconcileMissingPmtiles, requestStop, waitForPoll,
-    isSourceRetryable, retryLimit, retryDelayMs, retryAt, sourceIdFor
+    isSourceRetryable, retryLimit, isExhaustedPending, retryDelayMs, retryAt, sourceIdFor
 };

--- a/server/scripts/retry-map-source.js
+++ b/server/scripts/retry-map-source.js
@@ -15,14 +15,18 @@ async function retryMapSource(db, sourceId, apply = false) {
     const source = getSource(sourceId);
     if (!source) throw new Error('unknown or missing --source');
     const result = await db.query(`
-        SELECT count(*)::int AS failed
+        SELECT count(*) FILTER (WHERE j.status = 'failed')::int AS failed,
+               count(*) FILTER (
+                   WHERE j.status = 'skipped' AND j.failure_code = 'DOWNLOAD_PENDING'
+               )::int AS retryable_skipped
         FROM map_index_jobs j
         JOIN resources r ON r.id = j.resource_id
-        WHERE j.status = 'failed' AND r.raw->>'source_id' = $1
+        WHERE r.raw->>'source_id' = $1
     `, [source.id]);
     const failed = Number(result.rows[0].failed) || 0;
+    const retryableSkipped = Number(result.rows[0].retryable_skipped) || 0;
     if (!apply) {
-        return { source_id: source.id, failed, apply: false };
+        return { source_id: source.id, failed, retryable_skipped: retryableSkipped, apply: false };
     }
     const updated = await db.query(`
         UPDATE map_index_jobs j
@@ -32,11 +36,15 @@ async function retryMapSource(db, sourceId, apply = false) {
             next_attempt_at = now(), failure_code = NULL, updated_at = now()
         FROM resources r
         WHERE j.resource_id = r.id
-          AND j.status = 'failed'
+          AND (j.status = 'failed'
+               OR (j.status = 'skipped' AND j.failure_code = 'DOWNLOAD_PENDING'))
           AND r.raw->>'source_id' = $1
         RETURNING j.resource_id
     `, [source.id]);
-    return { source_id: source.id, failed, requeued: updated.rowCount, apply: true };
+    return {
+        source_id: source.id, failed, retryable_skipped: retryableSkipped,
+        requeued: updated.rowCount, apply: true
+    };
 }
 
 async function main() {


### PR DESCRIPTION
## What & why

A Sherbrooke GeoJSON export remained in ArcGIS `ExportingData` and returned HTTP 202 through the bounded five-attempt retry budget. This follow-up makes that terminal condition an explicit retryable `skipped` job rather than a queue `failed` row, and teaches the source recovery command to requeue only those typed skips after an operator probe.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

- No schema change; migration 030 remains sufficient.
- Release gate: 59 server suites/482 tests (12 expected skips), 27 client suites/109 tests.
- The paused production queue contains the single pending 202 export and will resume after merge.