### PR TITLE
v38: expand search visibility and resource discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ psql canquery -c "CREATE EXTENSION IF NOT EXISTS unaccent;"
 cd server
 npm install
 cp .env.example .env              # set DATABASE_URL (and optional S3_* for PMTiles)
-npm run migrate                   # apply migrations (runs 001..030)
+npm run migrate                   # apply migrations (runs 001..031)
 npm run sync:places               # populate the 2021 SGC hierarchy
 
 # sync the federal catalogue (batched harvest, chunks of 50)

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -261,10 +261,11 @@ sudo -u canquery npm run gsc:report --prefix /home/canquery/canquery/server
 ```
 
 The client requests only `webmasters.readonly`. The first sync imports 90
-finalized Pacific-time days; later runs replace a seven-day overlap. Serve the
-file configured by `GSC_REPORT_PATH` only through an authenticated, noindex
-operator route. Once the initial import and protected report are verified,
-uncomment the 06:15 UTC sync and 06:30 UTC report entries.
+finalized Pacific-time days, including aggregate query-to-page attribution;
+later runs replace a seven-day overlap atomically. Serve the file configured by
+`GSC_REPORT_PATH` only through an authenticated, noindex operator route. Once the
+initial import and protected report are verified, uncomment the 06:15 UTC sync
+and 06:30 UTC report entries.
 
 Incremental sync advances its persisted checkpoint only after a complete
 overlap-window traversal. Reaching its safety page cap records an incomplete run

--- a/server/__tests__/searchConsoleQueries.test.js
+++ b/server/__tests__/searchConsoleQueries.test.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 jest.mock('../db/pool', () => ({}));
 
 const queries = require('../db/searchConsoleQueries');
@@ -9,7 +12,11 @@ function day() {
         total: { clicks: 3, impressions: 10, ctr: 0.3, position: 4.2 },
         breakdowns: [
             { dimension: 'query', value: 'oshawa data', clicks: 2, impressions: 5, ctr: 0.4, position: 2 }
-        ]
+        ],
+        queryPages: [{
+            query: 'oshawa data', page: 'https://canquery.com/datasets/roads',
+            clicks: 2, impressions: 5, ctr: 0.4, position: 2
+        }]
     };
 }
 
@@ -22,6 +29,8 @@ it('atomically replaces totals and all breakdown slices for a day', async () => 
     expect(sql.some(text => text.startsWith('INSERT INTO search_console_daily'))).toBe(true);
     expect(sql.some(text => text.startsWith('DELETE FROM search_console_breakdowns'))).toBe(true);
     expect(sql.some(text => text.startsWith('INSERT INTO search_console_breakdowns'))).toBe(true);
+    expect(sql.some(text => text.startsWith('DELETE FROM search_console_query_pages'))).toBe(true);
+    expect(sql.some(text => text.startsWith('INSERT INTO search_console_query_pages'))).toBe(true);
     expect(sql.at(-1)).toBe('COMMIT');
     expect(client.release).toHaveBeenCalled();
 });
@@ -59,6 +68,7 @@ it('surfaces high-impression, low-CTR dataset and resource pages in the report d
         .mockResolvedValueOnce({ rows: [opportunity] })
         .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [] }) };
 
     const report = await queries.getSearchGrowthReportData(db);
@@ -67,4 +77,55 @@ it('surfaces high-impression, low-CTR dataset and resource pages in the report d
     const opportunitySql = db.query.mock.calls.find(call => call[0].includes('HAVING sum(impressions) >= 50'));
     expect(opportunitySql[0]).toContain("value ~ '/datasets/[^/?#]+'");
     expect(opportunitySql[0]).toContain("value ~ '/resources/[^/?#]+'");
+});
+
+it('returns query-to-page opportunities and per-family visible-page counts', async () => {
+    const pair = {
+        query: 'water data', page: 'https://canquery.com/resources/r1',
+        clicks: 0, impressions: 12, ctr: 0, position: 4
+    };
+    const route = {
+        value: 'Resource pages', pages_with_impressions: 870, pages_with_clicks: 11,
+        clicks: 16, impressions: 6269, ctr: 0.0026, position: 10.1
+    };
+    const db = { query: jest.fn()
+        .mockResolvedValueOnce({ rows: [{ latest_date: '2026-08-27', last_synced_at: '2026-08-29T00:00:00Z' }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{
+            current_clicks: 1, current_impressions: 100,
+            prior_clicks: 0, prior_impressions: 50,
+            current_position: 5, prior_position: 6
+        }] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [pair] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [route] }) };
+
+    const report = await queries.getSearchGrowthReportData(db);
+
+    expect(report.queryPageOpportunities).toEqual([pair]);
+    expect(report.routes).toEqual([route]);
+    const pairSql = db.query.mock.calls.find(call => call[0].includes('FROM search_console_query_pages'));
+    expect(pairSql[0]).toContain('sum(impressions) >= 5');
+    expect(pairSql[0]).toContain('BETWEEN 1 AND 20');
+    const routeSql = db.query.mock.calls.find(call => call[0].includes('pages_with_impressions'));
+    expect(routeSql[0]).toContain('count(*) FILTER (WHERE clicks > 0)');
+});
+
+it('migrates query-to-page aggregates with durable uniqueness and report indexes', () => {
+    const sql = fs.readFileSync(path.join(
+        __dirname,
+        '..',
+        'sql',
+        'migrations',
+        '031_search_console_query_pages.sql'
+    ), 'utf8');
+    expect(sql).toContain('CREATE TABLE IF NOT EXISTS search_console_query_pages');
+    expect(sql).toContain('PRIMARY KEY (data_date, search_type, query_text, page_url)');
+    expect(sql).toContain('idx_search_console_query_pages_type_date');
+    expect(sql).toContain('idx_search_console_query_pages_page_date');
 });

--- a/server/__tests__/searchConsoleService.test.js
+++ b/server/__tests__/searchConsoleService.test.js
@@ -49,6 +49,20 @@ describe('Search Console API pagination', () => {
         expect(request).toHaveBeenCalledTimes(2);
     });
 
+    it('requests validated query-to-page dimension pairs', async () => {
+        const request = jest.fn().mockResolvedValue({ data: { rows: [] } });
+        await service.querySlice(request, {
+            siteUrl: 'https://example.com/',
+            dataDate: '2026-08-19',
+            dimensions: ['query', 'page']
+        });
+        expect(request.mock.calls[0][0].data.dimensions).toEqual(['query', 'page']);
+        expect(() => service.normalizeDimensions(null, ['query', 'query']))
+            .toThrow(/duplicate/);
+        expect(() => service.normalizeDimensions(null, ['query', 'unknown']))
+            .toThrow(/unsupported/);
+    });
+
     it('retries 429/5xx responses with bounded backoff', async () => {
         const error = Object.assign(new Error('limited'), { response: { status: 429 } });
         const request = jest.fn().mockRejectedValueOnce(error).mockResolvedValue({ data: { rows: [] } });
@@ -65,6 +79,10 @@ describe('Search Console daily synchronization', () => {
     it('collects totals and each allowed breakdown without copying empty keys', async () => {
         const request = jest.fn(async ({ data }) => {
             if (!data.dimensions) return { data: { rows: [{ clicks: 3, impressions: 10, ctr: 0.3, position: 4.2 }] } };
+            if (data.dimensions.length === 2) return { data: { rows: [
+                { keys: ['water data', 'https://example.com/datasets/water'], clicks: 1, impressions: 4, ctr: 0.25, position: 3 },
+                { keys: ['', 'https://example.com/'], clicks: 0, impressions: 1, ctr: 0, position: 9 }
+            ] } };
             return { data: { rows: [
                 { keys: [data.dimensions[0] + '-value'], clicks: 1, impressions: 2, ctr: 0.5, position: 2 },
                 { keys: [''], clicks: 0, impressions: 0, ctr: 0, position: 0 }
@@ -76,6 +94,14 @@ describe('Search Console daily synchronization', () => {
         expect(day.total).toEqual({ clicks: 3, impressions: 10, ctr: 0.3, position: 4.2 });
         expect(day.breakdowns).toHaveLength(4);
         expect(day.breakdowns.map(row => row.dimension)).toEqual(service.DIMENSIONS);
+        expect(day.queryPages).toEqual([{
+            query: 'water data',
+            page: 'https://example.com/datasets/water',
+            clicks: 1,
+            impressions: 4,
+            ctr: 0.25,
+            position: 3
+        }]);
     });
 
     it('replaces one transactionally complete day at a time', async () => {
@@ -89,7 +115,12 @@ describe('Search Console daily synchronization', () => {
             startDate: '2026-08-18', endDate: '2026-08-19', logger: log
         });
         expect(db.replaceSearchConsoleDay).toHaveBeenCalledTimes(2);
-        expect(result).toEqual({ days: 2, breakdownRows: 0, truncated: [] });
+        expect(result).toEqual({
+            days: 2,
+            breakdownRows: 0,
+            queryPageRows: 0,
+            truncated: []
+        });
         expect(log).toHaveBeenCalledTimes(2);
     });
 });

--- a/server/__tests__/searchGrowthReport.test.js
+++ b/server/__tests__/searchGrowthReport.test.js
@@ -17,7 +17,15 @@ function sample() {
         topQueries: [{ value: '<img src=x onerror=alert(1)>', clicks: 2, impressions: 10, ctr: 0.2, position: 3 }],
         topPages: [], zeroClickQueries: [],
         pageOpportunities: [{ value: 'https://canquery.com/datasets/roads', clicks: 0, impressions: 200, ctr: 0, position: 5 }],
-        countries: [], devices: [], routes: []
+        queryPageOpportunities: [{
+            query: '<script>alert(1)</script>',
+            page: 'https://canquery.com/resources/r1?x=<bad>',
+            clicks: 0, impressions: 12, ctr: 0, position: 4
+        }],
+        countries: [], devices: [], routes: [{
+            value: 'Resource pages', pages_with_impressions: 870, pages_with_clicks: 11,
+            clicks: 16, impressions: 6269, ctr: 0.0026, position: 10.1
+        }]
     };
 }
 
@@ -30,13 +38,17 @@ it('escapes imported Search Console text and emits no executable scripts', () =>
     expect(html).toContain('Finalized through 2026-08-19');
     expect(html).toContain('High-impression, low-CTR pages');
     expect(html).toContain('https://canquery.com/datasets/roads');
+    expect(html).toContain('Query-to-page opportunities');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(html).toContain('Page-family visibility');
+    expect(html).toContain('870');
 });
 
 it('renders a safe empty report before the first import', () => {
     const html = renderSearchGrowthReport({
         latestDate: null, lastSyncedAt: null, summary: null, daily: [],
         topQueries: [], topPages: [], zeroClickQueries: [], pageOpportunities: [],
-        countries: [], devices: [], routes: []
+        queryPageOpportunities: [], countries: [], devices: [], routes: []
     });
     expect(html).toContain('No imported data');
     expect(html).toContain('Run the Search Console import');

--- a/server/__tests__/seoApi.test.js
+++ b/server/__tests__/seoApi.test.js
@@ -7,6 +7,8 @@ jest.mock('../db/catalogReadQueries', () => ({
     getStats: jest.fn(),
     countSitemapDatasets: jest.fn(),
     listDatasetSitemap: jest.fn(),
+    countSitemapResources: jest.fn(),
+    listResourceSitemap: jest.fn(),
     listPlaceSitemap: jest.fn(),
     getPlaceByIdOrSlug: jest.fn(),
     pingDb: jest.fn(),
@@ -36,8 +38,9 @@ describe('robots.txt', () => {
 });
 
 describe('sitemap index', () => {
-    it('lists the pages sitemap plus one chunk per 25k datasets', async () => {
+    it('lists one chunk per 25k quality-gated datasets and resources', async () => {
         catalogRead.countSitemapDatasets.mockResolvedValue(30000);
+        catalogRead.countSitemapResources.mockResolvedValue(26000);
         const res = await request(app).get('/sitemap.xml');
         expect(res.status).toBe(200);
         expect(res.headers['content-type']).toMatch(/xml/);
@@ -46,12 +49,17 @@ describe('sitemap index', () => {
         expect(res.text).toContain('<loc>https://canquery.com/sitemap-datasets-1.xml</loc>');
         expect(res.text).toContain('<loc>https://canquery.com/sitemap-datasets-2.xml</loc>');
         expect(res.text).not.toContain('sitemap-datasets-3.xml');
+        expect(res.text).toContain('<loc>https://canquery.com/sitemap-resources-1.xml</loc>');
+        expect(res.text).toContain('<loc>https://canquery.com/sitemap-resources-2.xml</loc>');
+        expect(res.text).not.toContain('sitemap-resources-3.xml');
     });
 
-    it('always emits at least one dataset chunk', async () => {
+    it('always emits a dataset chunk but omits empty resource chunks', async () => {
         catalogRead.countSitemapDatasets.mockResolvedValue(0);
+        catalogRead.countSitemapResources.mockResolvedValue(0);
         const res = await request(app).get('/sitemap.xml');
         expect(res.text).toContain('sitemap-datasets-1.xml');
+        expect(res.text).not.toContain('sitemap-resources-1.xml');
     });
 });
 
@@ -108,6 +116,41 @@ describe('dataset sitemap chunk', () => {
         catalogRead.listDatasetSitemap.mockResolvedValue([]);
         const res = await request(app).get('/sitemap-datasets-99.xml');
         expect(res.status).toBe(404);
+    });
+});
+
+describe('resource sitemap chunk', () => {
+    it('emits canonical resource urls with parent-dataset lastmod values', async () => {
+        catalogRead.listResourceSitemap.mockResolvedValue([
+            { id: 'r1', metadata_modified: '2026-08-27T12:00:00Z' },
+            { id: 'r/2', metadata_modified: null }
+        ]);
+        const res = await request(app).get('/sitemap-resources-1.xml');
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toMatch(/xml/);
+        expect(catalogRead.listResourceSitemap).toHaveBeenCalledWith({ limit: 25000, offset: 0 });
+        expect(res.text).toContain('<loc>https://canquery.com/resources/r1</loc>');
+        expect(res.text).toContain('<lastmod>2026-08-27T12:00:00.000Z</lastmod>');
+        expect(res.text).toContain('<loc>https://canquery.com/resources/r%2F2</loc>');
+    });
+
+    it('computes chunk offsets and 404s beyond the current resource set', async () => {
+        catalogRead.listResourceSitemap
+            .mockResolvedValueOnce([{ id: 'r9', metadata_modified: null }])
+            .mockResolvedValueOnce([]);
+        await request(app).get('/sitemap-resources-3.xml');
+        expect(catalogRead.listResourceSitemap).toHaveBeenNthCalledWith(1, {
+            limit: 25000,
+            offset: 50000
+        });
+        const res = await request(app).get('/sitemap-resources-99.xml');
+        expect(res.status).toBe(404);
+    });
+
+    it('rejects malformed chunk numbers without querying the catalogue', async () => {
+        const res = await request(app).get('/sitemap-resources-1x.xml');
+        expect(res.status).toBe(404);
+        expect(catalogRead.listResourceSitemap).not.toHaveBeenCalled();
     });
 });
 

--- a/server/__tests__/sitemapQueries.test.js
+++ b/server/__tests__/sitemapQueries.test.js
@@ -1,0 +1,36 @@
+jest.mock('../db/pool', () => ({ query: jest.fn() }));
+
+const pool = require('../db/pool');
+const queries = require('../db/catalogReadQueries');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('resource sitemap queries', () => {
+    it('counts only resources with a live table, local table, or map capability', async () => {
+        pool.query.mockResolvedValue({ rows: [{ n: 13 }] });
+
+        await expect(queries.countSitemapResources()).resolves.toBe(13);
+
+        const sql = pool.query.mock.calls[0][0];
+        expect(sql).toContain('FROM resources r');
+        expect(sql).toContain('r.datastore_active');
+        expect(sql).toContain("ir.status = 'ready'");
+        expect(sql).toContain('resource_maps');
+    });
+
+    it('lists each qualifying resource once with its parent dataset modification time', async () => {
+        const rows = [{ id: 'r1', metadata_modified: '2026-08-27T00:00:00Z' }];
+        pool.query.mockResolvedValue({ rows });
+
+        await expect(queries.listResourceSitemap({ limit: 25000, offset: 50000 }))
+            .resolves.toEqual(rows);
+
+        const [sql, params] = pool.query.mock.calls[0];
+        expect(sql).toContain('WITH eligible_resources AS MATERIALIZED');
+        expect(sql).toContain('JOIN datasets d ON d.id = eligible.dataset_id');
+        expect(sql).toContain('ORDER BY eligible.id LIMIT $1 OFFSET $2');
+        expect(sql).toContain('EXISTS (SELECT 1 FROM ingested_resources');
+        expect(sql).toContain('EXISTS (SELECT 1 FROM resource_maps');
+        expect(params).toEqual([25000, 50000]);
+    });
+});

--- a/server/controllers/sitemapController.js
+++ b/server/controllers/sitemapController.js
@@ -33,6 +33,13 @@ function urlset(entries) {
     );
 }
 
+function chunkNumber(value) {
+    if (!/^[1-9]\d*$/.test(value || '')) return null;
+    const parsed = Number(value);
+    const maxChunk = Math.floor(Number.MAX_SAFE_INTEGER / PAGE_SIZE);
+    return Number.isSafeInteger(parsed) && parsed <= maxChunk ? parsed : null;
+}
+
 // GET /robots.txt - allow everything, point at the sitemap index. We do NOT
 // block /api: Googlebot fetches it while rendering the SPA, and the per-page
 // <head> injection plus canonicals keep the index clean.
@@ -42,13 +49,18 @@ const robots = (req, res) => {
     res.send('User-agent: *\nAllow: /\n\nSitemap: ' + SITE_URL + '/sitemap.xml\n');
 };
 
-// GET /sitemap.xml - the index: the static hub pages plus one chunk per slice
-// of datasets.
+// GET /sitemap.xml - the index: static/place pages plus quality-gated dataset
+// and interactive-resource chunks.
 const sitemapIndex = catchAsync(async (req, res) => {
-    const total = await catalogRead.countSitemapDatasets();
-    const pages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+    const [datasetTotal, resourceTotal] = await Promise.all([
+        catalogRead.countSitemapDatasets(),
+        catalogRead.countSitemapResources()
+    ]);
+    const datasetPages = Math.max(1, Math.ceil(datasetTotal / PAGE_SIZE));
+    const resourcePages = Math.ceil(resourceTotal / PAGE_SIZE);
     const locs = [SITE_URL + '/sitemap-pages.xml', SITE_URL + '/sitemap-places.xml'];
-    for (let i = 1; i <= pages; i++) locs.push(SITE_URL + '/sitemap-datasets-' + i + '.xml');
+    for (let i = 1; i <= datasetPages; i++) locs.push(SITE_URL + '/sitemap-datasets-' + i + '.xml');
+    for (let i = 1; i <= resourcePages; i++) locs.push(SITE_URL + '/sitemap-resources-' + i + '.xml');
     const body =
         '<?xml version="1.0" encoding="UTF-8"?>\n' +
         '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
@@ -90,8 +102,8 @@ const sitemapPlaces = catchAsync(async (req, res) => {
 
 // GET /sitemap-datasets-:n.xml - one chunk of dataset URLs.
 const sitemapDatasets = catchAsync(async (req, res, next) => {
-    const n = parseInt(req.params.n, 10);
-    if (!Number.isInteger(n) || n < 1) return next(new AppError('Not found', 404));
+    const n = chunkNumber(req.params.n);
+    if (n === null) return next(new AppError('Not found', 404));
     const rows = await catalogRead.listDatasetSitemap({
         limit: PAGE_SIZE,
         offset: (n - 1) * PAGE_SIZE,
@@ -107,4 +119,32 @@ const sitemapDatasets = catchAsync(async (req, res, next) => {
     res.send(urlset(entries));
 });
 
-module.exports = { robots, sitemapIndex, sitemapPages, sitemapPlaces, sitemapDatasets };
+// GET /sitemap-resources-:n.xml - datastore, locally ingested, and mapped
+// resource pages only. Loadable/file-only resources remain discoverable through
+// their dataset page without expanding the crawl surface.
+const sitemapResources = catchAsync(async (req, res, next) => {
+    const n = chunkNumber(req.params.n);
+    if (n === null) return next(new AppError('Not found', 404));
+    const rows = await catalogRead.listResourceSitemap({
+        limit: PAGE_SIZE,
+        offset: (n - 1) * PAGE_SIZE,
+    });
+    if (!rows.length) return next(new AppError('Not found', 404));
+    const entries = rows.map(resource => ({
+        loc: SITE_URL + '/resources/' + encodeURIComponent(resource.id),
+        lastmod: resource.metadata_modified ? new Date(resource.metadata_modified).toISOString() : null,
+        changefreq: 'monthly',
+    }));
+    res.type('application/xml');
+    res.set('Cache-Control', 'public, max-age=3600');
+    res.send(urlset(entries));
+});
+
+module.exports = {
+    robots,
+    sitemapIndex,
+    sitemapPages,
+    sitemapPlaces,
+    sitemapDatasets,
+    sitemapResources
+};

--- a/server/db/catalogReadQueries.js
+++ b/server/db/catalogReadQueries.js
@@ -400,6 +400,11 @@ const SITEMAP_DATASET_PREDICATE = `EXISTS (
                           WHERE ir.resource_id = r.id AND ir.status = 'ready')
                OR EXISTS (SELECT 1 FROM resource_maps rm WHERE rm.resource_id = r.id)))`;
 
+const SITEMAP_RESOURCE_PREDICATE = `(r.datastore_active
+        OR EXISTS (SELECT 1 FROM ingested_resources ir
+                   WHERE ir.resource_id = r.id AND ir.status = 'ready')
+        OR EXISTS (SELECT 1 FROM resource_maps rm WHERE rm.resource_id = r.id))`;
+
 async function countSitemapDatasets() {
     const result = await pool.query(`SELECT count(*)::int AS n FROM datasets d WHERE ${SITEMAP_DATASET_PREDICATE}`);
     return result.rows[0].n;
@@ -410,6 +415,29 @@ async function listDatasetSitemap({ limit, offset }) {
         SELECT d.id, d.name, d.metadata_modified FROM datasets d
         WHERE ${SITEMAP_DATASET_PREDICATE}
         ORDER BY d.id LIMIT $1 OFFSET $2
+    `, [limit, offset]);
+    return result.rows;
+}
+
+async function countSitemapResources() {
+    const result = await pool.query(`
+        SELECT count(*)::int AS n FROM resources r
+        WHERE ${SITEMAP_RESOURCE_PREDICATE}
+    `);
+    return result.rows[0].n;
+}
+
+async function listResourceSitemap({ limit, offset }) {
+    const result = await pool.query(`
+        WITH eligible_resources AS MATERIALIZED (
+            SELECT r.id, r.dataset_id
+            FROM resources r
+            WHERE ${SITEMAP_RESOURCE_PREDICATE}
+        )
+        SELECT eligible.id, d.metadata_modified
+        FROM eligible_resources eligible
+        JOIN datasets d ON d.id = eligible.dataset_id
+        ORDER BY eligible.id LIMIT $1 OFFSET $2
     `, [limit, offset]);
     return result.rows;
 }
