### PR TITLE
fix: guard small-source catalogue sweeps

### DIFF
--- a/server/__tests__/catalogWrite.test.js
+++ b/server/__tests__/catalogWrite.test.js
@@ -69,6 +69,33 @@ describe('sweepMissingDatasets', () => {
         expect(db.query).toHaveBeenCalledTimes(1);
     });
 
+    test('refuses a truncated small-source catalogue', async () => {
+        const db = {
+            query: jest.fn().mockResolvedValueOnce({ rows: [{ total: '27', missing: '26' }] })
+        };
+
+        await expect(sweepMissingDatasets(db, ['kept'], {
+            sourceId: 'small-municipality', maxDeleteFraction: 0.1
+        })).rejects.toThrow('26/27');
+        expect(db.query).toHaveBeenCalledTimes(1);
+    });
+
+    test('allows one routine deletion from a tiny catalogue', async () => {
+        const db = {
+            query: jest.fn()
+                .mockResolvedValueOnce({ rows: [{ total: '5', missing: '1' }] })
+                .mockResolvedValueOnce({ rows: [{ dataset_id: 'shared-dataset' }] })
+                .mockResolvedValueOnce({ rowCount: 1 })
+                .mockResolvedValueOnce({ rows: [] })
+        };
+
+        await expect(sweepMissingDatasets(db, ['kept'], {
+            sourceId: 'tiny-municipality', maxDeleteFraction: 0.1
+        })).resolves.toEqual({ datasetsDeleted: 0, resourcesDeleted: 0 });
+        expect(db.query.mock.calls[0][1]).toEqual([['kept'], 'tiny-municipality']);
+        expect(db.query.mock.calls[1][0]).toContain('DELETE FROM dataset_sources');
+    });
+
     test('deletes missing resources before their datasets', async () => {
         const db = {
             query: jest.fn()

--- a/server/db/catalogWriteQueries.js
+++ b/server/db/catalogWriteQueries.js
@@ -331,13 +331,16 @@ async function sweepMissingDatasets(db, upstreamIdsRaw, options = {}) {
     const total = Number(countResult.rows[0].total) || 0;
     const missing = Number(countResult.rows[0].missing) || 0;
 
-    // Small development catalogues can legitimately lose one of a handful of
-    // rows. On a real harvest, require an operator decision before deleting more
-    // than the safety fraction in one run.
-    if (total >= 100 && missing / total > maxDeleteFraction) {
+    // Permit one routine removal even when the configured fraction rounds down
+    // to zero, but never disable the guard for small production catalogues.
+    // Several municipal sources contain fewer than 100 datasets, where a
+    // truncated response would otherwise be allowed to delete nearly everything.
+    const maxDeleteCount = Math.max(1, Math.floor(total * maxDeleteFraction));
+    if (missing > maxDeleteCount) {
         throw new Error(
             'refusing catalogue sweep of ' + missing + '/' + total +
-            ' datasets (limit ' + (maxDeleteFraction * 100) + '%)'
+            ' datasets (limit ' + (maxDeleteFraction * 100) + '%, ' +
+            maxDeleteCount + ' for current catalogue size)'
         );
     }
     if (missing === 0) return { datasetsDeleted: 0, resourcesDeleted: 0 };


### PR DESCRIPTION
## What & why

Apply the configured catalogue deletion fraction to sources of every size.

Previously, the safety check only ran when a source already had at least 100 datasets. Several live municipal sources have 27–67 datasets, so a truncated but non-empty upstream response could remove nearly the entire source during the automated sync.

The new threshold allows at least one routine removal, then refuses any sweep above `max(1, floor(total * maxDeleteFraction))`.

## Checklist

- [x] `server`: `npm run lint && npm test -- --runInBand` pass
- [x] Added regression tests for a 26/27 deletion wave and a permitted one-row removal
- [x] No user-facing strings changed
- [x] No secrets, credentials, migrations, or production-specific values added

## Notes

Server verification: 59 suites passed, 484 tests passed, 12 spatial tests skipped without a configured PostGIS test database.