### PR TITLE
fix: serialize federal catalogue sync jobs

### DIFF
--- a/server/__tests__/catalogSyncLock.test.js
+++ b/server/__tests__/catalogSyncLock.test.js
@@ -1,0 +1,59 @@
+const {
+    CATALOG_SYNC_LOCK_KEYS,
+    acquireCatalogSyncLock,
+    releaseCatalogSyncLock
+} = require('../db/catalogSyncLock');
+
+describe('catalog sync advisory lock', () => {
+    function makePool(result) {
+        const client = {
+            query: jest.fn().mockResolvedValue(result),
+            release: jest.fn()
+        };
+        return { pool: { connect: jest.fn().mockResolvedValue(client) }, client };
+    }
+
+    it('holds a dedicated client when the lock is acquired', async () => {
+        const { pool, client } = makePool({ rows: [{ acquired: true }] });
+
+        await expect(acquireCatalogSyncLock(pool)).resolves.toBe(client);
+        expect(client.query).toHaveBeenCalledWith(
+            'SELECT pg_try_advisory_lock($1, $2) AS acquired',
+            CATALOG_SYNC_LOCK_KEYS
+        );
+        expect(client.release).not.toHaveBeenCalled();
+    });
+
+    it('returns a graceful skip and releases the client when busy', async () => {
+        const { pool, client } = makePool({ rows: [{ acquired: false }] });
+
+        await expect(acquireCatalogSyncLock(pool)).resolves.toBeNull();
+        expect(client.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the lock and client after a successful run', async () => {
+        const { client } = makePool({ rows: [{ released: true }] });
+
+        await expect(releaseCatalogSyncLock(client)).resolves.toBe(true);
+        expect(client.query).toHaveBeenCalledWith(
+            'SELECT pg_advisory_unlock($1, $2) AS released',
+            CATALOG_SYNC_LOCK_KEYS
+        );
+        expect(client.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the client if lock acquisition fails', async () => {
+        const client = { query: jest.fn().mockRejectedValue(new Error('connection lost')), release: jest.fn() };
+        const pool = { connect: jest.fn().mockResolvedValue(client) };
+
+        await expect(acquireCatalogSyncLock(pool)).rejects.toThrow('connection lost');
+        expect(client.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the client even if unlock fails', async () => {
+        const client = { query: jest.fn().mockRejectedValue(new Error('unlock failed')), release: jest.fn() };
+
+        await expect(releaseCatalogSyncLock(client)).rejects.toThrow('unlock failed');
+        expect(client.release).toHaveBeenCalledTimes(1);
+    });
+});

--- a/server/db/catalogSyncLock.js
+++ b/server/db/catalogSyncLock.js
@@ -1,0 +1,52 @@
+// Two signed int32 keys spelling "canq" / "sync". A session-level advisory
+// lock held on a dedicated client prevents the federal full and incremental
+// catalogue syncs from running at the same time.
+const CATALOG_SYNC_LOCK_KEYS = [1667329649, 1937337955];
+
+/**
+ * Acquire the process-wide federal catalogue sync lock.
+ *
+ * The returned client must remain checked out for the whole sync run. A busy
+ * lock returns null and releases the client immediately so the caller can
+ * treat contention as an expected, successful skip.
+ */
+async function acquireCatalogSyncLock(pool) {
+    const client = await pool.connect();
+    try {
+        const result = await client.query(
+            'SELECT pg_try_advisory_lock($1, $2) AS acquired',
+            CATALOG_SYNC_LOCK_KEYS
+        );
+        if (result.rows[0]?.acquired !== true) {
+            client.release();
+            return null;
+        }
+        return client;
+    } catch (error) {
+        client.release();
+        throw error;
+    }
+}
+
+/**
+ * Release a previously acquired catalogue sync lock and return its client.
+ * The client is released even if PostgreSQL reports an error while unlocking.
+ */
+async function releaseCatalogSyncLock(client) {
+    if (!client) return false;
+    try {
+        const result = await client.query(
+            'SELECT pg_advisory_unlock($1, $2) AS released',
+            CATALOG_SYNC_LOCK_KEYS
+        );
+        return result.rows[0]?.released === true;
+    } finally {
+        client.release();
+    }
+}
+
+module.exports = {
+    CATALOG_SYNC_LOCK_KEYS,
+    acquireCatalogSyncLock,
+    releaseCatalogSyncLock
+};

--- a/server/scripts/catalog-sync.js
+++ b/server/scripts/catalog-sync.js
@@ -24,6 +24,10 @@ const {
     setProgress,
     insertSyncRun
 } = require('../db/catalogWriteQueries');
+const {
+    acquireCatalogSyncLock,
+    releaseCatalogSyncLock
+} = require('../db/catalogSyncLock');
 
 const args = process.argv.slice(2);
 function getArgValue(name) {
@@ -47,11 +51,19 @@ const maxDeleteFraction = deleteFraction(process.env.FULL_SYNC_MAX_DELETE_FRACTI
 async function main() {
     const startedAt = new Date();
     let ok = false;
+    let skipped = false;
     let error = null;
     let datasetsUpserted = 0;
     let resourcesUpserted = 0;
+    let lockClient = null;
 
     try {
+        lockClient = await acquireCatalogSyncLock(pool);
+        if (!lockClient) {
+            skipped = true;
+            console.log('catalog-sync skipped: federal catalogue sync already active');
+            return;
+        }
         if (limit !== null && (!Number.isInteger(limit) || limit < 1)) {
             throw new Error('--limit must be a positive integer');
         }
@@ -165,13 +177,22 @@ async function main() {
         error = err.message;
         console.error('catalog-sync failed:', err);
     } finally {
-        try {
-            await insertSyncRun(pool, { kind: 'full', sourceId: 'open-canada', startedAt, finishedAt: new Date(), ok, datasetsUpserted, resourcesUpserted, error });
-        } catch (logErr) {
-            console.error('run log failed:', logErr.message);
+        if (lockClient) {
+            try {
+                await releaseCatalogSyncLock(lockClient);
+            } catch (unlockErr) {
+                console.error('catalog sync lock release failed:', unlockErr.message);
+            }
+        }
+        if (!skipped) {
+            try {
+                await insertSyncRun(pool, { kind: 'full', sourceId: 'open-canada', startedAt, finishedAt: new Date(), ok, datasetsUpserted, resourcesUpserted, error });
+            } catch (logErr) {
+                console.error('run log failed:', logErr.message);
+            }
         }
         await pool.end();
-        process.exit(ok ? 0 : 1);
+        process.exit(skipped || ok ? 0 : 1);
     }
 }
 

--- a/server/scripts/incremental-sync.js
+++ b/server/scripts/incremental-sync.js
@@ -47,6 +47,10 @@ const {
     collectIncrementalPackages,
     latestTimestamp
 } = require('../services/incrementalSync');
+const {
+    acquireCatalogSyncLock,
+    releaseCatalogSyncLock
+} = require('../db/catalogSyncLock');
 
 function positiveInteger(value, fallback) {
     const parsed = Number(value);
@@ -59,11 +63,19 @@ const overlapSeconds = positiveInteger(process.env.INCREMENTAL_SYNC_OVERLAP_SECO
 async function main() {
     const startedAt = new Date();
     let ok = false;
+    let skipped = false;
     let error = null;
     let datasetsUpserted = 0;
     let resourcesUpserted = 0;
+    let lockClient = null;
 
     try {
+        lockClient = await acquireCatalogSyncLock(pool);
+        if (!lockClient) {
+            skipped = true;
+            console.log('incremental-sync skipped: federal catalogue sync already active');
+            return;
+        }
         if (limit !== null && (!Number.isInteger(limit) || limit < 1)) {
             throw new Error('--limit must be a positive integer');
         }
@@ -175,13 +187,22 @@ async function main() {
         error = err.message;
         console.error('incremental-sync failed:', err);
     } finally {
-        try {
-            await insertSyncRun(pool, { kind: 'incremental', sourceId: 'open-canada', startedAt, finishedAt: new Date(), ok, datasetsUpserted, resourcesUpserted, error });
-        } catch (logErr) {
-            console.error('run log failed:', logErr.message);
+        if (lockClient) {
+            try {
+                await releaseCatalogSyncLock(lockClient);
+            } catch (unlockErr) {
+                console.error('catalog sync lock release failed:', unlockErr.message);
+            }
+        }
+        if (!skipped) {
+            try {
+                await insertSyncRun(pool, { kind: 'incremental', sourceId: 'open-canada', startedAt, finishedAt: new Date(), ok, datasetsUpserted, resourcesUpserted, error });
+            } catch (logErr) {
+                console.error('run log failed:', logErr.message);
+            }
         }
         await pool.end();
-        process.exit(ok ? 0 : 1);
+        process.exit(skipped || ok ? 0 : 1);
     }
 }
 


### PR DESCRIPTION
Adds a shared PostgreSQL advisory lock around federal full and incremental catalogue syncs. Contention exits cleanly without writing a misleading sync_runs row; lock acquisition failures remain hard failures. Includes focused lock lifecycle tests.

Local verification: npm run verify (server lint, 522 Jest tests, client lint, 114 Vitest tests, production build).