@@ -546,6 +574,8 @@ module.exports = {
     getStats,
     countSitemapDatasets,
     listDatasetSitemap,
+    countSitemapResources,
+    listResourceSitemap,
     listPlaceSitemap,
     pingDb,
     getLastSyncTime,

--- a/server/db/searchConsoleQueries.js
+++ b/server/db/searchConsoleQueries.js
@@ -33,6 +33,35 @@ async function insertBreakdowns(client, day) {
     }
 }
 
+async function insertQueryPages(client, day) {
+    const rows = day.queryPages || [];
+    const size = 500;
+    for (let offset = 0; offset < rows.length; offset += size) {
+        const chunk = rows.slice(offset, offset + size);
+        const values = [];
+        const tuples = chunk.map((row, index) => {
+            const p = index * 8 + 1;
+            values.push(
+                day.dataDate, day.searchType, row.query, row.page,
+                row.clicks, row.impressions, row.ctr, row.position
+            );
+            return `($${p},$${p + 1},$${p + 2},$${p + 3},$${p + 4},$${p + 5},$${p + 6},$${p + 7})`;
+        });
+        await client.query(`
+            INSERT INTO search_console_query_pages (
+                data_date, search_type, query_text, page_url,
+                clicks, impressions, ctr, position
+            ) VALUES ${tuples.join(',')}
+            ON CONFLICT (data_date, search_type, query_text, page_url) DO UPDATE SET
+                clicks = EXCLUDED.clicks,
+                impressions = EXCLUDED.impressions,
+                ctr = EXCLUDED.ctr,
+                position = EXCLUDED.position,
+                synced_at = now()
+        `, values);
+    }
+}
+
 async function replaceSearchConsoleDay(day, db = pool) {
     const client = await db.connect();
     try {
@@ -56,6 +85,11 @@ async function replaceSearchConsoleDay(day, db = pool) {
             [day.dataDate, day.searchType]
         );
         await insertBreakdowns(client, day);
+        await client.query(
+            'DELETE FROM search_console_query_pages WHERE data_date = $1 AND search_type = $2',
+            [day.dataDate, day.searchType]
+        );
+        await insertQueryPages(client, day);
         await client.query('COMMIT');
     } catch (err) {
         await client.query('ROLLBACK');
@@ -97,12 +131,13 @@ async function getSearchGrowthReportData(db = pool) {
         return {
             latestDate: null, lastSyncedAt: null, daily: [], summary: null,
             topQueries: [], topPages: [], zeroClickQueries: [], pageOpportunities: [],
-            countries: [], devices: [], routes: []
+            queryPageOpportunities: [], countries: [], devices: [], routes: []
         };
     }
     const [
         dailyResult, summaryResult, topQueries, topPages, zeroClickQueries,
-        pageOpportunitiesResult, countries, devices, routesResult
+        pageOpportunitiesResult, queryPageOpportunitiesResult,
+        countries, devices, routesResult
     ] = await Promise.all([
         db.query(`
             SELECT data_date::text, clicks, impressions, ctr, position
@@ -145,25 +180,52 @@ async function getSearchGrowthReportData(db = pool) {
             ORDER BY impressions DESC, clicks, value
             LIMIT 50
         `, [latestDate]),
+        db.query(`
+            WITH latest AS (SELECT $1::date AS d)
+            SELECT query_text AS query, page_url AS page,
+                   sum(clicks)::float8 AS clicks,
+                   sum(impressions)::float8 AS impressions,
+                   CASE WHEN sum(impressions) = 0 THEN 0
+                        ELSE sum(clicks) / sum(impressions) END::float8 AS ctr,
+                   CASE WHEN sum(impressions) = 0 THEN 0
+                        ELSE sum(position * impressions) / sum(impressions) END::float8 AS position
+            FROM search_console_query_pages, latest
+            WHERE search_type = 'web'
+              AND data_date BETWEEN latest.d - 27 AND latest.d
+            GROUP BY query_text, page_url
+            HAVING sum(impressions) >= 5
+               AND sum(position * impressions) / nullif(sum(impressions), 0) BETWEEN 1 AND 20
+               AND sum(clicks) / nullif(sum(impressions), 0) < 0.01
+            ORDER BY impressions DESC, clicks, query_text, page_url
+            LIMIT 100
+        `, [latestDate]),
         aggregateBreakdown(db, 'country', { limit: 15 }),
         aggregateBreakdown(db, 'device', { limit: 10 }),
         db.query(`
-            WITH latest AS (SELECT $1::date AS d), grouped AS (
+            WITH latest AS (SELECT $1::date AS d), page_totals AS (
                 SELECT CASE
-                    WHEN value ~ '/places/[^/?#]+' THEN 'Place pages'
-                    WHEN value ~ '/datasets/[^/?#]+' THEN 'Dataset pages'
-                    WHEN value ~ '/resources/[^/?#]+' THEN 'Resource pages'
-                    WHEN value ~ '/insights/?([?#].*)?$' THEN 'Insights'
-                    ELSE 'Other pages' END AS value,
-                    clicks, impressions, position
-                FROM search_console_breakdowns, latest
-                WHERE search_type = 'web' AND dimension = 'page'
-                  AND data_date BETWEEN latest.d - 27 AND latest.d
+                    WHEN scb.value ~ '/places/[^/?#]+' THEN 'Place pages'
+                    WHEN scb.value ~ '/datasets/[^/?#]+' THEN 'Dataset pages'
+                    WHEN scb.value ~ '/resources/[^/?#]+' THEN 'Resource pages'
+                    WHEN scb.value ~ '/insights/?([?#].*)?$' THEN 'Insights'
+                    ELSE 'Other pages' END AS family,
+                    scb.value AS page,
+                    sum(scb.clicks)::float8 AS clicks,
+                    sum(scb.impressions)::float8 AS impressions,
+                    sum(scb.position * scb.impressions)::float8 AS position_weight
+                FROM search_console_breakdowns scb, latest
+                WHERE scb.search_type = 'web' AND scb.dimension = 'page'
+                  AND scb.data_date BETWEEN latest.d - 27 AND latest.d
+                GROUP BY 1, scb.value
             )
-            SELECT value, sum(clicks)::float8 AS clicks, sum(impressions)::float8 AS impressions,
+            SELECT family AS value,
+                   count(*)::int AS pages_with_impressions,
+                   count(*) FILTER (WHERE clicks > 0)::int AS pages_with_clicks,
+                   sum(clicks)::float8 AS clicks,
+                   sum(impressions)::float8 AS impressions,
                    CASE WHEN sum(impressions) = 0 THEN 0 ELSE sum(clicks) / sum(impressions) END::float8 AS ctr,
-                   CASE WHEN sum(impressions) = 0 THEN 0 ELSE sum(position * impressions) / sum(impressions) END::float8 AS position
-            FROM grouped GROUP BY value ORDER BY clicks DESC, impressions DESC
+                   CASE WHEN sum(impressions) = 0 THEN 0 ELSE sum(position_weight) / sum(impressions) END::float8 AS position
+            FROM page_totals GROUP BY family ORDER BY impressions DESC, clicks DESC
         `, [latestDate])
     ]);
     const summary = summaryResult.rows[0];
@@ -178,6 +240,7 @@ async function getSearchGrowthReportData(db = pool) {
         topPages,
         zeroClickQueries,
         pageOpportunities: pageOpportunitiesResult.rows,
+        queryPageOpportunities: queryPageOpportunitiesResult.rows,
         countries,
         devices,
         routes: routesResult.rows
@@ -187,6 +250,7 @@ async function getSearchGrowthReportData(db = pool) {
 module.exports = {
     latestSearchConsoleDate,
     insertBreakdowns,
+    insertQueryPages,
     replaceSearchConsoleDay,
     aggregateBreakdown,
     getSearchGrowthReportData

--- a/server/routes/seo.js
+++ b/server/routes/seo.js
@@ -10,5 +10,6 @@ router.get('/sitemap.xml', sitemap.sitemapIndex);
 router.get('/sitemap-pages.xml', sitemap.sitemapPages);
 router.get('/sitemap-places.xml', sitemap.sitemapPlaces);
 router.get('/sitemap-datasets-:n.xml', sitemap.sitemapDatasets);
+router.get('/sitemap-resources-:n.xml', sitemap.sitemapResources);
 
 module.exports = router;

--- a/server/scripts/sync-search-console.js
+++ b/server/scripts/sync-search-console.js
@@ -43,11 +43,14 @@ async function main() {
             endDate,
             logger: message => console.log(message)
         });
-        rowCount = result.breakdownRows;
+        rowCount = result.breakdownRows + result.queryPageRows;
         if (result.truncated.length) {
             console.warn('Search Console row cap reached:', JSON.stringify(result.truncated));
         }
-        console.log('synced ' + result.days + ' days and ' + result.breakdownRows + ' breakdown rows');
+        console.log(
+            'synced ' + result.days + ' days, ' + result.breakdownRows +
+            ' breakdown rows, and ' + result.queryPageRows + ' query-page rows'
+        );
         ok = true;
     } catch (err) {
         error = err.message;

--- a/server/services/searchConsoleService.js
+++ b/server/services/searchConsoleService.js
@@ -1,4 +1,5 @@
 const DIMENSIONS = ['query', 'page', 'country', 'device'];
+const QUERY_PAGE_DIMENSIONS = ['query', 'page'];
 const ROW_LIMIT = 25000;
 const MAX_ROWS = 50000;
 const SEARCH_TYPE = 'web';
@@ -56,9 +57,31 @@ async function requestWithRetry(request, options, { retries = 3, sleep = (ms) =>
     }
 }
 
-async function querySlice(request, { siteUrl, dataDate, dimension = null, sleep }) {
+function normalizeDimensions(dimension, dimensions) {
+    if (dimension !== null && dimensions !== null) {
+        throw new Error('use either dimension or dimensions, not both');
+    }
+    const values = dimensions === null
+        ? (dimension === null ? [] : [dimension])
+        : dimensions;
+    if (!Array.isArray(values) || values.some(value => !DIMENSIONS.includes(value))) {
+        throw new Error('unsupported Search Console dimension');
+    }
+    if (new Set(values).size !== values.length) {
+        throw new Error('duplicate Search Console dimension');
+    }
+    return values;
+}
+
+async function querySlice(request, {
+    siteUrl,
+    dataDate,
+    dimension = null,
+    dimensions = null,
+    sleep
+}) {
     validateDate(dataDate);
-    if (dimension !== null && !DIMENSIONS.includes(dimension)) throw new Error('unsupported Search Console dimension');
+    const groupBy = normalizeDimensions(dimension, dimensions);
     const rows = [];
     const url = API_ROOT + encodeURIComponent(siteUrl) + '/searchAnalytics/query';
     for (let startRow = 0; startRow < MAX_ROWS; startRow += ROW_LIMIT) {
@@ -70,7 +93,7 @@ async function querySlice(request, { siteUrl, dataDate, dimension = null, sleep 
             rowLimit: ROW_LIMIT,
             startRow
         };
-        if (dimension) body.dimensions = [dimension];
+        if (groupBy.length) body.dimensions = groupBy;
         const response = await requestWithRetry(request, { url, method: 'POST', data: body }, { sleep });
         const page = Array.isArray(response?.data?.rows) ? response.data.rows : [];
         rows.push(...page);
@@ -102,24 +125,49 @@ async function collectDay(request, { siteUrl, dataDate, sleep }) {
             breakdowns.push({ dimension, value: String(value), ...metricRow(row) });
         }
     }
-    return { dataDate, searchType: SEARCH_TYPE, total, breakdowns, truncated };
+    const queryPageResult = await querySlice(request, {
+        siteUrl,
+        dataDate,
+        dimensions: QUERY_PAGE_DIMENSIONS,
+        sleep
+    });
+    if (queryPageResult.truncated) truncated.push('query+page');
+    const queryPages = queryPageResult.rows.flatMap(row => {
+        const query = row?.keys?.[0];
+        const page = row?.keys?.[1];
+        if (query == null || query === '' || page == null || page === '') return [];
+        return [{ query: String(query), page: String(page), ...metricRow(row) }];
+    });
+    return {
+        dataDate,
+        searchType: SEARCH_TYPE,
+        total,
+        breakdowns,
+        queryPages,
+        truncated
+    };
 }
 
 async function syncRange({ db, request, siteUrl, startDate, endDate, logger = () => {}, sleep }) {
-    const summary = { days: 0, breakdownRows: 0, truncated: [] };
+    const summary = { days: 0, breakdownRows: 0, queryPageRows: 0, truncated: [] };
     for (const dataDate of dateRange(startDate, endDate)) {
         const day = await collectDay(request, { siteUrl, dataDate, sleep });
         await db.replaceSearchConsoleDay(day);
         summary.days += 1;
         summary.breakdownRows += day.breakdowns.length;
+        summary.queryPageRows += day.queryPages.length;
         if (day.truncated.length) summary.truncated.push({ dataDate, dimensions: day.truncated });
-        logger('synced ' + dataDate + ': ' + day.breakdowns.length + ' breakdown rows');
+        logger(
+            'synced ' + dataDate + ': ' + day.breakdowns.length +
+            ' breakdown rows, ' + day.queryPages.length + ' query-page rows'
+        );
     }
     return summary;
 }
 
 module.exports = {
     DIMENSIONS,
+    QUERY_PAGE_DIMENSIONS,
     ROW_LIMIT,
     MAX_ROWS,
     SEARCH_TYPE,
@@ -127,6 +175,7 @@ module.exports = {
     addDays,
     pacificDate,
     dateRange,
+    normalizeDimensions,
     requestWithRetry,
     querySlice,
     metricRow,

--- a/server/services/searchGrowthReport.js
+++ b/server/services/searchGrowthReport.js
@@ -63,6 +63,27 @@ function table(title, rows, { valueLabel = 'Value', limit = 20 } = {}) {
         : '<p class="empty">No data yet.</p>') + '</section>';
 }
 
+function queryPageTable(rows, limit = 50) {
+    const body = rows.slice(0, limit).map(row => '<tr><td class="text" title="' +
+        escapeHtml(row.query) + '">' + escapeHtml(row.query) + '</td><td class="text" title="' +
+        escapeHtml(row.page) + '">' + escapeHtml(row.page) + '</td><td>' + number(row.clicks) +
+        '</td><td>' + number(row.impressions) + '</td><td>' + percent(row.ctr) + '</td><td>' +
+        number(row.position, 1) + '</td></tr>').join('');
+    return '<section class="panel"><h2>Query-to-page opportunities</h2>' + (body
+        ? '<div class="table-wrap"><table><thead><tr><th class="text">Query</th><th class="text">Page</th><th>Clicks</th><th>Impressions</th><th>CTR</th><th>Position</th></tr></thead><tbody>' + body + '</tbody></table></div>'
+        : '<p class="empty">No query-to-page opportunities yet.</p>') + '</section>';
+}
+
+function routeTable(rows) {
+    const body = rows.map(row => '<tr><td>' + escapeHtml(row.value) + '</td><td>' +
+        number(row.pages_with_impressions) + '</td><td>' + number(row.pages_with_clicks) +
+        '</td><td>' + number(row.clicks) + '</td><td>' + number(row.impressions) +
+        '</td><td>' + percent(row.ctr) + '</td><td>' + number(row.position, 1) + '</td></tr>').join('');
+    return '<section class="panel"><h2>Page-family visibility</h2>' + (body
+        ? '<div class="table-wrap"><table><thead><tr><th>Route group</th><th>Visible pages</th><th>Pages with clicks</th><th>Clicks</th><th>Impressions</th><th>CTR</th><th>Position</th></tr></thead><tbody>' + body + '</tbody></table></div>'
+        : '<p class="empty">No page visibility data yet.</p>') + '</section>';
+}
+
 function renderSearchGrowthReport(data, generatedAt = new Date()) {
     const stale = data.lastSyncedAt && generatedAt.getTime() - new Date(data.lastSyncedAt).getTime() > 48 * 60 * 60 * 1000;
     const status = !data.latestDate ? 'No imported data' : stale ? 'Import may be stale' : 'Import current';
@@ -78,7 +99,7 @@ function renderSearchGrowthReport(data, generatedAt = new Date()) {
         '<meta name="robots" content="noindex,nofollow,noarchive">' +
         '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; style-src \'unsafe-inline\'; img-src data:">' +
         '<title>canquery search growth</title><style>' +
-        ':root{color-scheme:dark;font-family:Inter,system-ui,sans-serif;background:#090e17;color:#e9f2ff}*{box-sizing:border-box}body{margin:0;padding:32px}main{max-width:1180px;margin:auto}h1,h2{font-family:system-ui,sans-serif}h1{margin:0;font-size:2rem}h2{font-size:1.05rem;margin:0 0 16px}.meta{color:#91a0b8;font-size:.84rem;margin:8px 0 24px}.status{display:inline-block;border:1px solid #2dd4bf55;color:#5eead4;border-radius:999px;padding:4px 9px;margin-left:8px}.metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}.metric,.panel{background:#111a28;border:1px solid #ffffff14;border-radius:14px;padding:18px}.metric span,.metric small{display:block;color:#91a0b8;font-size:.78rem}.metric strong{display:block;font-size:1.8rem;margin:8px 0}.delta{color:#b7c2d3}.delta.up{color:#5eead4}.delta.down{color:#ff958c}.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px}.panel{margin-top:16px;overflow:hidden}.grid .panel{margin-top:0}.table-wrap{overflow:auto}table{width:100%;border-collapse:collapse;font-size:.82rem}th,td{text-align:right;padding:8px;border-bottom:1px solid #ffffff10;white-space:nowrap}th:first-child,td:first-child{text-align:left;max-width:430px;overflow:hidden;text-overflow:ellipsis}th{color:#91a0b8;font-weight:600}.empty{color:#91a0b8}svg{width:100%;height:auto}.trend{fill:none;stroke:#d52b1e;stroke-width:3;stroke-linejoin:round;stroke-linecap:round}.axis{stroke:#ffffff22}svg text{fill:#91a0b8;font-size:11px}@media(max-width:800px){body{padding:18px}.metrics,.grid{grid-template-columns:1fr 1fr}}@media(max-width:520px){.metrics,.grid{grid-template-columns:1fr}}' +
+        ':root{color-scheme:dark;font-family:Inter,system-ui,sans-serif;background:#090e17;color:#e9f2ff}*{box-sizing:border-box}body{margin:0;padding:32px}main{max-width:1180px;margin:auto}h1,h2{font-family:system-ui,sans-serif}h1{margin:0;font-size:2rem}h2{font-size:1.05rem;margin:0 0 16px}.meta{color:#91a0b8;font-size:.84rem;margin:8px 0 24px}.status{display:inline-block;border:1px solid #2dd4bf55;color:#5eead4;border-radius:999px;padding:4px 9px;margin-left:8px}.metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:12px}.metric,.panel{background:#111a28;border:1px solid #ffffff14;border-radius:14px;padding:18px}.metric span,.metric small{display:block;color:#91a0b8;font-size:.78rem}.metric strong{display:block;font-size:1.8rem;margin:8px 0}.delta{color:#b7c2d3}.delta.up{color:#5eead4}.delta.down{color:#ff958c}.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-top:16px}.panel{margin-top:16px;overflow:hidden}.grid .panel{margin-top:0}.table-wrap{overflow:auto}table{width:100%;border-collapse:collapse;font-size:.82rem}th,td{text-align:right;padding:8px;border-bottom:1px solid #ffffff10;white-space:nowrap}th:first-child,td:first-child,th.text,td.text{text-align:left;max-width:430px;overflow:hidden;text-overflow:ellipsis}th{color:#91a0b8;font-weight:600}.empty{color:#91a0b8}svg{width:100%;height:auto}.trend{fill:none;stroke:#d52b1e;stroke-width:3;stroke-linejoin:round;stroke-linecap:round}.axis{stroke:#ffffff22}svg text{fill:#91a0b8;font-size:11px}@media(max-width:800px){body{padding:18px}.metrics,.grid{grid-template-columns:1fr 1fr}}@media(max-width:520px){.metrics,.grid{grid-template-columns:1fr}}' +
         '</style></head><body><main><h1>Search growth</h1><p class="meta">Private canquery operator report. Finalized through ' +
         escapeHtml(data.latestDate || 'none') + '. Generated ' + escapeHtml(generatedAt.toISOString()) +
         '. <span class="status">' + escapeHtml(status) + '</span></p><section class="metrics">' + metrics +
@@ -87,10 +108,21 @@ function renderSearchGrowthReport(data, generatedAt = new Date()) {
         table('Top pages: 28 days', data.topPages || [], { valueLabel: 'Page' }) + '</div><div class="grid">' +
         table('Zero-click opportunities', data.zeroClickQueries || [], { valueLabel: 'Query' }) +
         table('High-impression, low-CTR pages', data.pageOpportunities || [], { valueLabel: 'Page', limit: 50 }) +
-        '</div><div class="grid">' + table('Page families', data.routes || [], { valueLabel: 'Route group' }) +
+        '</div>' + queryPageTable(data.queryPageOpportunities || []) +
+        '<div class="grid">' + routeTable(data.routes || []) +
         table('Countries', data.countries || [], { valueLabel: 'Country', limit: 15 }) + '</div><div class="grid">' +
         table('Devices', data.devices || [], { valueLabel: 'Device', limit: 10 }) +
         '</div></main></body></html>';
 }
 
-module.exports = { escapeHtml, number, percent, change, trendSvg, table, renderSearchGrowthReport };
+module.exports = {
+    escapeHtml,
+    number,
+    percent,
+    change,
+    trendSvg,
+    table,
+    queryPageTable,
+    routeTable,
+    renderSearchGrowthReport
+};

--- a/server/sql/migrations/031_search_console_query_pages.sql
+++ b/server/sql/migrations/031_search_console_query_pages.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS search_console_query_pages (
+    data_date date NOT NULL,
+    search_type text NOT NULL,
+    query_text text NOT NULL CHECK (query_text <> ''),
+    page_url text NOT NULL CHECK (page_url <> ''),
+    clicks double precision NOT NULL DEFAULT 0,
+    impressions double precision NOT NULL DEFAULT 0,
+    ctr double precision NOT NULL DEFAULT 0,
+    position double precision NOT NULL DEFAULT 0,
+    synced_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (data_date, search_type, query_text, page_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_console_query_pages_type_date
+    ON search_console_query_pages(search_type, data_date DESC);
+CREATE INDEX IF NOT EXISTS idx_search_console_query_pages_page_date
+    ON search_console_query_pages(page_url, data_date DESC);


### PR DESCRIPTION
## Summary
- publish capability-gated resource sitemap chunks for live tables and maps
- persist aggregate Search Console query-to-page attribution
- extend the private growth report with page-family coverage and targeted opportunities

## Verification
- server ESLint
- 62 server suites / 530 tests passed (PostGIS-only suite intentionally skipped)
- client ESLint
- 27 client files / 114 tests passed
- Vite production build