### PR TITLE
Complete v38 crawlable discovery and search reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - run: npm run build
 
   spatial:
-    name: spatial (PostGIS migrations + viewport)
+    name: database (PostGIS + search reporting)
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -74,4 +74,4 @@ jobs:
           cache-dependency-path: server/package-lock.json
       - run: npm ci
       - run: npm run migrate
-      - run: npx jest __tests__/spatialIntegration.test.js --runInBand
+      - run: npx jest __tests__/spatialIntegration.test.js __tests__/searchConsoleIntegration.test.js --runInBand

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ curl -X POST 'http://localhost:3100/api/v1/resources/<id>/ingest'
 curl 'http://localhost:3100/api/v1/jobs/<jobId>'
 
 curl 'http://localhost:3100/api/v1/organizations?limit=10'
+curl 'http://localhost:3100/api/v1/organizations/<name>'
 curl 'http://localhost:3100/api/v1/stats'
 
 # the live Top 100 Downloaded Datasets leaderboard (period + ranked items)

--- a/client/index.html
+++ b/client/index.html
@@ -17,18 +17,18 @@
     <!-- analytics:config -->
     <script type="module" src="/src/analytics-init.js"></script>
     <!-- seo:start -->
-    <title>canquery - query Canada's open data</title>
-    <meta name="description" content="Search every dataset on open.canada.ca, load CSV and Excel files into live tables, then filter, chart and export them. No signup." />
+    <title>CanQuery: Canadian open data search, tables &amp; maps</title>
+    <meta name="description" content="Search Canadian open data by place, load CSV and Excel files into live tables, and explore spatial data on a map. No signup." />
     <link rel="canonical" href="https://canquery.com/" />
-    <meta property="og:title" content="canquery - query Canada's open data" />
-    <meta property="og:description" content="Search every dataset on open.canada.ca, load CSV and Excel files into live tables, then filter, chart and export them." />
+    <meta property="og:title" content="CanQuery: Canadian open data search, tables &amp; maps" />
+    <meta property="og:description" content="Search Canadian open data by place, load CSV and Excel files into live tables, and explore spatial data on a map. No signup." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://canquery.com/" />
-    <meta property="og:site_name" content="canquery" />
+    <meta property="og:site_name" content="CanQuery" />
     <meta property="og:image" content="https://canquery.com/og-image.svg" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="canquery - query Canada's open data" />
-    <meta name="twitter:description" content="Search every dataset on open.canada.ca, load CSV and Excel files into live tables, then filter, chart and export them." />
+    <meta name="twitter:title" content="CanQuery: Canadian open data search, tables &amp; maps" />
+    <meta name="twitter:description" content="Search Canadian open data by place, load CSV and Excel files into live tables, and explore spatial data on a map. No signup." />
     <meta name="twitter:image" content="https://canquery.com/og-image.svg" />
     <!-- seo:end -->
   </head>

--- a/client/public/og-image.svg
+++ b/client/public/og-image.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="canquery - query Canada's open data">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="CanQuery: Canadian open data search, tables and maps">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#0a0e16"/>

--- a/client/public/site.webmanifest
+++ b/client/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "canquery",
+  "name": "CanQuery",
   "short_name": "canquery",
-  "description": "Query Canada's open data.",
+  "description": "Search Canada's open data, query live tables, and explore maps.",
   "icons": [
     {
       "src": "/android-chrome-192.png",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,11 +6,13 @@ import HomePage from './pages/HomePage'
 import DatasetPage from './pages/DatasetPage'
 import ResourcePage from './pages/ResourcePage'
 import OrganizationsPage from './pages/OrganizationsPage'
+import OrganizationPage from './pages/OrganizationPage'
 import DocsPage from './pages/DocsPage'
 import PlacesPage from './pages/PlacesPage'
 import PlacePage from './pages/PlacePage'
 import PrivacyPage from './pages/PrivacyPage'
 import AnalyticsBridge from './components/AnalyticsBridge.jsx'
+import RouteHead from './components/RouteHead.jsx'
 import { MapleLeaf } from './components/Icons.jsx'
 import { useLang } from './i18n.jsx'
 
@@ -43,6 +45,7 @@ export default function App() {
   return (
     <div className="min-h-screen flex flex-col text-base-content">
       <ScrollToTop />
+      <RouteHead />
       <AnalyticsBridge />
       <Navbar />
       <main className="flex-1 w-full">
@@ -53,6 +56,7 @@ export default function App() {
             <Route path="/datasets/:idOrName" element={<DatasetPage />} />
             <Route path="/resources/:id" element={<ResourcePage />} />
             <Route path="/organizations" element={<OrganizationsPage />} />
+            <Route path="/organizations/:name" element={<OrganizationPage />} />
             <Route path="/places" element={<PlacesPage />} />
             <Route path="/places/:slug" element={<PlacePage />} />
             <Route path="/docs" element={<DocsPage />} />

--- a/client/src/api/catalog.js
+++ b/client/src/api/catalog.js
@@ -32,6 +32,10 @@ export function fetchOrganizations({ place, source, limit, cursor } = {}) {
   return getJSON('/api/v1/organizations', { place, source, limit, cursor });
 }
 
+export function fetchOrganization(name) {
+  return getJSON('/api/v1/organizations/' + encodeURIComponent(name));
+}
+
 export function fetchPlaces({ q, kind, parent, featured, limit, cursor } = {}) {
   return getJSON('/api/v1/places', { q, kind, parent, featured, limit, cursor });
 }

--- a/client/src/components/DatasetRow.jsx
+++ b/client/src/components/DatasetRow.jsx
@@ -9,7 +9,7 @@ export default function DatasetRow({ dataset }) {
   const place = dataset.place_match?.place || dataset.places?.[0];
   const source = dataset.provenance?.sources?.[0];
   const modifiedDate = dataset.metadata_modified
-    ? new Date(dataset.metadata_modified).toLocaleDateString()
+    ? new Date(dataset.metadata_modified).toLocaleDateString(lang === 'fr' ? 'fr-CA' : 'en-CA')
     : null;
 
   return (
@@ -21,8 +21,8 @@ export default function DatasetRow({ dataset }) {
       data-analytics-dataset-slug={dataset.name || ''}
       data-analytics-source="catalog_result"
     >
-      <div className="flex justify-between items-center gap-4">
-        <div className="min-w-0">
+      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
+        <div className="min-w-0 sm:flex-1">
           <div className="font-semibold text-[0.95rem] leading-snug line-clamp-2 group-hover:text-base-content transition-colors">
             {title}
           </div>
@@ -49,13 +49,13 @@ export default function DatasetRow({ dataset }) {
             {source && <span className="truncate">{source.name?.[lang] || source.name?.en || source.id}</span>}
           </div>
         </div>
-        <div className="flex items-center gap-2 shrink-0">
+        <div className="flex flex-wrap items-center gap-2 shrink-0">
           <span className="cq-chip">
-            {dataset.resource_count} {t('row.resources')}
+            {dataset.resource_count.toLocaleString(lang === 'fr' ? 'fr-CA' : 'en-CA')} {t('row.resources')}
           </span>
           {dataset.queryable_count > 0 && (
             <span className="cq-chip cq-chip-red">
-              {dataset.queryable_count} {t('row.queryable')}
+              {dataset.queryable_count.toLocaleString(lang === 'fr' ? 'fr-CA' : 'en-CA')} {t('row.queryable')}
             </span>
           )}
           {dataset.mappable_count > 0 && (

--- a/client/src/components/RouteHead.jsx
+++ b/client/src/components/RouteHead.jsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { clearRouteHead, readSeoElements, replaceSeoHead } from '../utils/routeHead.js';
+
+export default function RouteHead() {
+  const { pathname } = useLocation();
+  const previousPath = useRef(pathname);
+  const siteOrigin = useRef(new URL(
+    document.querySelector('link[rel="canonical"]')?.href || window.location.href
+  ).origin);
+
+  useEffect(() => {
+    // The initial response already contains the authoritative server head.
+    if (previousPath.current === pathname) return;
+    previousPath.current = pathname;
+    const controller = new AbortController();
+    let disposed = false;
+    const timeout = setTimeout(() => controller.abort(), 10000);
+
+    fetch(pathname, {
+      signal: controller.signal,
+      credentials: 'same-origin',
+      headers: { Accept: 'text/html' },
+    })
+      .then(async response => {
+        if (![200, 404, 503].includes(response.status) ||
+            !response.headers.get('content-type')?.includes('text/html')) {
+          throw new Error('No usable page metadata');
+        }
+        const html = await response.text();
+        const elements = readSeoElements(html, response.url);
+        if (!disposed && !controller.signal.aborted) replaceSeoHead(elements);
+      })
+      .catch(() => {
+        if (!disposed) clearRouteHead(pathname, siteOrigin.current);
+      })
+      .finally(() => clearTimeout(timeout));
+
+    return () => {
+      disposed = true;
+      clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [pathname]);
+
+  return null;
+}

--- a/client/src/components/RouteHead.test.jsx
+++ b/client/src/components/RouteHead.test.jsx
@@ -1,0 +1,101 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Link, MemoryRouter, useNavigate } from 'react-router-dom';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import RouteHead from './RouteHead.jsx';
+
+function seo(path, title, extra = '') {
+  return '<!-- seo:start --><title>' + title + '</title>' +
+    '<link rel="canonical" href="https://canquery.com' + path + '">' +
+    '<script type="application/ld+json">{"name":"' + title + '"}</script>' + extra + '<!-- seo:end -->';
+}
+
+function response(path, title, status = 200, extra = '') {
+  return {
+    status, url: 'https://canquery.com' + path,
+    headers: new Headers({ 'content-type': 'text/html; charset=utf-8' }),
+    text: async () => '<html><head>' + seo(path, title, extra) + '</head></html>',
+  };
+}
+
+function Navigation() {
+  const navigate = useNavigate();
+  return <><RouteHead />
+    <Link to="/datasets/roads">Dataset</Link>
+    <Link to="/resources/r1">Resource</Link>
+    <Link to="/resources/r1?sort=name#table">Sort</Link>
+    <button onClick={() => navigate(-1)}>Back</button>
+  </>;
+}
+
+beforeEach(() => {
+  document.head.innerHTML = '<meta name="cq-analytics" content="preserve">' +
+    seo('/organizations/city', 'City') + '<link rel="stylesheet" href="/assets/app.css">';
+  vi.stubGlobal('fetch', vi.fn().mockImplementation(async path =>
+    response(path, path.startsWith('/datasets') ? 'Roads' : 'Resource')));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  document.head.innerHTML = '';
+});
+
+function start() {
+  render(<MemoryRouter initialEntries={['/organizations/city']}><Navigation /></MemoryRouter>);
+}
+
+test('updates title, canonical and schema through navigation and Back without touching assets or analytics', async () => {
+  start();
+  expect(fetch).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByText('Dataset'));
+  await waitFor(() => expect(document.title).toBe('Roads'));
+  expect(document.querySelector('link[rel=canonical]').href).toBe('https://canquery.com/datasets/roads');
+  expect(JSON.parse(document.querySelector('script[type="application/ld+json"]').textContent).name).toBe('Roads');
+  fireEvent.click(screen.getByText('Resource'));
+  await waitFor(() => expect(document.title).toBe('Resource'));
+  fireEvent.click(screen.getByText('Sort'));
+  expect(fetch).toHaveBeenCalledTimes(2);
+  fireEvent.click(screen.getByText('Back'));
+  fireEvent.click(screen.getByText('Back'));
+  await waitFor(() => expect(document.title).toBe('Roads'));
+  expect(document.querySelectorAll('title')).toHaveLength(1);
+  expect(document.querySelectorAll('link[rel=canonical]')).toHaveLength(1);
+  expect(document.querySelector('meta[name=cq-analytics]').content).toBe('preserve');
+  expect(document.querySelector('link[rel=stylesheet]')).not.toBeNull();
+});
+
+test('aborts obsolete navigation and ignores a late response even when transport ignores abort', async () => {
+  let finishOld;
+  fetch.mockImplementationOnce(() => new Promise(resolve => { finishOld = resolve; }));
+  start();
+  fireEvent.click(screen.getByText('Dataset'));
+  const oldSignal = fetch.mock.calls[0][1].signal;
+  fireEvent.click(screen.getByText('Resource'));
+  await waitFor(() => expect(document.title).toBe('Resource'));
+  expect(oldSignal.aborted).toBe(true);
+  await act(async () => finishOld(response('/datasets/roads', 'Stale roads')));
+  expect(document.title).toBe('Resource');
+});
+
+test.each([404, 503])('uses the server noindex response for status %i', async status => {
+  fetch.mockResolvedValue(response('/datasets/roads', 'Unavailable', status, '<meta name="robots" content="noindex">'));
+  start();
+  fireEvent.click(screen.getByText('Dataset'));
+  await waitFor(() => expect(document.title).toBe('Unavailable'));
+  expect(document.querySelector('meta[name=robots]').content).toBe('noindex');
+});
+
+test.each(['network', 'mismatched canonical', 'malformed schema'])('clears stale identity after %s', async mode => {
+  if (mode === 'network') fetch.mockRejectedValue(new Error('offline'));
+  if (mode === 'mismatched canonical') {
+    fetch.mockResolvedValue({ ...response('/organizations/city', 'Wrong'), url: 'https://canquery.com/datasets/roads' });
+  }
+  if (mode === 'malformed schema') fetch.mockResolvedValue(response('/datasets/roads', 'Roads', 200,
+    '<script type="application/ld+json">invalid</script>'));
+  start();
+  fireEvent.click(screen.getByText('Dataset'));
+  await waitFor(() => expect(document.title).toBe('CanQuery'));
+  expect(document.querySelector('link[rel=canonical]').href).toBe('https://canquery.com/datasets/roads');
+  expect(document.querySelector('script[type="application/ld+json"]')).toBeNull();
+  expect(document.querySelector('meta[name=robots]')).toBeNull();
+});

--- a/client/src/i18n.jsx
+++ b/client/src/i18n.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-refresh/only-export-components -- context module: provider + hook + strings belong together */
-import { createContext, useContext, useState, useCallback } from 'react';
+import { createContext, useContext, useState, useCallback, useEffect } from 'react';
 
 // Every user-facing chrome string lives here. Dataset/resource CONTENT is
 // already bilingual from the catalogue; this covers the interface around it,
@@ -88,11 +88,19 @@ export const STRINGS = {
     'dataset.download': 'Download',
     'orgs.filter_placeholder': 'Filter organizations...',
     'orgs.loading': 'Loading organizations',
+    'orgs.loading_one': 'Loading organization',
     'orgs.datasets': 'datasets',
+    'orgs.publisher': 'Open data publisher',
+    'orgs.queryable': 'queryable',
+    'orgs.mappable': 'mappable',
+    'orgs.has_map': 'Has a map',
+    'orgs.dataset_list': 'Published datasets',
+    'orgs.no_datasets': 'No datasets matched your search.',
     'common.back_search': 'Back to search',
     'common.not_found': 'Page not found',
     'common.dataset_not_found': 'Dataset not found',
     'common.resource_not_found': 'Resource not found',
+    'common.organization_not_found': 'Organization not found',
     'common.updated': 'Updated',
     'common.explore': 'Explore data',
     'common.retry': 'Retry',
@@ -248,6 +256,8 @@ export const STRINGS = {
     'docs.ep_query_csv': 'Download the current query (same q, filters and sort parameters) as a CSV file, capped at 10,000 rows.',
     'docs.ep_datasets': 'Full-text search over the catalogue. Params: q, org, format, keyword, place, source, mappable, limit, cursor.',
     'docs.ep_places': 'Places backed by open datasets. Search by q, kind or parent, or pass featured=true for featured regions and cities. Counts distinguish direct publishing from inherited broader-area coverage.',
+    'docs.ep_organizations': 'Public-sector publishers with dataset counts. Filter by place or source and paginate with limit and cursor.',
+    'docs.ep_organization_detail': 'One publisher with total, queryable and mappable dataset counts plus its associated place.',
     'docs.ep_sources': 'Source portals and their current total and authoritative dataset counts. Pass place to see only authoritative portals relevant to one municipality or region.',
     'docs.ep_map': 'Bounded GeoJSON for one spatial resource, served from its official ArcGIS layer or CanQuery’s local PostGIS index. bbox is west,south,east,north; zoom controls geometry simplification; limit is capped at 1,000.',
     'docs.ep_dataset_detail': 'Dataset detail with resources tagged by query_mode: datastore, ingested, ingestable or file-only.',
@@ -342,11 +352,19 @@ export const STRINGS = {
     'dataset.download': 'Télécharger',
     'orgs.filter_placeholder': 'Filtrer les organisations...',
     'orgs.loading': 'Chargement des organisations',
+    'orgs.loading_one': 'Chargement de l’organisation',
     'orgs.datasets': 'jeux de données',
+    'orgs.publisher': 'Diffuseur de données ouvertes',
+    'orgs.queryable': 'interrogeables',
+    'orgs.mappable': 'cartographiables',
+    'orgs.has_map': 'Avec une carte',
+    'orgs.dataset_list': 'Jeux de données publiés',
+    'orgs.no_datasets': 'Aucun jeu de données ne correspond à votre recherche.',
     'common.back_search': 'Retour à la recherche',
     'common.not_found': 'Page introuvable',
     'common.dataset_not_found': 'Jeu de données introuvable',
     'common.resource_not_found': 'Ressource introuvable',
+    'common.organization_not_found': 'Organisation introuvable',
     'common.updated': 'Mis à jour',
     'common.explore': 'Explorer les données',
     'common.retry': 'Réessayer',
@@ -502,6 +520,8 @@ export const STRINGS = {
     'docs.ep_query_csv': 'Téléchargez la requête actuelle (mêmes paramètres q, filters et sort) sous forme de fichier CSV, limité à 10 000 lignes.',
     'docs.ep_datasets': 'Recherche plein texte dans le catalogue. Paramètres : q, org, format, keyword, place, source, mappable, limit, cursor.',
     'docs.ep_places': 'Lieux associés à des données ouvertes. Recherchez par q, kind ou parent, ou passez featured=true pour les régions et villes en vedette. Les totaux distinguent la publication directe de la couverture héritée d’une zone plus vaste.',
+    'docs.ep_organizations': 'Diffuseurs du secteur public avec le nombre de jeux de données. Filtrez par lieu ou source et paginez avec limit et cursor.',
+    'docs.ep_organization_detail': 'Un diffuseur avec le nombre total de jeux de données, ceux qui sont interrogeables et cartographiables, ainsi que son lieu associé.',
     'docs.ep_sources': 'Portails sources et nombres totaux et officiels de jeux de données. Passez place pour voir uniquement les portails officiels pertinents pour une municipalité ou une région.',
     'docs.ep_map': 'GeoJSON limité pour une ressource spatiale, servi depuis sa couche ArcGIS officielle ou l’index PostGIS local de CanQuery. bbox vaut ouest,sud,est,nord; zoom contrôle la simplification; limit est plafonné à 1 000.',
     'docs.ep_dataset_detail': 'Détail d’un jeu de données, avec les ressources étiquetées par query_mode : datastore, ingested, ingestable ou file-only.',
@@ -531,6 +551,7 @@ export function LangProvider({ children }) {
       return 'en';
     }
   });
+  useEffect(() => { document.documentElement.lang = lang; }, [lang]);
   const setLang = useCallback((next) => {
     setLangState(next);
     try {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -710,6 +710,76 @@ a.cq-card:hover,
   overflow-wrap: anywhere;
 }
 
+/* Server-rendered, user-agent-neutral crawl snapshot. React replaces this
+   bounded fallback as soon as the interactive application starts. */
+.cq-seo-snapshot article {
+  max-width: 52rem;
+  margin-top: 1.5rem;
+}
+.cq-seo-snapshot nav ol {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.6rem;
+  color: color-mix(in oklab, var(--color-base-content) 52%, transparent);
+  font-size: 0.8rem;
+}
+.cq-seo-snapshot nav li:not(:last-child)::after {
+  content: '/';
+  margin-left: 0.6rem;
+  opacity: 0.45;
+}
+.cq-seo-snapshot h1 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 700;
+  line-height: 1.08;
+}
+.cq-seo-snapshot h2 {
+  margin-top: 2rem;
+  font-family: var(--font-display);
+  font-size: 1.15rem;
+  font-weight: 650;
+}
+.cq-seo-snapshot p {
+  margin-top: 1rem;
+  color: color-mix(in oklab, var(--color-base-content) 72%, transparent);
+  line-height: 1.7;
+}
+.cq-seo-snapshot dl {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  margin-top: 1.25rem;
+}
+.cq-seo-snapshot dl div {
+  border: 1px solid color-mix(in oklab, var(--color-base-content) 12%, transparent);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.8rem;
+}
+.cq-seo-snapshot dt {
+  color: color-mix(in oklab, var(--color-base-content) 48%, transparent);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+.cq-seo-snapshot dd {
+  margin: 0.2rem 0 0;
+}
+.cq-seo-snapshot ul {
+  display: grid;
+  gap: 0.6rem;
+  margin-top: 0.85rem;
+}
+.cq-seo-snapshot a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+.cq-seo-snapshot li span {
+  color: color-mix(in oklab, var(--color-base-content) 45%, transparent);
+  font-size: 0.78rem;
+}
+
 /* ------------------------------------------------------------ motion */
 
 @keyframes cq-fade-up {

--- a/client/src/pages/DatasetPage.jsx
+++ b/client/src/pages/DatasetPage.jsx
@@ -221,10 +221,13 @@ function DatasetExplorer({ idOrName }) {
 
       <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm text-base-content/55">
         {dataset.organization && (
-          <span className="inline-flex items-center gap-1.5">
+          <Link
+            to={'/organizations/' + encodeURIComponent(dataset.organization.name)}
+            className="inline-flex items-center gap-1.5 hover:text-base-content"
+          >
             <BuildingIcon size={14} />
             {pick(dataset.organization.title)}
-          </span>
+          </Link>
         )}
         {dataset.metadata_modified && (
           <span className="inline-flex items-center gap-1.5">

--- a/client/src/pages/DatasetPage.test.jsx
+++ b/client/src/pages/DatasetPage.test.jsx
@@ -47,6 +47,22 @@ beforeEach(() => {
 });
 
 describe('DatasetPage ingestion', () => {
+  test('links the publisher to its canonical organization page', async () => {
+    const env = datasetEnvelope('datastore');
+    env.data.organization = { name: 'city-works', title: { en: 'City Works', fr: null } };
+    fetchDataset.mockReset();
+    fetchDataset.mockResolvedValue(env);
+
+    render(
+      <MemoryRouter initialEntries={['/datasets/dataset-a']}>
+        <Routes><Route path="/datasets/:idOrName" element={<DatasetPage />} /></Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('link', { name: 'City Works' }))
+      .toHaveAttribute('href', '/organizations/city-works');
+  });
+
   test.each([
     ['en', 'Breadcrumb', 'Datasets', 'Dataset A'],
     ['fr', 'Fil d’Ariane', 'Jeux de données', 'Jeu de données A'],

--- a/client/src/pages/DocsPage.jsx
+++ b/client/src/pages/DocsPage.jsx
@@ -127,6 +127,19 @@ export default function DocsPage() {
         />
         <Endpoint
           method="GET"
+          path="/api/v1/organizations"
+          desc={t('docs.ep_organizations')}
+          example={'curl "' + BASE + '/api/v1/organizations?limit=10"'}
+          runPath="/api/v1/organizations?limit=3"
+        />
+        <Endpoint
+          method="GET"
+          path="/api/v1/organizations/:name"
+          desc={t('docs.ep_organization_detail')}
+          example={'curl "' + BASE + '/api/v1/organizations/ORGANIZATION_NAME"'}
+        />
+        <Endpoint
+          method="GET"
           path="/api/v1/sources"
           desc={t('docs.ep_sources')}
           example={'curl "' + BASE + '/api/v1/sources?place=toronto-on"'}

--- a/client/src/pages/OrganizationPage.jsx
+++ b/client/src/pages/OrganizationPage.jsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { fetchOrganization, searchDatasets } from '../api/catalog.js';
+import { NotFoundError } from '../api/client.js';
+import useDebouncedValue from '../hooks/useDebouncedValue.js';
+import usePaginatedCollection from '../hooks/usePaginatedCollection.js';
+import { track } from '../utils/analytics.js';
+import { useLang } from '../i18n.jsx';
+import SearchBar from '../components/SearchBar.jsx';
+import DatasetRow from '../components/DatasetRow.jsx';
+import LoadingSpinner from '../components/LoadingSpinner.jsx';
+import Breadcrumbs from '../components/Breadcrumbs.jsx';
+import { BuildingIcon, MapIcon, MapPinIcon, TableIcon } from '../components/Icons.jsx';
+
+export default function OrganizationPage() {
+  const { name } = useParams();
+  const { lang, t } = useLang();
+  const [organization, setOrganization] = useState(null);
+  const [query, setQuery] = useState('');
+  const [mappable, setMappable] = useState(false);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState(null);
+  const debouncedQuery = useDebouncedValue(query, 250);
+
+  useEffect(() => {
+    let cancelled = false;
+    setOrganization(null);
+    setNotFound(false);
+    setError(null);
+    fetchOrganization(name)
+      .then(env => {
+        if (cancelled) return;
+        setOrganization(env.data);
+        track('organization_open', {
+          organization: env.data.name,
+          dataset_count: env.data.dataset_count,
+          source: 'page',
+        });
+      })
+      .catch(err => {
+        if (cancelled) return;
+        if (err instanceof NotFoundError) setNotFound(true);
+        else setError(err);
+      });
+    return () => { cancelled = true; };
+  }, [name]);
+
+  useEffect(() => {
+    if (debouncedQuery) {
+      track('catalog_filter', {
+        filter: 'organization_search',
+        value: debouncedQuery,
+        organization: name,
+      });
+    }
+  }, [debouncedQuery, name]);
+
+  const { items, loading, loadingMore, error: searchError, hasMore, loadMore } = usePaginatedCollection(
+    cursor => searchDatasets({
+      q: debouncedQuery || undefined,
+      org: name,
+      mappable: mappable || undefined,
+      limit: 20,
+      cursor,
+    }),
+    [name, debouncedQuery, mappable]
+  );
+
+  if (notFound) {
+    return <div className="text-center py-28"><h1 className="text-2xl font-bold font-display">{t('common.organization_not_found')}</h1></div>;
+  }
+  if (error) return <div className="max-w-5xl mx-auto px-4 py-8"><div className="alert alert-error">{error.message}</div></div>;
+  if (!organization) return <LoadingSpinner label={t('orgs.loading_one')} />;
+
+  const title = organization.title?.[lang] || organization.title?.en || organization.title?.fr || organization.name;
+  const locale = lang === 'fr' ? 'fr-CA' : 'en-CA';
+
+  return (
+    <div className="max-w-6xl mx-auto px-4 py-8 cq-fade">
+      <Breadcrumbs
+        className="mb-5"
+        label={t('breadcrumbs.label')}
+        items={[
+          { label: t('nav.organizations'), to: '/organizations' },
+          { label: title },
+        ]}
+      />
+
+      <div className="cq-card p-6 sm:p-8 overflow-hidden relative">
+        <div className="absolute inset-0 cq-grid-bg opacity-40 pointer-events-none" />
+        <div className="relative">
+          <span className="cq-chip"><BuildingIcon size={12} />{t('orgs.publisher')}</span>
+          <h1 className="text-3xl sm:text-4xl font-bold font-display mt-3">{title}</h1>
+          <div className="flex flex-wrap gap-2 mt-4">
+            <span className="cq-chip cq-chip-mono">{organization.dataset_count.toLocaleString(locale)} {t('orgs.datasets')}</span>
+            <span className="cq-chip cq-chip-red"><TableIcon size={11} />{organization.queryable_dataset_count.toLocaleString(locale)} {t('orgs.queryable')}</span>
+            <span className="cq-chip cq-chip-teal"><MapIcon size={11} />{organization.mappable_dataset_count.toLocaleString(locale)} {t('orgs.mappable')}</span>
+          </div>
+          {organization.place && (
+            <Link
+              to={'/places/' + organization.place.slug}
+              className="inline-flex items-center gap-1.5 text-sm text-base-content/60 hover:text-base-content mt-4"
+            >
+              <MapPinIcon size={13} />
+              {organization.place.name?.[lang] || organization.place.name?.en || organization.place.slug}
+            </Link>
+          )}
+        </div>
+      </div>
+
+      <div className="grid sm:grid-cols-[minmax(0,1fr)_auto] gap-3 mt-8">
+        <SearchBar value={query} onChange={setQuery} />
+        <button
+          className={'cq-pill justify-center inline-flex items-center gap-1.5' + (mappable ? ' cq-pill-active' : '')}
+          onClick={() => setMappable(value => {
+            track('catalog_filter', { filter: 'mappable', value: !value, organization: name });
+            return !value;
+          })}
+          aria-pressed={mappable}
+        >
+          <MapIcon size={13} />{t('orgs.has_map')}
+        </button>
+      </div>
+
+      <section className="space-y-3 mt-6" aria-label={t('orgs.dataset_list')}>
+        {loading ? [...Array(5)].map((_, index) => <div className="cq-skel h-[82px]" key={index} />) :
+          searchError ? <div className="alert alert-error">{searchError.message}</div> :
+            items.length === 0 ? <div className="text-center py-14 text-base-content/50">{t('orgs.no_datasets')}</div> :
+              items.map(dataset => <DatasetRow key={dataset.id} dataset={dataset} />)}
+      </section>
+      {hasMore && (
+        <div className="text-center mt-6">
+          <button
+            className="btn btn-outline btn-sm rounded-full px-7"
+            onClick={() => {
+              track('catalog_filter', { action: 'load_more', organization: name });
+              loadMore();
+            }}
+            disabled={loadingMore}
+          >
+            {loadingMore ? t('home.loading') : t('home.load_more')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/OrganizationPage.test.jsx
+++ b/client/src/pages/OrganizationPage.test.jsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import OrganizationPage from './OrganizationPage.jsx';
+import { LangProvider } from '../i18n.jsx';
+
+vi.mock('../api/catalog.js', () => ({
+  fetchOrganization: vi.fn(),
+  searchDatasets: vi.fn(),
+}));
+import { fetchOrganization, searchDatasets } from '../api/catalog.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  fetchOrganization.mockResolvedValue({ data: {
+    id: 'o1', name: 'city-works',
+    title: { en: 'City Works', fr: 'Travaux municipaux' },
+    dataset_count: 23, queryable_dataset_count: 4, mappable_dataset_count: 8,
+    place: { id: 'p1', slug: 'example-on', name: { en: 'Example', fr: 'Exemple' } },
+  } });
+  searchDatasets.mockResolvedValue({
+    data: [{
+      id: 'd1', name: 'roads', title: { en: 'Road network', fr: 'Réseau routier' },
+      organization: { name: 'city-works', title: { en: 'City Works', fr: 'Travaux municipaux' } },
+      resource_count: 2, queryable_count: 1, mappable_count: 1,
+      places: [], provenance: { sources: [] },
+    }],
+    pagination: { nextCursor: null },
+  });
+});
+
+describe('OrganizationPage', () => {
+  test('shows publisher capability counts, place context, and filtered datasets', async () => {
+    render(
+      <MemoryRouter initialEntries={['/organizations/city-works']}>
+        <Routes><Route path="/organizations/:name" element={<OrganizationPage />} /></Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'City Works' })).toBeInTheDocument();
+    const breadcrumb = screen.getByRole('navigation', { name: 'Breadcrumb' });
+    expect(within(breadcrumb).getByRole('link', { name: 'Organizations' })).toHaveAttribute('href', '/organizations');
+    expect(screen.getByText('23 datasets')).toBeInTheDocument();
+    expect(screen.getByText('4 queryable')).toBeInTheDocument();
+    expect(screen.getByText('8 mappable')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Example' })).toHaveAttribute('href', '/places/example-on');
+    expect(await screen.findByText('Road network')).toBeInTheDocument();
+    expect(searchDatasets).toHaveBeenCalledWith(expect.objectContaining({ org: 'city-works', limit: 20 }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Has a map' }));
+    await waitFor(() => expect(searchDatasets).toHaveBeenLastCalledWith(expect.objectContaining({
+      org: 'city-works', mappable: true
+    })));
+  });
+
+  test('keeps the interactive organization page bilingual', async () => {
+    localStorage.setItem('cq-lang', 'fr');
+    render(
+      <LangProvider>
+        <MemoryRouter initialEntries={['/organizations/city-works']}>
+          <Routes><Route path="/organizations/:name" element={<OrganizationPage />} /></Routes>
+        </MemoryRouter>
+      </LangProvider>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Travaux municipaux' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Exemple' })).toHaveAttribute('href', '/places/example-on');
+    expect(screen.getByRole('navigation', { name: 'Fil d’Ariane' })).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/OrganizationsPage.jsx
+++ b/client/src/pages/OrganizationsPage.jsx
@@ -12,12 +12,12 @@ function OrgCard({ org, t }) {
   return (
     <Link
       key={org.id}
-      to={'/?org=' + encodeURIComponent(org.name)}
+      to={'/organizations/' + encodeURIComponent(org.name)}
       title={'See every dataset from ' + title}
       className="cq-card p-4 flex items-center gap-3.5 group"
-      data-analytics-event="catalog_filter"
-      data-analytics-filter="organization"
-      data-analytics-value={org.name}
+      data-analytics-event="organization_open"
+      data-analytics-organization={org.name}
+      data-analytics-dataset-count={org.dataset_count}
       data-analytics-source="organization_card"
     >
       <span className="w-10 h-10 rounded-xl bg-accent/10 text-accent flex items-center justify-center font-display font-bold text-base shrink-0">

--- a/client/src/pages/ResourcePage.jsx
+++ b/client/src/pages/ResourcePage.jsx
@@ -39,6 +39,7 @@ import {
   LineChartIcon,
   FileIcon,
   MapIcon,
+  BuildingIcon,
 } from '../components/Icons.jsx';
 
 const PAGE_SIZE = 50;
@@ -413,6 +414,18 @@ function ResourceExplorer({ id }) {
               {t('resource.raw')}
             </a>
           </div>
+          {resource.dataset.organization && (
+            <Link
+              to={'/organizations/' + encodeURIComponent(resource.dataset.organization.name)}
+              className="inline-flex items-center gap-1.5 text-sm text-base-content/55 hover:text-base-content"
+            >
+              <BuildingIcon size={13} />
+              {resource.dataset.organization.title?.[lang] ||
+                resource.dataset.organization.title?.en ||
+                resource.dataset.organization.title?.fr ||
+                resource.dataset.organization.name}
+            </Link>
+          )}
           <Provenance provenance={resource.provenance} compact />
         </div>
       )}

--- a/client/src/utils/analytics.js
+++ b/client/src/utils/analytics.js
@@ -2,6 +2,7 @@ export const ANALYTICS_EVENTS = new Set([
   'catalog_search',
   'catalog_filter',
   'dataset_open',
+  'organization_open',
   'place_search',
   'place_open',
   'place_source_open',

--- a/client/src/utils/routeHead.js
+++ b/client/src/utils/routeHead.js
@@ -1,0 +1,64 @@
+function seoRange(doc) {
+  const nodes = Array.from(doc.head.childNodes);
+  const start = nodes.find(node => node.nodeType === 8 && node.data.trim() === 'seo:start');
+  const end = nodes.find(node => node.nodeType === 8 && node.data.trim() === 'seo:end');
+  if (!start || !end || nodes.indexOf(start) >= nodes.indexOf(end)) return null;
+  return { start, end, nodes: nodes.slice(nodes.indexOf(start) + 1, nodes.indexOf(end)) };
+}
+
+// Only the server-owned SEO block is copied. Analytics, assets, CSP and other
+// head elements remain owned by the original document.
+export function readSeoElements(html, responseUrl) {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  const range = seoRange(doc);
+  if (!range) throw new Error('Missing SEO block');
+  const elements = range.nodes.filter(node => {
+    if (node.nodeType !== 1) return false;
+    if (node.tagName === 'TITLE') return true;
+    if (node.tagName === 'LINK') return node.getAttribute('rel') === 'canonical';
+    if (node.tagName === 'META') {
+      return /^(description|robots|twitter:.+)$/.test(node.getAttribute('name') || '') ||
+        /^og:/.test(node.getAttribute('property') || '');
+    }
+    return node.tagName === 'SCRIPT' && node.getAttribute('type') === 'application/ld+json';
+  });
+  const titles = elements.filter(node => node.tagName === 'TITLE');
+  const canonicals = elements.filter(node => node.tagName === 'LINK');
+  if (titles.length !== 1 || !titles[0].textContent.trim() || canonicals.length !== 1) {
+    throw new Error('Invalid SEO identity');
+  }
+  const canonical = new URL(canonicals[0].getAttribute('href'), responseUrl);
+  if (!['http:', 'https:'].includes(canonical.protocol) ||
+      canonical.pathname !== new URL(responseUrl).pathname) {
+    throw new Error('SEO response belongs to a different page');
+  }
+  return elements.map(node => {
+    const copy = document.createElement(node.tagName.toLowerCase());
+    for (const name of ['name', 'content', 'property', 'rel', 'href', 'type']) {
+      if (node.hasAttribute(name)) copy.setAttribute(name, node.getAttribute(name));
+    }
+    if (node.tagName === 'SCRIPT') JSON.parse(node.textContent);
+    copy.textContent = node.textContent;
+    return copy;
+  });
+}
+
+export function replaceSeoHead(elements) {
+  const range = seoRange(document);
+  if (!range) return;
+  const fragment = document.createDocumentFragment();
+  for (const element of elements) fragment.append(element);
+  for (const node of range.nodes) node.remove();
+  range.end.before(fragment);
+}
+
+export function clearRouteHead(pathname, siteOrigin) {
+  const title = document.createElement('title');
+  title.textContent = 'CanQuery';
+  const canonical = document.createElement('link');
+  canonical.rel = 'canonical';
+  canonical.href = new URL(pathname, siteOrigin).href;
+  // A failed metadata fetch cannot justify retaining another entity's schema
+  // or declaring the current, potentially valid page permanently missing.
+  replaceSeoHead([title, canonical]);
+}

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -267,6 +267,21 @@ later runs replace a seven-day overlap atomically. Serve the file configured by
 initial import and protected report are verified, uncomment the 06:15 UTC sync
 and 06:30 UTC report entries.
 
+After an SEO-facing release, verify the response before asking Google to
+recrawl it. A canonical dataset, resource, place, and organization page must
+return HTTP 200 with a non-empty `data-cq-seo-snapshot`, one `<h1>`, one
+canonical link, and valid JSON-LD in the initial HTML. An alias should return
+301 to the canonical slug, an unknown route should return a noindex 404, and a
+catalogue lookup outage should return a noindex 503 with `Retry-After`.
+Confirm that `/sitemap.xml` includes the dataset, resource, place, and
+organization sitemap families. The installed read-only OAuth grant supports
+API URL inspection. Sitemap submission and requesting indexing require the
+owner-authenticated Search Console UI; retain the existing OAuth scope.
+Rebuild the private report after
+seven finalized days for crawl/indexing checks and compare the next complete
+28-day semantic-query cohort with the pre-release baseline; diagnostic UUID and
+`site:` traffic is retained in storage but excluded from the actionable table.
+
 Incremental sync advances its persisted checkpoint only after a complete
 overlap-window traversal. Reaching its safety page cap records an incomplete run
 and does not advance that checkpoint. A successful unlimited full sync also sweeps

--- a/deploy/RELEASE_RUNBOOK_v38.md
+++ b/deploy/RELEASE_RUNBOOK_v38.md
@@ -1,0 +1,93 @@
+# v38 search visibility closeout
+
+This release adds crawlable initial content and organization discovery, keeps
+page metadata current during client navigation, and separates semantic search
+opportunities from brand and diagnostic queries. It follows the first v38
+release (PR #38). Migration 031 belongs to that earlier release and must remain
+applied; this closeout introduces no migration.
+
+## Verification before deployment
+
+1. Preserve existing local work and prepare the release in an isolated worktree
+   based on current `main`. Keep raw catalogue/SEO fixtures and backup records
+   in a private evidence directory outside the public repository.
+2. Run `npm ci` in `server/` and `client/`, then `npm run verify --prefix server`.
+3. Use a disposable PostgreSQL 16/PostGIS 3.5 database. Set
+   `CANQUERY_DATABASE_URL` and `SPATIAL_TEST_DATABASE_URL` to that database,
+   run `npm run migrate --prefix server`, then run the spatial and Search Console
+   integration suites. CI repeats these checks, including migration 031
+   idempotence, query classification parity, report limits and publisher counts.
+4. Check canonical dataset, resource, place and organization pages with
+   JavaScript enabled and disabled. Require a single h1, canonical and valid
+   JSON-LD. Verify client navigation and Back update the title, canonical and
+   schema. Check French mobile layout and document language.
+5. Confirm aliases return 301 with query strings preserved; unknown routes
+   return 404/noindex; catalogue failures, including directory/preview queries,
+   return 503/noindex with `Retry-After: 60` and `Cache-Control: no-store`.
+6. Review the complete diff and merge only after all CI jobs pass. Record the
+   reviewed merge and pre-deployment commit in the private release manifest.
+
+## Production preflight and backups
+
+- Require a clean checkout, healthy database/upstream checks and active API,
+  ingest-worker and map-worker units. Record any existing source-job failures
+  separately from release regressions. Verify service-user ownership of Git,
+  dependencies and generated output before running Git or npm as that user.
+- Confirm migration 031 and both query-page reporting indexes exist. Do not
+  reverse or re-create this migration during the closeout.
+- Take fresh catalogue and analytics custom-format dumps under the existing
+  backup lock. Exclude only rebuildable `map_store.features` data. Validate
+  both with `pg_restore --list` before any production source or checkout write.
+- Encrypt both dumps with the existing private backup credential, copy to the
+  established off-host destination, and verify ciphertext hashes plus decrypted
+  plaintext hashes. Retain manifests privately and remove temporary plaintext
+  transport copies. Existing scheduled local retention continues unchanged.
+- Freeze the latest finalized Search Console 28-day report baseline. Keep
+  property totals separate from reported-query metrics and query-page pairs.
+
+## Source recovery, only when still needed
+
+If `source:red-deer-hub` remains failed, recover only that source:
+
+1. Capture one upstream catalogue snapshot and validate it with the configured
+   adapter. Dry-run that exact snapshot with catalogue comparison enabled.
+2. Require the expected source identity, nonzero admission, zero enrichment
+   failures and zero proposed dataset deletions. Independently compare admitted
+   resource IDs and map-job IDs against stored rows; require zero removals.
+3. Hold the existing municipal cron lock and a database transaction lock on
+   the affected catalogue tables while rechecking these assertions. Use the
+   same frozen snapshot for the write with `source.maxDeleteFraction = 0`.
+   Roll back the source transaction if any deletion assertion fails.
+4. Retain dry-run/write summaries, resource identity checks and before/after
+   health responses in the private release directory. Do not run a broad
+   municipal or federal sync or start a second map worker.
+
+## Deploy and public acceptance
+
+As the service user, fetch `origin`, fast-forward the clean checkout to the
+reviewed merge, run `npm ci` in both packages, and run the release verifier.
+Restart the API after the production bundle succeeds. Confirm the two existing
+worker services remain active; this release does not change their runtime
+behavior. Rebuild the private Search Console report with `npm run gsc:report`
+from `server/` using the existing read-only grant.
+
+Record production commit/cleanliness, unit states, `/healthz`, `/api/v1/ops`,
+stats and settled map queue counts. Repeat the canonical/alias/unknown-page
+checks against public HTTPS, validate all sitemap families including
+`sitemap-organizations.xml`, and test browser navigation against the deployed
+bundle. Never simulate a database outage in production.
+
+## Rollback and observation
+
+For an application regression, return the clean checkout to the recorded
+previous release, reinstall its locked dependencies, rebuild its client and
+restart the API. Retain migration 031, all catalogue rows, ingestion state and
+map data. A successful source-only recovery does not need to be reversed with
+an application rollback.
+
+Use read-only API URL inspection for representative dataset, resource, place
+and organization pages. The owner must submit the sitemap and request indexing
+through authenticated Search Console; keep the current OAuth scope. Compare
+the first seven finalized post-release days for crawl changes and the first
+complete 28-day cohort for semantic search visibility. These observations
+require elapsed time and must not be recorded as completed at deployment.

--- a/deploy/RELEASE_RUNBOOK_v38.md
+++ b/deploy/RELEASE_RUNBOOK_v38.md
@@ -54,8 +54,9 @@ If `source:red-deer-hub` remains failed, recover only that source:
 2. Require the expected source identity, nonzero admission, zero enrichment
    failures and zero proposed dataset deletions. Independently compare admitted
    resource IDs and map-job IDs against stored rows; require zero removals.
-3. Hold the existing municipal cron lock and a database transaction lock on
-   the affected catalogue tables while rechecking these assertions. Use the
+3. Run outside the municipal cron window and require no active municipal sync
+   process. Hold a database transaction lock on the affected catalogue tables
+   while rechecking these assertions. Use the
    same frozen snapshot for the write with `source.maxDeleteFraction = 0`.
    Roll back the source transaction if any deletion assertion fails.
 4. Retain dry-run/write summaries, resource identity checks and before/after

--- a/server/__tests__/catalogApi.test.js
+++ b/server/__tests__/catalogApi.test.js
@@ -5,6 +5,7 @@ jest.mock('../db/catalogReadQueries', () => ({
     listResourcesForDataset: jest.fn(),
     getResourceById: jest.fn(),
     listOrganizations: jest.fn(),
+    getOrganizationByName: jest.fn(),
     getStats: jest.fn(),
     pingDb: jest.fn(),
     getLastSyncTime: jest.fn(),
@@ -144,6 +145,22 @@ describe('Catalog API', () => {
         }));
     });
 
+    it('GET /api/v1/resources/:id adds the parent publisher without changing resource fields', async () => {
+        queries.getResourceById.mockResolvedValue({
+            id: 'r1', dataset_id: 'd1', dataset_name: 'roads', dataset_title_en: 'Roads',
+            name_en: 'Road lines', format: 'GEOJSON', url: 'https://example.test/roads.geojson',
+            size_bytes: '1024', datastore_active: false, language: null, last_modified: null,
+            org_name: 'city-works', org_title_en: 'City Works', org_title_fr: null,
+            provenance_sources: [], places: []
+        });
+        const res = await request(app).get('/api/v1/resources/r1');
+        expect(res.status).toBe(200);
+        expect(res.body.data.name.en).toBe('Road lines');
+        expect(res.body.data.dataset.organization).toEqual({
+            name: 'city-works', title: { en: 'City Works', fr: null }
+        });
+    });
+
     it('GET /api/v1/stats wraps totals in the envelope', async () => {
         queries.getStats.mockResolvedValue({
             datasets: 10,
@@ -157,6 +174,29 @@ describe('Catalog API', () => {
         expect(res.status).toBe(200);
         expect(res.body.data.store_bytes).toBe(1234);
         expect(res.body.meta.source).toBe('canquery');
+    });
+
+    it('GET /api/v1/organizations/:name returns capability counts and place context', async () => {
+        queries.getOrganizationByName.mockResolvedValue({
+            id: 'o1', name: 'city-works', title_en: 'City Works', title_fr: 'Travaux municipaux',
+            dataset_count: '23', queryable_dataset_count: '4', mappable_dataset_count: '8',
+            metadata_modified: '2026-08-30T00:00:00Z',
+            place_id: 'p1', place_slug: 'example-on', place_name_en: 'Example', place_name_fr: 'Exemple'
+        });
+        const res = await request(app).get('/api/v1/organizations/city-works');
+        expect(res.status).toBe(200);
+        expect(res.body.data).toEqual(expect.objectContaining({
+            id: 'o1', name: 'city-works', dataset_count: 23,
+            queryable_dataset_count: 4, mappable_dataset_count: 8
+        }));
+        expect(res.body.data.place).toEqual(expect.objectContaining({ slug: 'example-on' }));
+    });
+
+    it('GET /api/v1/organizations/:name returns 404 for an unknown publisher', async () => {
+        queries.getOrganizationByName.mockResolvedValue(null);
+        const res = await request(app).get('/api/v1/organizations/unknown');
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('Organization not found');
     });
 
     it('healthz reports ok when db and upstream are reachable', async () => {

--- a/server/__tests__/searchConsoleIntegration.test.js
+++ b/server/__tests__/searchConsoleIntegration.test.js
@@ -1,0 +1,110 @@
+const { Pool } = require('pg');
+const fs = require('node:fs');
+const path = require('node:path');
+const { getSearchGrowthReportData, replaceSearchConsoleDay } = require('../db/searchConsoleQueries');
+const { getOrganizationByName } = require('../db/catalogReadQueries');
+const { classifySearchIntent, searchIntentSql } = require('../services/searchIntent');
+
+const databaseUrl = process.env.SPATIAL_TEST_DATABASE_URL;
+const integrationDescribe = databaseUrl ? describe : describe.skip;
+
+integrationDescribe('search visibility PostgreSQL integration', () => {
+    let admin;
+    let db;
+    const schema = 'search_test_' + process.pid + '_' + Date.now();
+    const org = schema + '_org';
+    const migration = name => fs.readFileSync(path.join(__dirname, '../sql/migrations', name), 'utf8');
+
+    beforeAll(async () => {
+        admin = new Pool({ connectionString: databaseUrl });
+        await admin.query('CREATE SCHEMA ' + schema);
+        db = new Pool({ connectionString: databaseUrl, options: '-c search_path=' + schema });
+        await db.query(migration('011_search_console.sql'));
+        await db.query(migration('031_search_console_query_pages.sql'));
+    });
+
+    afterAll(async () => {
+        if (admin) {
+            await admin.query('DELETE FROM resources WHERE dataset_id IN (SELECT id FROM datasets WHERE org_id = $1)', [org]);
+            await admin.query('DELETE FROM datasets WHERE org_id = $1', [org]);
+            await admin.query('DELETE FROM organizations WHERE id = $1', [org]);
+            await admin.query('DROP SCHEMA IF EXISTS ' + schema + ' CASCADE');
+        }
+        if (db) await db.end();
+        if (admin) await admin.end();
+    });
+
+    test('classifies queries identically in JavaScript and PostgreSQL', async () => {
+        const values = [null, '', ' ', '\t\n', '\uFEFF', '\u00a0', 'CANQUERY', 'Can Query roads',
+            'site :canquery.com', 'website:roads', 'canquery github', 'api data', 'éCan Queryé',
+            'water quality', '"1f3f08ee-5c60-4c8d-8b70-bd5f0350f5e8" csv',
+            'abcd12345678901234567890', 'canquery_road', 'canquery api docs'];
+        const result = await db.query('SELECT value, ' + searchIntentSql('value') +
+            ' AS intent FROM unnest($1::text[]) AS value', [values]);
+        expect(result.rows.map(row => row.intent)).toEqual(values.map(classifySearchIntent));
+    });
+
+    test('filters before report caps and counts full distinct query totals independently of query-page pairs', async () => {
+        const metric = { clicks: 0, impressions: 100, ctr: 0, position: 5 };
+        const diagnostic = Array.from({ length: 300 }, (_, i) => ({
+            dimension: 'query', value: 'site:canquery.com probe ' + i, ...metric
+        }));
+        const semantic = Array.from({ length: 30 }, (_, i) => ({
+            dimension: 'query', value: 'water quality ' + i, ...metric, impressions: 10
+        }));
+        const data = {
+            dataDate: '2026-09-01', searchType: 'web',
+            total: { ...metric, clicks: 4, impressions: 50000 },
+            breakdowns: [...diagnostic, ...semantic, { dimension: 'query', value: 'canquery', ...metric }],
+            queryPages: [...diagnostic, ...semantic].map(row => ({
+                query: row.value, page: 'https://canquery.com/datasets/roads', ...metric,
+                impressions: row.impressions
+            }))
+        };
+        data.queryPages.push({ query: semantic[0].value, page: 'https://canquery.com/resources/roads', ...metric });
+        await replaceSearchConsoleDay(data, db);
+        await replaceSearchConsoleDay({ ...data, dataDate: '2026-09-02', queryPages: [] }, db);
+        const report = await getSearchGrowthReportData(db);
+        expect(report.topQueries).toHaveLength(25);
+        expect(report.zeroClickQueries).toHaveLength(25);
+        expect(report.queryPageOpportunities).toHaveLength(31);
+        expect(report.topQueries.every(row => row.intent === 'semantic')).toBe(true);
+        expect(report.brandQueries).toHaveLength(1);
+        expect(report.queryIntentSummary.find(row => row.intent === 'semantic')).toMatchObject({
+            queries: 30, clicks: 0, impressions: 600
+        });
+        expect(report.queryIntentSummary.find(row => row.intent === 'diagnostic').queries).toBe(300);
+        expect(report.summary.current_impressions).toBe(100000);
+    });
+
+    test('reruns migration 031 without losing query pairs or uniqueness', async () => {
+        const before = await db.query('SELECT count(*)::int AS n FROM search_console_query_pages');
+        await db.query(migration('031_search_console_query_pages.sql'));
+        await db.query(migration('031_search_console_query_pages.sql'));
+        expect((await db.query('SELECT count(*)::int AS n FROM search_console_query_pages')).rows).toEqual(before.rows);
+        await expect(db.query(`INSERT INTO search_console_query_pages
+            (data_date, search_type, query_text, page_url)
+            SELECT data_date, search_type, query_text, page_url FROM search_console_query_pages LIMIT 1`))
+            .rejects.toMatchObject({ code: '23505' });
+        const indexes = await db.query('SELECT indexname FROM pg_indexes WHERE schemaname = $1', [schema]);
+        expect(indexes.rows.map(row => row.indexname)).toEqual(expect.arrayContaining([
+            'idx_search_console_query_pages_type_date', 'idx_search_console_query_pages_page_date'
+        ]));
+    });
+
+    test('counts publisher dataset capabilities once despite multiple qualifying resources', async () => {
+        await admin.query('INSERT INTO organizations (id, name, title_en) VALUES ($1, $1, $1)', [org]);
+        await admin.query(`INSERT INTO datasets (id, name, title_en, org_id)
+            VALUES ($1, $1, 'Roads', $3), ($2, $2, 'Downloads', $3)`, [org + '_d1', org + '_d2', org]);
+        for (const id of [org + '_r1', org + '_r2']) {
+            await admin.query(`INSERT INTO resources (id, dataset_id, format, url, datastore_active)
+                VALUES ($1, $2, 'CSV', 'https://example.test/data.csv', true)`, [id, org + '_d1']);
+            await admin.query(`INSERT INTO resource_maps (resource_id, provider, service_url, geometry_type)
+                VALUES ($1, 'arcgis', 'https://example.test/FeatureServer/0', 'point')`, [id]);
+        }
+        expect(await getOrganizationByName(org, admin)).toMatchObject({
+            name: org, dataset_count: 2, queryable_dataset_count: 1, mappable_dataset_count: 1
+        });
+        expect(await getOrganizationByName(org + '_missing', admin)).toBeNull();
+    });
+});

--- a/server/__tests__/searchConsoleQueries.test.js
+++ b/server/__tests__/searchConsoleQueries.test.js
@@ -54,7 +54,7 @@ it('surfaces high-impression, low-CTR dataset and resource pages in the report d
         value: 'https://canquery.com/resources/r1',
         clicks: 0, impressions: 200, ctr: 0, position: 5
     };
-    const db = { query: jest.fn()
+    const db = { query: jest.fn().mockResolvedValue({ rows: [] })
         .mockResolvedValueOnce({ rows: [{ latest_date: '2026-08-27', last_synced_at: '2026-08-29T00:00:00Z' }] })
         .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [{
@@ -77,6 +77,8 @@ it('surfaces high-impression, low-CTR dataset and resource pages in the report d
     const opportunitySql = db.query.mock.calls.find(call => call[0].includes('HAVING sum(impressions) >= 50'));
     expect(opportunitySql[0]).toContain("value ~ '/datasets/[^/?#]+'");
     expect(opportunitySql[0]).toContain("value ~ '/resources/[^/?#]+'");
+    expect(opportunitySql[0]).toContain("value ~ '/places/[^/?#]+'");
+    expect(opportunitySql[0]).toContain("value ~ '/organizations/[^/?#]+'");
 });
 
 it('returns query-to-page opportunities and per-family visible-page counts', async () => {
@@ -88,7 +90,7 @@ it('returns query-to-page opportunities and per-family visible-page counts', asy
         value: 'Resource pages', pages_with_impressions: 870, pages_with_clicks: 11,
         clicks: 16, impressions: 6269, ctr: 0.0026, position: 10.1
     };
-    const db = { query: jest.fn()
+    const db = { query: jest.fn().mockResolvedValue({ rows: [] })
         .mockResolvedValueOnce({ rows: [{ latest_date: '2026-08-27', last_synced_at: '2026-08-29T00:00:00Z' }] })
         .mockResolvedValueOnce({ rows: [] })
         .mockResolvedValueOnce({ rows: [{
@@ -107,7 +109,7 @@ it('returns query-to-page opportunities and per-family visible-page counts', asy
 
     const report = await queries.getSearchGrowthReportData(db);
 
-    expect(report.queryPageOpportunities).toEqual([pair]);
+    expect(report.queryPageOpportunities).toEqual([{ ...pair, intent: 'semantic' }]);
     expect(report.routes).toEqual([route]);
     const pairSql = db.query.mock.calls.find(call => call[0].includes('FROM search_console_query_pages'));
     expect(pairSql[0]).toContain('sum(impressions) >= 5');

--- a/server/__tests__/searchIntent.test.js
+++ b/server/__tests__/searchIntent.test.js
@@ -1,0 +1,29 @@
+const { classifySearchIntent, classifyRows, summarizeIntent } = require('../services/searchIntent');
+
+describe('Search Console intent classification', () => {
+    test.each([
+        ['positive labour market impact assessment list', 'semantic'],
+        ['uxbridge ward map', 'semantic'],
+        ['canquery', 'brand'],
+        ['Can Query Canadian data', 'brand'],
+        ['site:canquery.com "api docs" canquery', 'diagnostic'],
+        ['"1f3f08ee-5c60-4c8d-8b70-bd5f0350f5e8" csv', 'diagnostic'],
+        ['canquery github', 'diagnostic']
+    ])('classifies %s as %s', (query, expected) => {
+        expect(classifySearchIntent(query)).toBe(expected);
+    });
+
+    it('keeps raw rows while adding intent and summarizes their metrics', () => {
+        const rows = classifyRows([
+            { query: 'water data', clicks: 1, impressions: 10 },
+            { query: 'canquery', clicks: 2, impressions: 5 },
+            { query: 'site:canquery.com', clicks: 0, impressions: 20 }
+        ], 'query');
+        expect(rows.map(row => row.intent)).toEqual(['semantic', 'brand', 'diagnostic']);
+        const summary = summarizeIntent(rows);
+        expect(summary.find(row => row.intent === 'semantic')).toEqual(expect.objectContaining({
+            queries: 1, clicks: 1, impressions: 10, ctr: 0.1
+        }));
+        expect(summary.find(row => row.intent === 'diagnostic').impressions).toBe(20);
+    });
+});

--- a/server/__tests__/seoApi.test.js
+++ b/server/__tests__/seoApi.test.js
@@ -4,12 +4,15 @@ jest.mock('../db/catalogReadQueries', () => ({
     listResourcesForDataset: jest.fn(),
     getResourceById: jest.fn(),
     listOrganizations: jest.fn(),
+    listPlaces: jest.fn(),
+    getOrganizationByName: jest.fn(),
     getStats: jest.fn(),
     countSitemapDatasets: jest.fn(),
     listDatasetSitemap: jest.fn(),
     countSitemapResources: jest.fn(),
     listResourceSitemap: jest.fn(),
     listPlaceSitemap: jest.fn(),
+    listOrganizationSitemap: jest.fn(),
     getPlaceByIdOrSlug: jest.fn(),
     pingDb: jest.fn(),
     getLastSyncTime: jest.fn(),
@@ -21,11 +24,20 @@ jest.mock('../db/storeQueries', () => ({ queryStoreTable: jest.fn(), aggregateSt
 jest.mock('../db/queryLogQueries', () => ({ logQueryHit: jest.fn(() => Promise.resolve()), listPopularResources: jest.fn(), countOlderThan: jest.fn(), pruneOlderThan: jest.fn() }));
 
 const request = require('supertest');
+const express = require('express');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const catalogRead = require('../db/catalogReadQueries');
 const app = require('../app');
-const { resolveMeta, injectAnalytics } = require('../controllers/spaController');
+const { serveSpa, resolvePage, resolveMeta, injectAnalytics } = require('../controllers/spaController');
 
-beforeEach(() => { jest.clearAllMocks(); });
+beforeEach(() => {
+    jest.resetAllMocks();
+    catalogRead.searchDatasets.mockResolvedValue([]);
+    catalogRead.listOrganizations.mockResolvedValue([]);
+    catalogRead.listPlaces.mockResolvedValue([]);
+});
 
 describe('robots.txt', () => {
     it('allows all and points at the sitemap index', async () => {
@@ -46,6 +58,7 @@ describe('sitemap index', () => {
         expect(res.headers['content-type']).toMatch(/xml/);
         expect(res.text).toContain('<loc>https://canquery.com/sitemap-pages.xml</loc>');
         expect(res.text).toContain('<loc>https://canquery.com/sitemap-places.xml</loc>');
+        expect(res.text).toContain('<loc>https://canquery.com/sitemap-organizations.xml</loc>');
         expect(res.text).toContain('<loc>https://canquery.com/sitemap-datasets-1.xml</loc>');
         expect(res.text).toContain('<loc>https://canquery.com/sitemap-datasets-2.xml</loc>');
         expect(res.text).not.toContain('sitemap-datasets-3.xml');
@@ -168,6 +181,18 @@ describe('place sitemap', () => {
     });
 });
 
+describe('organization sitemap', () => {
+    it('emits canonical organization pages with their latest dataset modification', async () => {
+        catalogRead.listOrganizationSitemap.mockResolvedValue([
+            { name: 'city-works', metadata_modified: '2026-08-30T00:00:00Z' }
+        ]);
+        const res = await request(app).get('/sitemap-organizations.xml');
+        expect(res.status).toBe(200);
+        expect(res.text).toContain('<loc>https://canquery.com/organizations/city-works</loc>');
+        expect(res.text).toContain('<lastmod>2026-08-30T00:00:00.000Z</lastmod>');
+    });
+});
+
 describe('resolveMeta routing', () => {
     it('resolves a dataset via the DB and includes Dataset JSON-LD', async () => {
         const deps = {
@@ -177,7 +202,7 @@ describe('resolveMeta routing', () => {
         };
         const meta = await resolveMeta('/datasets/n1', deps);
         expect(deps.getDatasetByIdOrName).toHaveBeenCalledWith('n1');
-        expect(meta.title).toBe('T - canquery');
+        expect(meta.title).toBe('T - CanQuery');
         expect(meta.jsonLd[0]['@type']).toBe('Dataset');
     });
 
@@ -202,17 +227,20 @@ describe('resolveMeta routing', () => {
             listResourcesForDataset: jest.fn(),
         };
         const meta = await resolveMeta('/resources/r1', deps);
-        expect(meta.title).toBe('DS (CSV) - canquery');
+        expect(meta.title).toBe('DS (CSV) - CanQuery');
         expect(meta.canonical).toBe('https://canquery.com/resources/r1');
-        expect(meta.jsonLd[0].itemListElement[1].item).toBe('https://canquery.com/datasets/dataset-slug');
+        const breadcrumb = meta.jsonLd.find(item => item['@type'] === 'BreadcrumbList');
+        expect(breadcrumb.itemListElement[1].item).toBe('https://canquery.com/datasets/dataset-slug');
     });
 
     it('resolves a place page from its stable slug', async () => {
         const deps = {
             getPlaceByIdOrSlug: jest.fn().mockResolvedValue({
                 id: 'ca-on-oshawa', slug: 'oshawa-on', name_en: 'Oshawa', type_en: 'City',
+                dataset_count: 10, mappable_dataset_count: 4,
                 ancestors: [{ id: 'ca-on-oshawa', slug: 'oshawa-on', name_en: 'Oshawa' }]
-            })
+            }),
+            searchDatasets: jest.fn().mockResolvedValue([])
         };
         const meta = await resolveMeta('/places/oshawa-on', deps);
         expect(deps.getPlaceByIdOrSlug).toHaveBeenCalledWith('oshawa-on');
@@ -226,5 +254,138 @@ describe('resolveMeta routing', () => {
         const meta = await resolveMeta('/', deps);
         expect(meta.jsonLd.some((o) => o['@type'] === 'WebSite')).toBe(true);
         expect(deps.getDatasetByIdOrName).not.toHaveBeenCalled();
+    });
+});
+
+describe('resolvePage crawl responses', () => {
+    it('returns a canonical dataset path and meaningful initial HTML', async () => {
+        const deps = {
+            getDatasetByIdOrName: jest.fn().mockResolvedValue({
+                id: 'd1', name: 'roads', title_en: 'Road network', notes_en: 'Public road geometry.',
+                org_name: 'city-works', org_title_en: 'City Works', places: []
+            }),
+            listResourcesForDataset: jest.fn().mockResolvedValue([{
+                id: 'r1', name_en: 'Road lines', format: 'GEOJSON', url: 'https://example.test/roads.geojson',
+                map_provider: 'arcgis'
+            }])
+        };
+        const page = await resolvePage('/datasets/d1', deps);
+        expect(page.status).toBe(200);
+        expect(page.canonicalPath).toBe('/datasets/roads');
+        expect(page.body).toContain('<h1>Road network</h1>');
+        expect(page.body).toContain('/resources/r1');
+        expect(page.body).toContain('/organizations/city-works');
+    });
+
+    it('resolves organization pages with datasets and CollectionPage metadata', async () => {
+        const deps = {
+            getOrganizationByName: jest.fn().mockResolvedValue({
+                id: 'o1', name: 'city-works', title_en: 'City Works',
+                dataset_count: 4, queryable_dataset_count: 2, mappable_dataset_count: 1
+            }),
+            searchDatasets: jest.fn().mockResolvedValue([{ id: 'd1', name: 'roads', title_en: 'Roads' }])
+        };
+        const page = await resolvePage('/organizations/city-works', deps);
+        expect(page.status).toBe(200);
+        expect(page.canonicalPath).toBe('/organizations/city-works');
+        expect(page.body).toContain('<h1>City Works open data</h1>');
+        expect(page.meta.jsonLd.some(item => item['@type'] === 'CollectionPage')).toBe(true);
+    });
+
+    it('returns a real noindex 404 page model for unknown routes and entities', async () => {
+        const route = await resolvePage('/not-a-route', {});
+        expect(route.status).toBe(404);
+        expect(route.meta.noindex).toBe(true);
+        expect(route.body).toContain('<h1>Page not found</h1>');
+
+        const dataset = await resolvePage('/datasets/missing', {
+            getDatasetByIdOrName: jest.fn().mockResolvedValue(null)
+        });
+        expect(dataset.status).toBe(404);
+        expect(dataset.body).toContain('<h1>Dataset not found</h1>');
+    });
+});
+
+describe('production SPA response semantics', () => {
+    let distDir;
+    let spa;
+
+    beforeAll(() => {
+        distDir = fs.mkdtempSync(path.join(os.tmpdir(), 'canquery-seo-'));
+        fs.writeFileSync(path.join(distDir, 'index.html'),
+            '<!doctype html><html><head><!-- seo:start --><title>x</title><!-- seo:end -->' +
+            '<!-- analytics:config --></head><body><div id="root"></div></body></html>');
+        spa = express();
+        spa.get(/.*/, serveSpa(distDir));
+    });
+
+    afterAll(() => fs.rmSync(distDir, { recursive: true, force: true }));
+
+    it('301s aliases and trailing slashes while preserving the query string', async () => {
+        catalogRead.getDatasetByIdOrName.mockResolvedValue({
+            id: 'd1', name: 'roads', title_en: 'Roads', notes_en: 'Road data for public use.'
+        });
+        catalogRead.listResourcesForDataset.mockResolvedValue([]);
+        const alias = await request(spa).get('/datasets/d1?highlight=r1');
+        expect(alias.status).toBe(301);
+        expect(alias.headers.location).toBe('/datasets/roads?highlight=r1');
+
+        const slash = await request(spa).get('/docs/');
+        expect(slash.status).toBe(301);
+        expect(slash.headers.location).toBe('/docs');
+    });
+
+    it('serves semantic initial HTML with the canonical 200 response', async () => {
+        catalogRead.getDatasetByIdOrName.mockResolvedValue({
+            id: 'd1', name: 'roads', title_en: 'Roads', notes_en: 'Road data for public use.'
+        });
+        catalogRead.listResourcesForDataset.mockResolvedValue([]);
+        const res = await request(spa).get('/datasets/roads');
+        expect(res.status).toBe(200);
+        expect(res.text).toContain('<h1>Roads</h1>');
+        expect(res.text).toContain('data-cq-seo-snapshot="true"');
+        expect(res.text).toContain('<link rel="canonical" href="https://canquery.com/datasets/roads"');
+    });
+
+    it('returns noindex 404s and retryable 503s instead of soft 200 pages', async () => {
+        const missing = await request(spa).get('/not-a-route');
+        expect(missing.status).toBe(404);
+        expect(missing.text).toContain('name="robots" content="noindex');
+
+        catalogRead.getDatasetByIdOrName.mockRejectedValue(new Error('db unavailable'));
+        const log = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const unavailable = await request(spa).get('/datasets/roads');
+        log.mockRestore();
+        expect(unavailable.status).toBe(503);
+        expect(unavailable.headers['retry-after']).toBe('60');
+        expect(unavailable.headers['cache-control']).toBe('no-store');
+        expect(unavailable.text).toContain('<h1>Temporarily unavailable</h1>');
+    });
+
+    test.each([
+        ['/organizations', 'listOrganizations'],
+        ['/places', 'listPlaces'],
+        ['/organizations/city-works', 'searchDatasets'],
+        ['/places/example-on', 'searchDatasets']
+    ])('returns a retryable 503 when required catalogue data fails for %s', async (route, method) => {
+        catalogRead.getOrganizationByName.mockResolvedValue({ name: 'city-works', title_en: 'City Works' });
+        catalogRead.getPlaceByIdOrSlug.mockResolvedValue({ id: 'p1', slug: 'example-on', name_en: 'Example' });
+        catalogRead[method].mockRejectedValue(new Error('private database detail'));
+        const log = jest.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            const res = await request(spa).get(route);
+            expect(res.status).toBe(503);
+            expect(res.headers['retry-after']).toBe('60');
+            expect(res.text).toContain('name="robots" content="noindex');
+            expect(res.text).not.toContain('private database detail');
+        } finally {
+            log.mockRestore();
+        }
+    });
+
+    test.each(['/organizations', '/places'])('keeps an empty but available directory valid: %s', async route => {
+        const res = await request(spa).get(route);
+        expect(res.status).toBe(200);
+        expect(res.text).not.toContain('name="robots" content="noindex');
     });
 });

--- a/server/__tests__/seoMeta.test.js
+++ b/server/__tests__/seoMeta.test.js
@@ -7,6 +7,7 @@ describe('seoMeta - route classification', () => {
         expect(seo.classifyRoute('/resources/abc-123')).toEqual({ type: 'resource', id: 'abc-123' });
         expect(seo.classifyRoute('/insights')).toEqual({ type: 'insights' });
         expect(seo.classifyRoute('/organizations')).toEqual({ type: 'organizations' });
+        expect(seo.classifyRoute('/organizations/statcan')).toEqual({ type: 'organization', id: 'statcan' });
         expect(seo.classifyRoute('/places')).toEqual({ type: 'places' });
         expect(seo.classifyRoute('/places/oshawa-on')).toEqual({ type: 'place', id: 'oshawa-on' });
         expect(seo.classifyRoute('/docs')).toEqual({ type: 'docs' });
@@ -58,9 +59,10 @@ describe('seoMeta - dataset meta + JSON-LD', () => {
 
     it('builds an English-default title and slug canonical', () => {
         const meta = seo.datasetMeta(dataset, resources);
-        expect(meta.title).toBe('Water Quality - canquery');
+        expect(meta.title).toBe('Water Quality - CanQuery');
         expect(meta.canonical).toBe('https://canquery.com/datasets/water-quality');
-        expect(meta.description).toBe('Lake and river measurements.');
+        expect(meta.description).toContain('Lake and river measurements.');
+        expect(meta.description.length).toBeGreaterThanOrEqual(50);
     });
 
     it('emits a schema.org Dataset with licence, keywords and absolute distributions', () => {
@@ -69,6 +71,7 @@ describe('seoMeta - dataset meta + JSON-LD', () => {
         expect(ld['@type']).toBe('Dataset');
         expect(ld.url).toBe('https://canquery.com/datasets/water-quality');
         expect(ld.identifier).toBe('d1');
+        expect(ld.alternateName).toBe('Qualite de l eau');
         expect(ld.license).toContain('open-government-licence-canada');
         expect(ld.sameAs).toBe('https://open.canada.ca/data/en/dataset/d1');
         expect(ld.keywords).toEqual(['water', 'lakes', 'eau']); // deduped, both langs
@@ -81,7 +84,7 @@ describe('seoMeta - dataset meta + JSON-LD', () => {
 
     it('falls back to the French title when English is missing', () => {
         const meta = seo.datasetMeta({ ...dataset, title_en: null }, []);
-        expect(meta.title).toBe('Qualite de l eau - canquery');
+        expect(meta.title).toBe('Qualite de l eau - CanQuery');
     });
 
     it('uses the authoritative municipal source for licence, publisher and sameAs', () => {
@@ -115,7 +118,7 @@ describe('seoMeta - dataset meta + JSON-LD', () => {
             notes_en: 'A very long dataset description '.repeat(20)
         }, []);
         expect(meta.title.length).toBeLessThanOrEqual(80);
-        expect(meta.title).toMatch(/ - canquery$/);
+        expect(meta.title).toMatch(/ - CanQuery$/);
         expect(meta.description.length).toBeLessThanOrEqual(160);
         const breadcrumb = meta.jsonLd.find(item => item['@type'] === 'BreadcrumbList');
         expect(breadcrumb.itemListElement).toEqual([
@@ -135,13 +138,23 @@ describe('seoMeta - resource titles, capabilities and breadcrumbs', () => {
         format: 'CSV', size_bytes: 1024
     };
 
+    test.each([null, undefined, ''])('omits unknown size %s instead of inventing zero bytes', size => {
+        const meta = seo.resourceMeta({ ...base, size_bytes: size });
+        expect(meta.jsonLd.find(item => item['@type'] === 'WebPage').mainEntity.contentSize).toBeUndefined();
+    });
+
+    it('preserves an explicitly reported zero-byte file size', () => {
+        const meta = seo.resourceMeta({ ...base, size_bytes: 0 });
+        expect(meta.jsonLd.find(item => item['@type'] === 'WebPage').mainEntity.contentSize).toBe('0 bytes');
+    });
+
     it('falls back from generic resource names and appends a missing format once', () => {
         expect(seo.resourceMeta({ ...base, name_en: 'Dataset' }).title)
-            .toBe('Water Quality (CSV) - canquery');
+            .toBe('Water Quality (CSV) - CanQuery');
         expect(seo.resourceMeta({ ...base, name_en: 'Measurements CSV' }).title)
-            .toBe('Measurements CSV - canquery');
+            .toBe('Measurements CSV - CanQuery');
         expect(seo.resourceMeta({ ...base, name_en: 'English' }).title)
-            .toBe('Water Quality (CSV) - canquery');
+            .toBe('Water Quality (CSV) - CanQuery');
     });
 
     it('bounds long resource titles and descriptions', () => {
@@ -156,9 +169,9 @@ describe('seoMeta - resource titles, capabilities and breadcrumbs', () => {
     });
 
     test.each([
-        [{ ...base, ingest_status: 'ready' }, /live CSV table.*query, filter, chart and export/i],
-        [{ ...base, datastore_active: true }, /live CSV table.*query, filter, chart and export/i],
-        [base, /Load this CSV resource.*query, filter, chart and export/i],
+        [{ ...base, ingest_status: 'ready' }, /query, filter, chart and export.*live CSV table/i],
+        [{ ...base, datastore_active: true }, /query, filter, chart and export.*live CSV table/i],
+        [base, /Load this CSV resource.*live table.*query, filter, chart and export/i],
         [{ ...base, format: 'PDF', map_provider: 'arcgis' }, /interactive map.*original PDF file/i],
         [{ ...base, format: 'PDF' }, /metadata.*original PDF file.*public-sector publisher/i]
     ])('writes truthful capability-specific copy for %#', (resource, expected) => {
@@ -167,7 +180,8 @@ describe('seoMeta - resource titles, capabilities and breadcrumbs', () => {
 
     it('emits the stable dataset and UUID resource hierarchy', () => {
         const meta = seo.resourceMeta(base);
-        expect(meta.jsonLd[0].itemListElement).toEqual([
+        const breadcrumb = meta.jsonLd.find(item => item['@type'] === 'BreadcrumbList');
+        expect(breadcrumb.itemListElement).toEqual([
             expect.objectContaining({ position: 1, name: 'Datasets', item: 'https://canquery.com/' }),
             expect.objectContaining({
                 position: 2, name: 'Water Quality',
@@ -195,7 +209,7 @@ describe('seoMeta - site + static meta', () => {
     it('builds indexable metadata for place pages', () => {
         const meta = seo.placeMeta({
             id: 'sgc-cd-3506', slug: 'ottawa-on', name_en: 'Ottawa',
-            type_en: 'City', latitude: 45.4215, longitude: -75.6972,
+            type_en: 'City', latitude: 45.4215, longitude: -75.6972, dataset_count: 12,
             ancestors: [
                 { id: 'ca', slug: 'canada', name_en: 'Canada' },
                 { id: 'sgc-cd-3506', slug: 'ottawa-on', name_en: 'Ottawa' }
@@ -204,7 +218,8 @@ describe('seoMeta - site + static meta', () => {
         expect(meta.canonical).toBe('https://canquery.com/places/ottawa-on');
         expect(meta.jsonLd[0]['@type']).toBe('AdministrativeArea');
         expect(meta.jsonLd[0].geo.latitude).toBeCloseTo(45.4215);
-        expect(meta.jsonLd[1].itemListElement).toEqual([
+        const breadcrumb = meta.jsonLd.find(item => item['@type'] === 'BreadcrumbList');
+        expect(breadcrumb.itemListElement).toEqual([
             expect.objectContaining({ position: 1, name: 'Places', item: 'https://canquery.com/places' }),
             expect.objectContaining({ position: 2, name: 'Canada', item: 'https://canquery.com/places/canada' }),
             expect.objectContaining({ position: 3, name: 'Ottawa', item: 'https://canquery.com/places/ottawa-on' })
@@ -216,6 +231,11 @@ describe('seoMeta - site + static meta', () => {
         expect(seo.staticMeta('docs').title).toContain('API documentation');
         expect(seo.staticMeta('insights').title).toContain('Top 100');
         expect(seo.staticMeta('privacy').canonical).toBe('https://canquery.com/privacy');
+    });
+
+    it('keeps empty place and organization pages out of the index', () => {
+        expect(seo.placeMeta({ id: 'p0', slug: 'empty', name_en: 'Empty', dataset_count: 0 }).noindex).toBe(true);
+        expect(seo.organizationMeta({ id: 'o0', name: 'empty', title_en: 'Empty', dataset_count: 0 }).noindex).toBe(true);
     });
 
     it('unknown routes are marked noindex', () => {
@@ -231,7 +251,7 @@ describe('seoMeta - renderHtml injection', () => {
 
     it('replaces the managed block with escaped tags + JSON-LD', () => {
         const html = seo.renderHtml(template, seo.datasetMeta({ id: 'd', name: 'n', title_en: 'A & B <c>', notes_en: 'x' }, []));
-        expect(html).toContain('<title>A &amp; B &lt;c&gt; - canquery</title>');
+        expect(html).toContain('<title>A &amp; B - CanQuery</title>');
         expect(html).toContain('<link rel="canonical" href="https://canquery.com/datasets/n" />');
         expect(html).toContain('application/ld+json');
         expect(html).not.toContain('<title>default</title>');
@@ -257,7 +277,7 @@ describe('seoMeta - renderHtml injection', () => {
             []
         );
         const html = seo.renderHtml(template, meta);
-        expect(html).toContain('<title>Grants and Contributions ($&#39;000) - canquery</title>');
+        expect(html).toContain('<title>Grants and Contributions ($&#39;000) - CanQuery</title>');
         expect(html).toContain('Amounts in $&amp;thousands, per $`unit, paid in CA$$.');
         expect(html.match(/<title>/g)).toHaveLength(1);
         expect(html.match(/rel="canonical"/g)).toHaveLength(1);
@@ -267,5 +287,52 @@ describe('seoMeta - renderHtml injection', () => {
     it('returns the template untouched when the markers are absent', () => {
         const plain = '<html><head><title>x</title></head></html>';
         expect(seo.renderHtml(plain, seo.homeMeta())).toBe(plain);
+    });
+
+    it('injects a semantic crawl snapshot into the empty React root', () => {
+        const page = '<html><head><!-- seo:start --><!-- seo:end --></head><body><div id="root"></div></body></html>';
+        const html = seo.renderHtml(page, seo.homeMeta(), '<main><h1>Search open data</h1></main>');
+        expect(html).toContain('<div id="root"><main><h1>Search open data</h1></main></div>');
+    });
+});
+
+describe('seoMeta - content hygiene and organization pages', () => {
+    it('strips markup and makes short Dataset descriptions schema-eligible', () => {
+        const dataset = {
+            id: 'd1', name: 'roads', title_en: 'Roads', title_fr: 'Routes',
+            notes_en: '<p>Roads<br>updated</p><script>bad()</script>',
+            org_title_en: 'City Works'
+        };
+        const ld = seo.buildDatasetJsonLd(dataset, []);
+        expect(ld.description).toContain('Roads updated');
+        expect(ld.description).not.toContain('<');
+        expect(ld.description).not.toContain('bad()');
+        expect(ld.description.length).toBeGreaterThanOrEqual(50);
+    });
+
+    it('decodes common French entities and rejects non-HTTP distributions', () => {
+        expect(seo.plainText('Ville de Qu&eacute;bec &amp; L&eacute;vis')).toBe('Ville de Québec & Lévis');
+        const ld = seo.buildDatasetJsonLd({
+            id: 'd1', name: 'roads', title_en: 'Roads', notes_en: 'A sufficiently descriptive public road dataset for testing.'
+        }, [
+            { url: 'javascript:alert(1)', format: 'CSV' },
+            { url: 'https://example.test/roads.csv', format: 'CSV', size_bytes: 2048 }
+        ]);
+        expect(ld.distribution).toHaveLength(1);
+        expect(ld.distribution[0]).toEqual(expect.objectContaining({
+            contentUrl: 'https://example.test/roads.csv', contentSize: '2 KB'
+        }));
+    });
+
+    it('builds bounded organization metadata and CollectionPage schema', () => {
+        const meta = seo.organizationMeta({
+            id: 'o1', name: 'city-works', title_en: 'City Works',
+            dataset_count: 23, queryable_dataset_count: 4, mappable_dataset_count: 8
+        }, [{ id: 'd1', name: 'roads', title_en: 'Roads' }]);
+        expect(meta.title).toBe('City Works open data - CanQuery');
+        expect(meta.canonical).toBe('https://canquery.com/organizations/city-works');
+        const collection = meta.jsonLd.find(item => item['@type'] === 'CollectionPage');
+        expect(collection.mainEntity.numberOfItems).toBe(23);
+        expect(collection.mainEntity.itemListElement[0].url).toBe('https://canquery.com/datasets/roads');
     });
 });

--- a/server/__tests__/seoSnapshot.test.js
+++ b/server/__tests__/seoSnapshot.test.js
@@ -1,0 +1,40 @@
+const snapshot = require('../services/seoSnapshot');
+
+describe('server-rendered crawl snapshots', () => {
+    it('escapes catalogue text and bounds linked resources', () => {
+        const resources = Array.from({ length: 30 }, (_, index) => ({
+            id: 'r' + index,
+            name_en: index === 0 ? '<img src=x onerror=alert(1)>Roads' : 'Resource ' + index,
+            format: 'CSV', size_bytes: 100
+        }));
+        const html = snapshot.datasetSnapshot({
+            id: 'd1', name: 'roads',
+            title_en: '<script>bad()</script>Road network',
+            notes_en: '<p>Public &amp; maintained roads.</p>',
+            org_name: 'city-works', org_title_en: 'City <Works>',
+            places: [{ slug: 'example-on', name_en: 'Example' }]
+        }, resources);
+        expect(html).toContain('<h1>Road network</h1>');
+        expect(html).toContain('Public &amp; maintained roads.');
+        expect(html).not.toContain('<script>');
+        expect(html).not.toContain('<img');
+        expect((html.match(/href="\/resources\//g) || [])).toHaveLength(12);
+        expect(html).toContain('href="/organizations/city-works"');
+        expect(html).toContain('href="/places/example-on"');
+    });
+
+    it('renders one semantic h1 and canonical internal links for organizations', () => {
+        const html = snapshot.organizationSnapshot({
+            id: 'o1', name: 'city-works', title_en: 'City Works', dataset_count: 2,
+            queryable_dataset_count: 1, mappable_dataset_count: 1,
+            place_id: 'p1', place_slug: 'example-on', place_name_en: 'Example'
+        }, [
+            { id: 'd1', name: 'roads', title_en: 'Roads' },
+            ...Array.from({ length: 20 }, (_, i) => ({ id: 'd' + i, name: 'parks' + i, title_en: 'Parks' }))
+        ]);
+        expect((html.match(/<h1>/g) || [])).toHaveLength(1);
+        expect(html).toContain('href="/datasets/roads"');
+        expect(html).toContain('href="/places/example-on"');
+        expect((html.match(/href="\/datasets\//g) || [])).toHaveLength(12);
+    });
+});

--- a/server/__tests__/sitemapQueries.test.js
+++ b/server/__tests__/sitemapQueries.test.js
@@ -34,3 +34,17 @@ describe('resource sitemap queries', () => {
         expect(params).toEqual([25000, 50000]);
     });
 });
+
+describe('organization sitemap queries', () => {
+    it('lists organizations with datasets and their latest modification time', async () => {
+        const rows = [{ name: 'city-works', metadata_modified: '2026-08-30T00:00:00Z' }];
+        pool.query.mockResolvedValue({ rows });
+
+        await expect(queries.listOrganizationSitemap()).resolves.toEqual(rows);
+
+        const sql = pool.query.mock.calls[0][0];
+        expect(sql).toContain('JOIN datasets d ON d.org_id = o.id');
+        expect(sql).toContain('HAVING count(d.id) > 0');
+        expect(sql).toContain('max(d.metadata_modified)');
+    });
+});

--- a/server/app.js
+++ b/server/app.js
@@ -101,8 +101,7 @@ const clientDist = path.join(__dirname, '..', 'client', 'dist');
 if (process.env.NODE_ENV === 'production' && fs.existsSync(clientDist)) {
     app.use('/assets', express.static(path.join(clientDist, 'assets'), { maxAge: '1y', immutable: true }));
     app.use(express.static(clientDist, { index: false }));
-    // Per-route <head> injection (title/description/canonical/OG + JSON-LD) for
-    // SEO; falls back to the untouched template on any error.
+    // Per-route SEO and initial content, with real 404s and retryable 503s.
     app.get(/^\/(?!api\/|healthz).*/, spaController.serveSpa(clientDist));
 }
 

--- a/server/controllers/catalogController.js
+++ b/server/controllers/catalogController.js
@@ -65,6 +65,14 @@ const listOrganizations = async (req, res) => {
     res.json(envelope(result.items, { nextCursor: result.nextCursor }));
 };
 
+const getOrganization = async (req, res) => {
+    const name = cleanStr(req.params.name);
+    if (!name) throw new AppError('Organization not found', 404);
+    const organization = await catalogService.getOrganization(name);
+    res.set('Cache-Control', 'public, max-age=300');
+    res.json(envelope(organization));
+};
+
 const listSources = async (req, res) => {
     const items = await catalogService.listSources({ place: cleanStr(req.query.place) });
     res.set('Cache-Control', 'public, max-age=300');
@@ -129,6 +137,7 @@ module.exports = {
     getDataset: catchAsync(getDataset),
     getResource: catchAsync(getResource),
     listOrganizations: catchAsync(listOrganizations),
+    getOrganization: catchAsync(getOrganization),
     listSources: catchAsync(listSources),
     listPlaces: catchAsync(listPlaces),
     getPlace: catchAsync(getPlace),

--- a/server/controllers/sitemapController.js
+++ b/server/controllers/sitemapController.js
@@ -58,7 +58,11 @@ const sitemapIndex = catchAsync(async (req, res) => {
     ]);
     const datasetPages = Math.max(1, Math.ceil(datasetTotal / PAGE_SIZE));
     const resourcePages = Math.ceil(resourceTotal / PAGE_SIZE);
-    const locs = [SITE_URL + '/sitemap-pages.xml', SITE_URL + '/sitemap-places.xml'];
+    const locs = [
+        SITE_URL + '/sitemap-pages.xml',
+        SITE_URL + '/sitemap-places.xml',
+        SITE_URL + '/sitemap-organizations.xml'
+    ];
     for (let i = 1; i <= datasetPages; i++) locs.push(SITE_URL + '/sitemap-datasets-' + i + '.xml');
     for (let i = 1; i <= resourcePages; i++) locs.push(SITE_URL + '/sitemap-resources-' + i + '.xml');
     const body =
@@ -93,6 +97,23 @@ const sitemapPlaces = catchAsync(async (req, res) => {
     const entries = rows.map(place => ({
         loc: SITE_URL + '/places/' + encodeURIComponent(place.slug),
         lastmod: place.metadata_modified ? new Date(place.metadata_modified).toISOString() : null,
+        changefreq: 'weekly'
+    }));
+    res.type('application/xml');
+    res.set('Cache-Control', 'public, max-age=3600');
+    res.send(urlset(entries));
+});
+
+// GET /sitemap-organizations.xml - public organizations with at least one
+// mirrored dataset. Their detail pages are useful discovery hubs even when a
+// particular dataset is download-only.
+const sitemapOrganizations = catchAsync(async (req, res) => {
+    const rows = await catalogRead.listOrganizationSitemap();
+    const entries = rows.map(organization => ({
+        loc: SITE_URL + '/organizations/' + encodeURIComponent(organization.name),
+        lastmod: organization.metadata_modified
+            ? new Date(organization.metadata_modified).toISOString()
+            : null,
         changefreq: 'weekly'
     }));
     res.type('application/xml');
@@ -145,6 +166,7 @@ module.exports = {
     sitemapIndex,
     sitemapPages,
     sitemapPlaces,
+    sitemapOrganizations,
     sitemapDatasets,
     sitemapResources
 };

--- a/server/controllers/spaController.js
+++ b/server/controllers/spaController.js
@@ -1,16 +1,19 @@
 const fs = require('fs');
 const path = require('path');
 const seoMeta = require('../services/seoMeta');
+const seoSnapshot = require('../services/seoSnapshot');
 const catalogRead = require('../db/catalogReadQueries');
 
 // The built index.html is immutable for the life of the process (a deploy
 // restarts the API), so read it once and reuse.
 let templateCache = null;
+let templateCacheDir = null;
 const ANALYTICS_MARKER = '<!-- analytics:config -->';
 const WEBSITE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 function loadTemplate(distDir) {
-    if (templateCache == null) {
+    if (templateCache == null || templateCacheDir !== distDir) {
         templateCache = fs.readFileSync(path.join(distDir, 'index.html'), 'utf8');
+        templateCacheDir = distDir;
     }
     return templateCache;
 }
@@ -23,49 +26,158 @@ function injectAnalytics(template, websiteId = process.env.ANALYTICS_WEBSITE_ID)
     return template.replace(ANALYTICS_MARKER, () => tag);
 }
 
-// Map a request path to a resolved meta object, fetching dataset/resource rows
-// as needed. `deps` is injected for testing; defaults to the real DB layer.
-async function resolveMeta(reqPath, deps = catalogRead) {
+const STATIC_PATHS = Object.freeze({
+    home: '/', insights: '/insights', organizations: '/organizations',
+    places: '/places', docs: '/docs', privacy: '/privacy'
+});
+
+function searchArgs(overrides) {
+    return {
+        q: null, org: null, format: null, keyword: null, place: null,
+        source: null, mappable: null, limit: 12, offset: 0, ...overrides
+    };
+}
+
+// Resolve the head, semantic initial body, canonical path and response status
+// in one pass. The same HTML is sent to every user agent; React replaces the
+// bounded snapshot when the application starts.
+async function resolvePage(reqPath, deps = catalogRead) {
     const route = seoMeta.classifyRoute(reqPath);
     if (route.type === 'dataset') {
         const dataset = await deps.getDatasetByIdOrName(route.id);
-        if (!dataset) return seoMeta.notFoundMeta(reqPath);
+        if (!dataset) return {
+            status: 404,
+            meta: seoMeta.notFoundMeta(reqPath),
+            body: seoSnapshot.errorSnapshot('Dataset not found', 'The requested dataset is not available in the CanQuery catalogue.')
+        };
         const resources = await deps.listResourcesForDataset(dataset.id);
-        return seoMeta.datasetMeta(dataset, resources);
+        const canonicalPath = '/datasets/' + encodeURIComponent(dataset.name || dataset.id);
+        return {
+            status: 200,
+            canonicalPath,
+            meta: seoMeta.datasetMeta(dataset, resources),
+            body: seoSnapshot.datasetSnapshot(dataset, resources)
+        };
     }
     if (route.type === 'resource') {
         const resource = await deps.getResourceById(route.id);
-        if (!resource) return seoMeta.notFoundMeta(reqPath);
-        return seoMeta.resourceMeta(resource);
+        if (!resource) return {
+            status: 404,
+            meta: seoMeta.notFoundMeta(reqPath),
+            body: seoSnapshot.errorSnapshot('Resource not found', 'The requested resource is not available in the CanQuery catalogue.')
+        };
+        const canonicalPath = '/resources/' + encodeURIComponent(resource.id);
+        return {
+            status: 200,
+            canonicalPath,
+            meta: seoMeta.resourceMeta(resource),
+            body: seoSnapshot.resourceSnapshot(resource)
+        };
     }
     if (route.type === 'place') {
         const place = await deps.getPlaceByIdOrSlug(route.id);
-        if (!place) return seoMeta.notFoundMeta(reqPath);
-        return seoMeta.placeMeta(place);
+        if (!place) return {
+            status: 404,
+            meta: seoMeta.notFoundMeta(reqPath),
+            body: seoSnapshot.errorSnapshot('Place not found', 'The requested place is not available in the CanQuery directory.')
+        };
+        const datasets = await deps.searchDatasets(searchArgs({ place: place.slug || place.id }));
+        const canonicalPath = '/places/' + encodeURIComponent(place.slug || place.id);
+        return {
+            status: 200,
+            canonicalPath,
+            meta: seoMeta.placeMeta(place, datasets),
+            body: seoSnapshot.placeSnapshot(place, datasets)
+        };
     }
-    return seoMeta.staticMeta(route.type, reqPath);
+    if (route.type === 'organization') {
+        const organization = await deps.getOrganizationByName(route.id);
+        if (!organization) return {
+            status: 404,
+            meta: seoMeta.notFoundMeta(reqPath),
+            body: seoSnapshot.errorSnapshot('Organization not found', 'The requested organization is not available in the CanQuery directory.')
+        };
+        const datasets = await deps.searchDatasets(searchArgs({ org: organization.name }));
+        const canonicalPath = '/organizations/' + encodeURIComponent(organization.name);
+        return {
+            status: 200,
+            canonicalPath,
+            meta: seoMeta.organizationMeta(organization, datasets),
+            body: seoSnapshot.organizationSnapshot(organization, datasets)
+        };
+    }
+    if (route.type === 'other') {
+        return {
+            status: 404,
+            meta: seoMeta.notFoundMeta(reqPath),
+            body: seoSnapshot.errorSnapshot('Page not found', 'The requested page does not exist on CanQuery.')
+        };
+    }
+    let items = [];
+    if (route.type === 'organizations') {
+        items = (await deps.listOrganizations({ source: null, place: null, limit: 12, offset: 0 })).slice(0, 12);
+    } else if (route.type === 'places') {
+        items = await deps.listPlaces({
+            q: null, kind: null, parent: null, featured: true, limit: 12, offset: 0
+        });
+    }
+    return {
+        status: 200,
+        canonicalPath: STATIC_PATHS[route.type],
+        meta: seoMeta.staticMeta(route.type, reqPath),
+        body: seoSnapshot.staticSnapshot(route.type, items)
+    };
 }
 
-// Catch-all SPA handler: inject per-route SEO <head> into the template. Any
-// failure (DB down, bad row) falls back to the untouched template so a page is
-// always served.
+// Backward-compatible head-only helper retained for tests and callers.
+async function resolveMeta(reqPath, deps = catalogRead) {
+    return (await resolvePage(reqPath, deps)).meta;
+}
+
+function requestPath(req) {
+    return req.path || '/';
+}
+
+function querySuffix(req) {
+    const index = req.originalUrl.indexOf('?');
+    return index === -1 ? '' : req.originalUrl.slice(index);
+}
+
+// Catch-all SPA handler: inject per-route SEO head and semantic initial body.
+// Unknown pages return a real 404; catalogue failures return a retryable 503 so
+// crawlers never mistake an outage for valid or missing content.
 function serveSpa(distDir) {
     return async (req, res) => {
         const template = loadTemplate(distDir);
-        let html = template;
+        let page;
         try {
-            const meta = await resolveMeta(req.path);
-            html = seoMeta.renderHtml(template, meta);
-        } catch {
-            // SEO is best-effort: on any failure serve the untouched template.
+            page = await resolvePage(req.path);
+        } catch (err) {
+            console.error('SPA page resolution failed:', err.message);
+            page = {
+                status: 503,
+                meta: seoMeta.serviceUnavailableMeta(req.path),
+                body: seoSnapshot.errorSnapshot(
+                    'Temporarily unavailable',
+                    'This CanQuery page could not be loaded. Please try again shortly.'
+                )
+            };
         }
+        if (page.status === 200 && page.canonicalPath && requestPath(req) !== page.canonicalPath) {
+            res.set('Cache-Control', 'public, max-age=3600');
+            return res.redirect(301, page.canonicalPath + querySuffix(req));
+        }
+        let html = seoMeta.renderHtml(template, page.meta, page.body);
         html = injectAnalytics(html);
         res.set('Content-Type', 'text/html; charset=utf-8');
         // HTML is revalidated each load so a new deploy (and its hashed asset
         // refs) propagates immediately; the hashed assets themselves cache for a year.
-        res.set('Cache-Control', 'public, max-age=0, must-revalidate');
-        res.send(html);
+        res.set('Cache-Control', page.status >= 500
+            ? 'no-store'
+            : 'public, max-age=0, must-revalidate');
+        if (page.status === 503) res.set('Retry-After', '60');
+        res.status(page.status).send(html);
     };
 }
 
-module.exports = { serveSpa, resolveMeta, loadTemplate, injectAnalytics };
+module.exports = { serveSpa, resolvePage, resolveMeta, loadTemplate, injectAnalytics };

--- a/server/db/catalogReadQueries.js
+++ b/server/db/catalogReadQueries.js
@@ -157,6 +157,7 @@ async function getResourceById(id) {
         SELECT r.id, r.dataset_id, r.name_en, r.name_fr, r.format, r.url, r.size_bytes, r.raw,
                r.datastore_active, r.language, r.last_modified,
                d.name AS dataset_name, d.title_en AS dataset_title_en, d.title_fr AS dataset_title_fr,
+               o.name AS org_name, o.title_en AS org_title_en, o.title_fr AS org_title_fr,
                ir.status AS ingest_status, ir.table_name, ir.row_count AS ingested_row_count,
                ir.byte_size AS ingested_byte_size, ir.columns AS ingested_columns,
                ir.ingested_at, ir.last_accessed_at,
@@ -171,10 +172,43 @@ async function getResourceById(id) {
                ${PLACES_SELECT}
         FROM resources r
         JOIN datasets d ON d.id = r.dataset_id
+        LEFT JOIN organizations o ON o.id = d.org_id
         LEFT JOIN ingested_resources ir ON ir.resource_id = r.id
         LEFT JOIN resource_maps rm ON rm.resource_id = r.id
         WHERE r.id = $1
     `, [id]);
+    return result.rows[0] || null;
+}
+
+async function getOrganizationByName(name, db = pool) {
+    const result = await db.query(`
+        SELECT o.id, o.name, o.title_en, o.title_fr,
+               p.id AS place_id, p.slug AS place_slug,
+               p.name_en AS place_name_en, p.name_fr AS place_name_fr,
+               (SELECT count(*)::int FROM datasets d
+                WHERE d.org_id = o.id) AS dataset_count,
+               (SELECT count(*)::int FROM datasets d
+                WHERE d.org_id = o.id AND EXISTS (
+                    SELECT 1 FROM resources r
+                    WHERE r.dataset_id = d.id
+                      AND (r.datastore_active OR EXISTS (
+                          SELECT 1 FROM ingested_resources ir
+                          WHERE ir.resource_id = r.id AND ir.status = 'ready'
+                      ))
+                )) AS queryable_dataset_count,
+               (SELECT count(*)::int FROM datasets d
+                WHERE d.org_id = o.id AND EXISTS (
+                    SELECT 1 FROM resources r
+                    JOIN resource_maps rm ON rm.resource_id = r.id
+                    WHERE r.dataset_id = d.id
+                )) AS mappable_dataset_count,
+               (SELECT max(d.metadata_modified) FROM datasets d
+                WHERE d.org_id = o.id) AS metadata_modified
+        FROM organizations o
+        LEFT JOIN places p ON p.id = o.place_id
+        WHERE o.name = $1
+        LIMIT 1
+    `, [name]);
     return result.rows[0] || null;
 }
 
@@ -469,6 +503,18 @@ async function listPlaceSitemap() {
     return result.rows;
 }
 
+async function listOrganizationSitemap() {
+    const result = await pool.query(`
+        SELECT o.name, max(d.metadata_modified) AS metadata_modified
+        FROM organizations o
+        JOIN datasets d ON d.org_id = o.id
+        GROUP BY o.id, o.name
+        HAVING count(d.id) > 0
+        ORDER BY o.name
+    `);
+    return result.rows;
+}
+
 async function pingDb() {
     await pool.query('SELECT 1');
     return true;
@@ -568,6 +614,7 @@ module.exports = {
     getResourceById,
     getResourceMapById,
     listOrganizations,
+    getOrganizationByName,
     listSources,
     listPlaces,
     getPlaceByIdOrSlug,
@@ -577,6 +624,7 @@ module.exports = {
     countSitemapResources,
     listResourceSitemap,
     listPlaceSitemap,
+    listOrganizationSitemap,
     pingDb,
     getLastSyncTime,
     listRecentlyIngested,

--- a/server/db/searchConsoleQueries.js
+++ b/server/db/searchConsoleQueries.js
@@ -1,4 +1,5 @@
 const pool = require('./pool');
+const { classifyRows, searchIntentSql, INTENTS } = require('../services/searchIntent');
 
 async function latestSearchConsoleDate(db = pool) {
     const result = await db.query("SELECT max(data_date)::text AS data_date FROM search_console_daily WHERE search_type = 'web'");
@@ -99,7 +100,8 @@ async function replaceSearchConsoleDay(day, db = pool) {
     }
 }
 
-async function aggregateBreakdown(db, dimension, { zeroClick = false, limit = 25 } = {}) {
+async function aggregateBreakdown(db, dimension, { zeroClick = false, limit = 25, intent = null } = {}) {
+    if (intent && (dimension !== 'query' || !INTENTS.includes(intent))) throw new Error('Invalid query intent');
     const result = await db.query(`
         WITH latest AS (
             SELECT max(data_date) AS d FROM search_console_daily WHERE search_type = 'web'
@@ -113,11 +115,12 @@ async function aggregateBreakdown(db, dimension, { zeroClick = false, limit = 25
         FROM search_console_breakdowns, latest
         WHERE search_type = 'web' AND dimension = $1
           AND data_date BETWEEN latest.d - 27 AND latest.d
+          ${intent ? 'AND ' + searchIntentSql('value') + ' = $3' : ''}
         GROUP BY value
         ${zeroClick ? 'HAVING sum(clicks) = 0 AND sum(impressions) > 0' : ''}
         ORDER BY ${zeroClick ? 'impressions' : 'clicks'} DESC, impressions DESC, value
         LIMIT $2
-    `, [dimension, limit]);
+    `, intent ? [dimension, limit, intent] : [dimension, limit]);
     return result.rows;
 }
 
@@ -131,13 +134,14 @@ async function getSearchGrowthReportData(db = pool) {
         return {
             latestDate: null, lastSyncedAt: null, daily: [], summary: null,
             topQueries: [], topPages: [], zeroClickQueries: [], pageOpportunities: [],
-            queryPageOpportunities: [], countries: [], devices: [], routes: []
+            queryPageOpportunities: [], brandQueries: [], queryIntentSummary: [],
+            countries: [], devices: [], routes: []
         };
     }
     const [
         dailyResult, summaryResult, topQueries, topPages, zeroClickQueries,
         pageOpportunitiesResult, queryPageOpportunitiesResult,
-        countries, devices, routesResult
+        countries, devices, routesResult, brandQueries, intentSummaryResult
     ] = await Promise.all([
         db.query(`
             SELECT data_date::text, clicks, impressions, ctr, position
@@ -157,9 +161,9 @@ async function getSearchGrowthReportData(db = pool) {
                     nullif(sum(impressions) FILTER (WHERE data_date BETWEEN $1::date - 55 AND $1::date - 28), 0), 0)::float8 AS prior_position
             FROM search_console_daily WHERE search_type = 'web'
         `, [latestDate]),
-        aggregateBreakdown(db, 'query'),
+        aggregateBreakdown(db, 'query', { intent: 'semantic' }),
         aggregateBreakdown(db, 'page'),
-        aggregateBreakdown(db, 'query', { zeroClick: true }),
+        aggregateBreakdown(db, 'query', { zeroClick: true, intent: 'semantic' }),
         db.query(`
             WITH latest AS (SELECT $1::date AS d)
             SELECT value,
@@ -172,7 +176,8 @@ async function getSearchGrowthReportData(db = pool) {
             FROM search_console_breakdowns, latest
             WHERE search_type = 'web' AND dimension = 'page'
               AND data_date BETWEEN latest.d - 27 AND latest.d
-              AND (value ~ '/datasets/[^/?#]+' OR value ~ '/resources/[^/?#]+')
+              AND (value ~ '/datasets/[^/?#]+' OR value ~ '/resources/[^/?#]+'
+                   OR value ~ '/places/[^/?#]+' OR value ~ '/organizations/[^/?#]+')
             GROUP BY value
             HAVING sum(impressions) >= 50
                AND CASE WHEN sum(impressions) = 0 THEN 0
@@ -192,6 +197,7 @@ async function getSearchGrowthReportData(db = pool) {
             FROM search_console_query_pages, latest
             WHERE search_type = 'web'
               AND data_date BETWEEN latest.d - 27 AND latest.d
+              AND ${searchIntentSql('query_text')} = 'semantic'
             GROUP BY query_text, page_url
             HAVING sum(impressions) >= 5
                AND sum(position * impressions) / nullif(sum(impressions), 0) BETWEEN 1 AND 20
@@ -205,6 +211,7 @@ async function getSearchGrowthReportData(db = pool) {
             WITH latest AS (SELECT $1::date AS d), page_totals AS (
                 SELECT CASE
                     WHEN scb.value ~ '/places/[^/?#]+' THEN 'Place pages'
+                    WHEN scb.value ~ '/organizations/[^/?#]+' THEN 'Organization pages'
                     WHEN scb.value ~ '/datasets/[^/?#]+' THEN 'Dataset pages'
                     WHEN scb.value ~ '/resources/[^/?#]+' THEN 'Resource pages'
                     WHEN scb.value ~ '/insights/?([?#].*)?$' THEN 'Insights'
@@ -226,21 +233,42 @@ async function getSearchGrowthReportData(db = pool) {
                    CASE WHEN sum(impressions) = 0 THEN 0 ELSE sum(clicks) / sum(impressions) END::float8 AS ctr,
                    CASE WHEN sum(impressions) = 0 THEN 0 ELSE sum(position_weight) / sum(impressions) END::float8 AS position
             FROM page_totals GROUP BY family ORDER BY impressions DESC, clicks DESC
+        `, [latestDate]),
+        aggregateBreakdown(db, 'query', { intent: 'brand' }),
+        db.query(`
+            WITH reported_queries AS (
+                SELECT value, sum(clicks)::float8 AS clicks, sum(impressions)::float8 AS impressions
+                FROM search_console_breakdowns
+                WHERE search_type = 'web' AND dimension = 'query'
+                  AND data_date BETWEEN $1::date - 27 AND $1::date
+                GROUP BY value
+            )
+            SELECT ${searchIntentSql('value')} AS intent, count(*)::int AS queries,
+                   sum(clicks)::float8 AS clicks, sum(impressions)::float8 AS impressions,
+                   coalesce(sum(clicks) / nullif(sum(impressions), 0), 0)::float8 AS ctr
+            FROM reported_queries GROUP BY intent
         `, [latestDate])
     ]);
     const summary = summaryResult.rows[0];
     summary.current_ctr = summary.current_impressions ? summary.current_clicks / summary.current_impressions : 0;
     summary.prior_ctr = summary.prior_impressions ? summary.prior_clicks / summary.prior_impressions : 0;
+    const classifiedTopQueries = classifyRows(topQueries);
+    const classifiedZeroClickQueries = classifyRows(zeroClickQueries);
+    const classifiedQueryPages = classifyRows(queryPageOpportunitiesResult.rows, 'query');
     return {
         latestDate,
         lastSyncedAt: latestResult.rows[0].last_synced_at,
         daily: dailyResult.rows,
         summary,
-        topQueries,
+        topQueries: classifiedTopQueries,
+        brandQueries: classifyRows(brandQueries),
         topPages,
-        zeroClickQueries,
+        zeroClickQueries: classifiedZeroClickQueries,
         pageOpportunities: pageOpportunitiesResult.rows,
-        queryPageOpportunities: queryPageOpportunitiesResult.rows,
+        queryPageOpportunities: classifiedQueryPages,
+        queryIntentSummary: INTENTS.map(intent => intentSummaryResult.rows.find(row => row.intent === intent) || {
+            intent, queries: 0, clicks: 0, impressions: 0, ctr: 0
+        }),
         countries,
         devices,
         routes: routesResult.rows

--- a/server/routes/organizations.js
+++ b/server/routes/organizations.js
@@ -2,4 +2,5 @@ const express = require('express');
 const router = express.Router();
 const catalogController = require('../controllers/catalogController');
 router.get('/', catalogController.listOrganizations);
+router.get('/:name', catalogController.getOrganization);
 module.exports = router;

--- a/server/routes/seo.js
+++ b/server/routes/seo.js
@@ -9,6 +9,7 @@ router.get('/robots.txt', sitemap.robots);
 router.get('/sitemap.xml', sitemap.sitemapIndex);
 router.get('/sitemap-pages.xml', sitemap.sitemapPages);
 router.get('/sitemap-places.xml', sitemap.sitemapPlaces);
+router.get('/sitemap-organizations.xml', sitemap.sitemapOrganizations);
 router.get('/sitemap-datasets-:n.xml', sitemap.sitemapDatasets);
 router.get('/sitemap-resources-:n.xml', sitemap.sitemapResources);
 

--- a/server/services/catalogService.js
+++ b/server/services/catalogService.js
@@ -176,7 +176,15 @@ const getResource = async (id) => {
     const row = await catalogReadQueries.getResourceById(id);
     if (!row) throw new AppError('Resource not found', 404);
     const shaped = shapeResource(row);
-    shaped.dataset = { id: row.dataset_id, name: row.dataset_name, title: { en: row.dataset_title_en, fr: row.dataset_title_fr } };
+    shaped.dataset = {
+        id: row.dataset_id,
+        name: row.dataset_name,
+        title: { en: row.dataset_title_en, fr: row.dataset_title_fr },
+        organization: row.org_name ? {
+            name: row.org_name,
+            title: { en: row.org_title_en, fr: row.org_title_fr }
+        } : null
+    };
     shaped.places = shapePlaces(row.places);
     shaped.provenance = shapeProvenance(row.provenance_sources);
     if (row.ingest_status) {
@@ -185,6 +193,25 @@ const getResource = async (id) => {
         shaped.ingestion.last_accessed_at = row.last_accessed_at;
     }
     return shaped;
+};
+
+const getOrganization = async (name) => {
+    const row = await catalogReadQueries.getOrganizationByName(name);
+    if (!row) throw new AppError('Organization not found', 404);
+    return {
+        id: row.id,
+        name: row.name,
+        title: { en: row.title_en, fr: row.title_fr },
+        dataset_count: Number(row.dataset_count) || 0,
+        queryable_dataset_count: Number(row.queryable_dataset_count) || 0,
+        mappable_dataset_count: Number(row.mappable_dataset_count) || 0,
+        metadata_modified: row.metadata_modified || null,
+        place: row.place_id ? {
+            id: row.place_id,
+            slug: row.place_slug,
+            name: { en: row.place_name_en, fr: row.place_name_fr }
+        } : null
+    };
 };
 
 const listOrganizations = async ({ source, place, limit, cursor }) => {
@@ -469,6 +496,7 @@ module.exports = {
     searchDatasets,
     getDataset,
     getResource,
+    getOrganization,
     listOrganizations,
     listSources,
     listPlaces,

--- a/server/services/searchGrowthReport.js
+++ b/server/services/searchGrowthReport.js
@@ -84,6 +84,16 @@ function routeTable(rows) {
         : '<p class="empty">No page visibility data yet.</p>') + '</section>';
 }
 
+function intentTable(rows) {
+    const body = (rows || []).map(row => '<tr><td>' + escapeHtml(row.intent) + '</td><td>' +
+        number(row.queries) + '</td><td>' + number(row.clicks) + '</td><td>' +
+        number(row.impressions) + '</td><td>' + percent(row.ctr) + '</td></tr>').join('');
+    return '<section class="panel"><h2>Reported query intent: 28 days</h2>' +
+        '<p>Counts cover distinct reported queries. Query metrics can be incomplete and do not equal property totals; query-page opportunities are a separate subset.</p>' + (body
+        ? '<div class="table-wrap"><table><thead><tr><th>Intent</th><th>Queries</th><th>Clicks</th><th>Impressions</th><th>CTR</th></tr></thead><tbody>' + body + '</tbody></table></div>'
+        : '<p class="empty">No query intent data yet.</p>') + '</section>';
+}
+
 function renderSearchGrowthReport(data, generatedAt = new Date()) {
     const stale = data.lastSyncedAt && generatedAt.getTime() - new Date(data.lastSyncedAt).getTime() > 48 * 60 * 60 * 1000;
     const status = !data.latestDate ? 'No imported data' : stale ? 'Import may be stale' : 'Import current';
@@ -104,12 +114,13 @@ function renderSearchGrowthReport(data, generatedAt = new Date()) {
         escapeHtml(data.latestDate || 'none') + '. Generated ' + escapeHtml(generatedAt.toISOString()) +
         '. <span class="status">' + escapeHtml(status) + '</span></p><section class="metrics">' + metrics +
         '</section><section class="panel"><h2>Daily clicks: last 90 finalized days</h2>' + trendSvg(data.daily || []) + '</section>' +
-        '<div class="grid">' + table('Top queries: 28 days', data.topQueries || [], { valueLabel: 'Query' }) +
+        '<div class="grid">' + table('Top semantic queries: 28 days', data.topQueries || [], { valueLabel: 'Query' }) +
         table('Top pages: 28 days', data.topPages || [], { valueLabel: 'Page' }) + '</div><div class="grid">' +
-        table('Zero-click opportunities', data.zeroClickQueries || [], { valueLabel: 'Query' }) +
+        table('Semantic zero-click opportunities', data.zeroClickQueries || [], { valueLabel: 'Query' }) +
         table('High-impression, low-CTR pages', data.pageOpportunities || [], { valueLabel: 'Page', limit: 50 }) +
-        '</div>' + queryPageTable(data.queryPageOpportunities || []) +
-        '<div class="grid">' + routeTable(data.routes || []) +
+        '</div>' + queryPageTable(data.queryPageOpportunities || []) + '<div class="grid">' +
+        table('Brand queries', data.brandQueries || [], { valueLabel: 'Query' }) +
+        intentTable(data.queryIntentSummary || []) + '</div><div class="grid">' + routeTable(data.routes || []) +
         table('Countries', data.countries || [], { valueLabel: 'Country', limit: 15 }) + '</div><div class="grid">' +
         table('Devices', data.devices || [], { valueLabel: 'Device', limit: 10 }) +
         '</div></main></body></html>';
@@ -124,5 +135,6 @@ module.exports = {
     table,
     queryPageTable,
     routeTable,
+    intentTable,
     renderSearchGrowthReport
 };

--- a/server/services/searchIntent.js
+++ b/server/services/searchIntent.js
@@ -1,0 +1,61 @@
+// Explicit ASCII word boundaries have the same meaning in JavaScript and
+// PostgreSQL, unlike their locale-dependent \b / \y implementations.
+const START = '(^|[^a-z0-9_])';
+const END = '($|[^a-z0-9_])';
+// ECMAScript whitespace, explicitly shared with PostgreSQL's regex engine.
+const SPACE = '[\\t\\n\\v\\f\\r \u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\uFEFF]';
+const PATTERNS = Object.freeze({
+    empty: '^' + SPACE + '*$',
+    diagnostic: START + 'site' + SPACE + '*:|' + START +
+        '[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}' + END +
+        '|' + START + '[0-9a-f]{20,}' + END,
+    brand: 'canquery|' + START + 'can query' + END,
+    technical: START + '(github|api docs?|resource id|dataset id)' + END
+});
+const MATCHERS = Object.fromEntries(Object.entries(PATTERNS).map(([key, pattern]) => [key, new RegExp(pattern, 'i')]));
+const INTENTS = ['semantic', 'brand', 'diagnostic'];
+
+function classifySearchIntent(value) {
+    const query = String(value == null ? '' : value).trim().toLowerCase();
+    if (MATCHERS.empty.test(query) || MATCHERS.diagnostic.test(query)) {
+        return 'diagnostic';
+    }
+    if (MATCHERS.brand.test(query) && MATCHERS.technical.test(query)) {
+        return 'diagnostic';
+    }
+    if (MATCHERS.brand.test(query)) {
+        return 'brand';
+    }
+    return 'semantic';
+}
+
+function searchIntentSql(column) {
+    if (!['value', 'query_text'].includes(column)) throw new Error('Unsupported query column');
+    const matches = key => `coalesce(${column}, '') ~* '${PATTERNS[key].replace(/'/g, "''")}'`;
+    return `(CASE WHEN ${matches('empty')} OR ${matches('diagnostic')}
+        OR (${matches('brand')} AND ${matches('technical')}) THEN 'diagnostic'
+        WHEN ${matches('brand')} THEN 'brand' ELSE 'semantic' END)`;
+}
+
+function classifyRows(rows, key = 'value') {
+    return (rows || []).map(row => ({ ...row, intent: classifySearchIntent(row[key]) }));
+}
+
+function summarizeIntent(rows) {
+    const totals = new Map(['semantic', 'brand', 'diagnostic'].map(intent => [intent, {
+        intent, queries: 0, clicks: 0, impressions: 0
+    }]));
+    for (const row of rows || []) {
+        const intent = row.intent || classifySearchIntent(row.query || row.value);
+        const total = totals.get(intent);
+        total.queries += 1;
+        total.clicks += Number(row.clicks) || 0;
+        total.impressions += Number(row.impressions) || 0;
+    }
+    return Array.from(totals.values()).map(total => ({
+        ...total,
+        ctr: total.impressions ? total.clicks / total.impressions : 0
+    }));
+}
+
+module.exports = { classifySearchIntent, classifyRows, summarizeIntent, searchIntentSql, INTENTS };

--- a/server/services/seoMeta.js
+++ b/server/services/seoMeta.js
@@ -7,15 +7,16 @@ const { toAbsoluteUrl } = require('../utils/resolveUrl');
 const { classifyResource } = require('./resourceCapabilities');
 
 const SITE_URL = (process.env.SITE_URL || 'https://canquery.com').replace(/\/+$/, '');
-const SITE_NAME = 'canquery';
-const DEFAULT_TITLE = "canquery - query Canada's open data";
+const SITE_NAME = 'CanQuery';
+const DEFAULT_TITLE = 'CanQuery: Canadian open data search, tables & maps';
 const DEFAULT_DESC =
     'Search Canadian open data by place, load CSV and Excel files into live tables, and explore spatial data on a map. No signup.';
 const DEFAULT_IMAGE = SITE_URL + '/og-image.svg';
 const REPO_URL = 'https://github.com/RyuPrad/canquery';
 const TITLE_MAX = 80;
 const DESCRIPTION_MAX = 160;
-const TITLE_SUFFIX = ' - canquery';
+const TITLE_SUFFIX = ' - CanQuery';
+const DATASET_DESCRIPTION_MIN = 50;
 
 function escapeHtml(value) {
     return String(value == null ? '' : value)
@@ -33,12 +34,62 @@ function jsonLdScript(obj) {
     const json = JSON.stringify(obj)
         .replace(/</g, '\\u003c')
         .replace(/>/g, '\\u003e')
-        .replace(/&/g, '\\u0026');
+        .replace(/&/g, '\\u0026')
+        .replace(/\u2028/g, '\\u2028')
+        .replace(/\u2029/g, '\\u2029');
     return '<script type="application/ld+json">' + json + '</script>';
 }
 
 function collapse(value) {
     return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+}
+
+const HTML_ENTITIES = Object.freeze({
+    amp: '&', apos: "'", copy: '©', gt: '>', lt: '<', nbsp: ' ', quot: '"', reg: '®',
+    agrave: 'à', acirc: 'â', auml: 'ä', ccedil: 'ç', eacute: 'é', egrave: 'è',
+    ecirc: 'ê', euml: 'ë', icirc: 'î', iuml: 'ï', ocirc: 'ô', ouml: 'ö',
+    ugrave: 'ù', ucirc: 'û', uuml: 'ü', yuml: 'ÿ',
+    laquo: '«', raquo: '»', lsquo: '‘', rsquo: '’', ldquo: '“', rdquo: '”',
+    ndash: '–', mdash: '—', hellip: '…', bull: '•', middot: '·'
+});
+
+function decodeHtmlEntities(value) {
+    return String(value == null ? '' : value).replace(
+        /&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);/gi,
+        (match, entity) => {
+            if (entity[0] === '#') {
+                const hex = entity[1].toLowerCase() === 'x';
+                const codePoint = Number.parseInt(entity.slice(hex ? 2 : 1), hex ? 16 : 10);
+                const control = codePoint < 32 && ![9, 10, 13].includes(codePoint);
+                const surrogate = codePoint >= 0xd800 && codePoint <= 0xdfff;
+                if (!Number.isInteger(codePoint) || control || surrogate || codePoint > 0x10ffff) return ' ';
+                try {
+                    return String.fromCodePoint(codePoint);
+                } catch {
+                    return ' ';
+                }
+            }
+            const normalized = entity.toLowerCase();
+            if (!Object.prototype.hasOwnProperty.call(HTML_ENTITIES, normalized)) return match;
+            const decoded = HTML_ENTITIES[normalized];
+            return entity[0] === entity[0].toUpperCase() && /^[a-zà-ÿ]$/i.test(decoded)
+                ? decoded.toLocaleUpperCase('fr-CA')
+                : decoded;
+        }
+    );
+}
+
+// Catalogue descriptions sometimes contain small HTML fragments. Search
+// metadata and the crawl snapshot must use the visible text, never upstream
+// markup or script/style contents.
+function plainText(value) {
+    const withoutExecutable = String(value == null ? '' : value)
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
+        .replace(/<br\s*\/?\s*>/gi, ' ')
+        .replace(/<\/(?:div|h[1-6]|li|p|section|td|th)>/gi, ' ')
+        .replace(/<[^>]*>/g, ' ');
+    return collapse(decodeHtmlEntities(withoutExecutable));
 }
 
 function truncate(value, max) {
@@ -49,7 +100,7 @@ function truncate(value, max) {
 
 // English-default site: prefer the EN value, fall back to FR when EN is blank.
 function pick(en, fr) {
-    return collapse(en) || collapse(fr) || '';
+    return plainText(en) || plainText(fr) || '';
 }
 
 function siteTitle(value) {
@@ -119,15 +170,37 @@ function canonicalFor(pathname) {
     return SITE_URL + p;
 }
 
+function decodePathSegment(value) {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return null;
+    }
+}
+
 function classifyRoute(pathname) {
     const p = (pathname || '/').replace(/\?.*$/, '');
     if (p === '/' || p === '') return { type: 'home' };
     let m = p.match(/^\/datasets\/([^/]+)\/?$/);
-    if (m) return { type: 'dataset', id: decodeURIComponent(m[1]) };
+    if (m) {
+        const id = decodePathSegment(m[1]);
+        return id == null ? { type: 'other' } : { type: 'dataset', id };
+    }
     m = p.match(/^\/resources\/([^/]+)\/?$/);
-    if (m) return { type: 'resource', id: decodeURIComponent(m[1]) };
+    if (m) {
+        const id = decodePathSegment(m[1]);
+        return id == null ? { type: 'other' } : { type: 'resource', id };
+    }
     m = p.match(/^\/places\/([^/]+)\/?$/);
-    if (m) return { type: 'place', id: decodeURIComponent(m[1]) };
+    if (m) {
+        const id = decodePathSegment(m[1]);
+        return id == null ? { type: 'other' } : { type: 'place', id };
+    }
+    m = p.match(/^\/organizations\/([^/]+)\/?$/);
+    if (m) {
+        const id = decodePathSegment(m[1]);
+        return id == null ? { type: 'other' } : { type: 'organization', id };
+    }
     if (/^\/places\/?$/.test(p)) return { type: 'places' };
     if (/^\/insights\/?$/.test(p)) return { type: 'insights' };
     if (/^\/organizations\/?$/.test(p)) return { type: 'organizations' };
@@ -139,32 +212,32 @@ function classifyRoute(pathname) {
 const STATIC_META = {
     home: { title: DEFAULT_TITLE, description: DEFAULT_DESC, path: '/' },
     insights: {
-        title: 'Insights: Top 100 downloaded datasets - canquery',
+        title: 'Insights: Top 100 downloaded datasets - CanQuery',
         description:
-            'The 100 most-downloaded datasets on open.canada.ca, loaded into canquery and turned into live charts you can explore.',
+            'The 100 most-downloaded datasets on open.canada.ca, loaded into CanQuery and turned into live charts you can explore.',
         path: '/insights',
     },
     organizations: {
-        title: 'Organizations - canquery',
+        title: 'Organizations publishing Canadian open data - CanQuery',
         description:
             'Browse governments and public organizations publishing Canadian open data, ranked by how many datasets they have.',
         path: '/organizations',
     },
     places: {
-        title: 'Places - canquery',
+        title: 'Canadian open data by place - CanQuery',
         description: 'Browse queryable and mappable open data for Canadian provinces, regions, and municipalities.',
         path: '/places',
     },
     docs: {
-        title: 'API documentation - canquery',
+        title: 'API documentation - CanQuery',
         description:
             'Anonymous JSON API over Canadian federal and local open data: search by place, map spatial layers, load tables and query them live.',
         path: '/docs',
     },
     privacy: {
-        title: 'Privacy and analytics - canquery',
+        title: 'Privacy and analytics - CanQuery',
         description:
-            'How canquery uses anonymous, self-hosted product analytics, honors browser privacy signals, and protects visitor data.',
+            'How CanQuery uses anonymous, self-hosted product analytics, honors browser privacy signals, and protects visitor data.',
         path: '/privacy',
     },
 };
@@ -210,11 +283,66 @@ function sourceForDataset(dataset) {
         sources[0] || null;
 }
 
+function absoluteHttpUrl(value) {
+    if (!value) return null;
+    try {
+        const resolved = new URL(toAbsoluteUrl(value));
+        return resolved.protocol === 'http:' || resolved.protocol === 'https:'
+            ? resolved.toString()
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+function humanFileSize(value) {
+    if (value == null || value === '') return null;
+    const bytes = Number(value);
+    if (!Number.isFinite(bytes) || bytes < 0) return null;
+    if (bytes < 1024) return Math.round(bytes) + ' bytes';
+    const units = ['KB', 'MB', 'GB', 'TB'];
+    let amount = bytes / 1024;
+    let unit = units[0];
+    for (let i = 1; i < units.length && amount >= 1024; i += 1) {
+        amount /= 1024;
+        unit = units[i];
+    }
+    return (amount >= 10 ? amount.toFixed(0) : amount.toFixed(1)).replace(/\.0$/, '') + ' ' + unit;
+}
+
+function datasetDescription(dataset, resources, max = 5000) {
+    const name = pick(dataset.title_en, dataset.title_fr) || 'This dataset';
+    const notes = pick(dataset.notes_en, dataset.notes_fr);
+    const org = pick(dataset.org_title_en, dataset.org_title_fr);
+    const list = Array.isArray(resources) ? resources : [];
+    const queryable = list.filter(resource => {
+        const capability = classifyResource(resource).capability;
+        return capability === 'datastore' || capability === 'ingested';
+    }).length;
+    const mapped = list.filter(resource => resource && (
+        resource.map_provider || (resource.map && resource.map.available)
+    )).length;
+    const facts = [
+        name + ' is an open dataset' + (org ? ' published by ' + org : ' available through CanQuery') + '.',
+        list.length ? 'It contains ' + list.length + ' resource' + (list.length === 1 ? '' : 's') + '.' : '',
+        queryable ? queryable + ' can be queried as a live table.' : '',
+        mapped ? mapped + ' can be explored on a map.' : ''
+    ].filter(Boolean).join(' ');
+    let description = notes;
+    if (description.length < DATASET_DESCRIPTION_MIN) {
+        description = [description, facts].filter(Boolean).join(' ');
+    }
+    if (description.length < DATASET_DESCRIPTION_MIN) {
+        description += ' Search and explore the public data on CanQuery.';
+    }
+    return truncate(description, max);
+}
+
 function buildDatasetJsonLd(dataset, resources) {
     const name = pick(dataset.title_en, dataset.title_fr) || 'Dataset';
     const slug = dataset.name || dataset.id;
     const url = SITE_URL + '/datasets/' + encodeURIComponent(slug);
-    const description = truncate(pick(dataset.notes_en, dataset.notes_fr) || name, 5000);
+    const description = datasetDescription(dataset, resources, 5000);
     const ld = {
         '@context': 'https://schema.org',
         '@type': 'Dataset',
@@ -224,6 +352,10 @@ function buildDatasetJsonLd(dataset, resources) {
         identifier: dataset.id,
         isAccessibleForFree: true,
     };
+    const alternateName = plainText(dataset.title_fr);
+    if (alternateName && alternateName.toLocaleLowerCase('fr-CA') !== name.toLocaleLowerCase('fr-CA')) {
+        ld.alternateName = alternateName;
+    }
     const source = sourceForDataset(dataset);
     ld.license = source && source.license_url
         ? source.license_url
@@ -250,17 +382,20 @@ function buildDatasetJsonLd(dataset, resources) {
         .map(place => pick(place.name_en, place.name_fr))
         .filter(Boolean);
     if (places.length) ld.spatialCoverage = Array.from(new Set(places));
-    const distribution = (resources || [])
-        .filter((r) => r && r.url)
-        .slice(0, 25)
-        .map((r) => {
-            const dl = { '@type': 'DataDownload', contentUrl: toAbsoluteUrl(r.url) };
-            const fmt = collapse(r.format);
-            if (fmt) dl.encodingFormat = fmt;
-            const rn = pick(r.name_en, r.name_fr);
-            if (rn) dl.name = rn;
-            return dl;
-        });
+    const distribution = [];
+    for (const resource of resources || []) {
+        if (distribution.length >= 25) break;
+        const contentUrl = absoluteHttpUrl(resource && resource.url);
+        if (!contentUrl) continue;
+        const dl = { '@type': 'DataDownload', contentUrl };
+        const fmt = plainText(resource.format);
+        if (fmt) dl.encodingFormat = fmt;
+        const resourceName = pick(resource.name_en, resource.name_fr);
+        if (resourceName) dl.name = resourceName;
+        const size = humanFileSize(resource.size_bytes);
+        if (size) dl.contentSize = size;
+        distribution.push(dl);
+    }
     if (distribution.length) ld.distribution = distribution;
     return ld;
 }
@@ -298,14 +433,7 @@ function staticMeta(type, pathname) {
 
 function datasetMeta(dataset, resources) {
     const title = pick(dataset.title_en, dataset.title_fr) || 'Dataset';
-    const org = pick(dataset.org_title_en, dataset.org_title_fr);
-    const notes = pick(dataset.notes_en, dataset.notes_fr);
-    const description = truncate(
-        notes || (org
-            ? 'Open data from ' + org + ': ' + title + '. Explore its resources on canquery.'
-            : title + '. Explore the available open-data resources on canquery.'),
-        DESCRIPTION_MAX
-    );
+    const description = datasetDescription(dataset, resources, DESCRIPTION_MAX);
     const slug = dataset.name || dataset.id;
     return {
         title: siteTitle(title),
@@ -326,36 +454,73 @@ function resourceDescription(resource) {
     const capability = classifyResource(resource).capability;
     const name = pick(resource.name_en, resource.name_fr);
     const datasetTitle = pick(resource.dataset_title_en, resource.dataset_title_fr);
-    const subject = datasetTitle || name || 'this open-data resource';
-    const format = collapse(resource.format).toUpperCase();
+    const organization = pick(resource.org_title_en, resource.org_title_fr);
+    const resourceLabel = isGenericResourceName(name, resource.format) ? '' : name;
+    const subject = [resourceLabel, datasetTitle && datasetTitle !== resourceLabel
+        ? 'from ' + datasetTitle
+        : '', organization ? 'by ' + organization : ''].filter(Boolean).join(' ') ||
+        datasetTitle || name || 'This open-data resource';
+    const format = plainText(resource.format).toUpperCase();
     const formatLabel = format ? format + ' ' : '';
     let description;
     if (capability === 'datastore' || capability === 'ingested') {
-        description = 'Explore ' + subject + ' as a live ' + formatLabel +
-            'table: query, filter, chart and export the data on canquery.';
+        description = subject + '. Query, filter, chart and export this live ' + formatLabel +
+            'table on CanQuery.';
     } else if (capability === 'ingestable') {
-        description = 'Load this ' + formatLabel + 'resource from ' + subject +
-            ' into a live table, then query, filter, chart and export it on canquery.';
+        description = subject + '. Load this ' + formatLabel +
+            'resource into a live table to query, filter, chart and export it.';
     } else if (capability === 'mapped') {
-        description = 'Explore ' + subject + ' on an interactive map, with metadata and access to the original ' +
-            formatLabel + 'file on canquery.';
+        description = subject + '. Explore it on an interactive map and access the original ' +
+            formatLabel + 'file on CanQuery.';
     } else {
-        description = 'View metadata for ' + subject + ' and access the original ' + formatLabel +
-            'file from its public-sector publisher on canquery.';
+        description = subject + '. View its metadata and access the original ' + formatLabel +
+            'file from the public-sector publisher.';
     }
     return truncate(description, DESCRIPTION_MAX);
+}
+
+function buildResourceJsonLd(resource, description) {
+    const name = pick(resource.name_en, resource.name_fr) || resourceTitleBase(resource);
+    const datasetName = pick(resource.dataset_title_en, resource.dataset_title_fr) || 'Dataset';
+    const datasetSlug = resource.dataset_name || resource.dataset_id;
+    const download = {
+        '@type': 'DataDownload',
+        name,
+        encodingFormat: plainText(resource.format) || undefined,
+        contentSize: humanFileSize(resource.size_bytes) || undefined,
+        contentUrl: absoluteHttpUrl(resource.url) || undefined,
+        isPartOf: datasetSlug ? {
+            '@type': 'Dataset',
+            name: datasetName,
+            url: SITE_URL + '/datasets/' + encodeURIComponent(datasetSlug)
+        } : undefined
+    };
+    for (const key of Object.keys(download)) {
+        if (download[key] === undefined) delete download[key];
+    }
+    const source = sourceForDataset(resource);
+    if (source && source.license_url) download.license = source.license_url;
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name,
+        description,
+        url: SITE_URL + '/resources/' + encodeURIComponent(resource.id),
+        mainEntity: download
+    };
 }
 
 function resourceMeta(resource) {
     const name = pick(resource.name_en, resource.name_fr) || 'Resource';
     const ds = pick(resource.dataset_title_en, resource.dataset_title_fr);
     const datasetSlug = resource.dataset_name || resource.dataset_id;
+    const description = resourceDescription(resource);
     return {
         title: siteTitle(resourceTitleBase(resource)),
-        description: resourceDescription(resource),
+        description,
         canonical: SITE_URL + '/resources/' + encodeURIComponent(resource.id),
         ogType: 'website',
-        jsonLd: [buildBreadcrumbJsonLd([
+        jsonLd: [buildResourceJsonLd(resource, description), buildBreadcrumbJsonLd([
             { name: 'Datasets', path: '/' },
             datasetSlug && ds ? {
                 name: ds,
@@ -366,11 +531,15 @@ function resourceMeta(resource) {
     };
 }
 
-function placeMeta(place) {
+function placeMeta(place, datasets = []) {
     const name = pick(place.name_en, place.name_fr) || 'Place';
     const type = pick(place.type_en, place.type_fr);
-    const description = 'Explore queryable and mappable open data' +
-        (type ? ' for the ' + type.toLowerCase() : ' for') + ' of ' + name + ' on canquery.';
+    const datasetCount = Number(place.dataset_count) || 0;
+    const mapCount = Number(place.mappable_dataset_count) || 0;
+    const description = 'Explore ' + datasetCount.toLocaleString('en-CA') + ' open dataset' +
+        (datasetCount === 1 ? '' : 's') + ' for ' + name +
+        (mapCount ? ', including ' + mapCount.toLocaleString('en-CA') + ' with interactive maps' : '') +
+        (type ? ' (' + type + ')' : '') + ' on CanQuery.';
     const slug = place.slug || place.id;
     const placePath = '/places/' + encodeURIComponent(slug);
     const ld = {
@@ -387,12 +556,36 @@ function placeMeta(place) {
             longitude: Number(place.longitude)
         };
     }
+    const collection = {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: name + ' open data',
+        description: truncate(description, DESCRIPTION_MAX),
+        url: SITE_URL + placePath,
+        about: {
+            '@type': 'AdministrativeArea',
+            name,
+            url: SITE_URL + placePath,
+            identifier: place.id
+        },
+        mainEntity: {
+            '@type': 'ItemList',
+            numberOfItems: datasetCount,
+            itemListElement: (datasets || []).slice(0, 12).map((dataset, index) => ({
+                '@type': 'ListItem',
+                position: index + 1,
+                name: pick(dataset.title_en, dataset.title_fr) || dataset.name || dataset.id,
+                url: SITE_URL + '/datasets/' + encodeURIComponent(dataset.name || dataset.id)
+            }))
+        }
+    };
     return {
         title: siteTitle(name + ' open data'),
         description: truncate(description, DESCRIPTION_MAX),
         canonical: SITE_URL + placePath,
         ogType: 'website',
-        jsonLd: [ld, buildBreadcrumbJsonLd([
+        noindex: datasetCount === 0,
+        jsonLd: [ld, collection, buildBreadcrumbJsonLd([
             { name: 'Places', path: '/places' },
             ...(Array.isArray(place.ancestors) ? place.ancestors.map(ancestor => ({
                 name: pick(ancestor.name_en, ancestor.name_fr),
@@ -403,13 +596,74 @@ function placeMeta(place) {
     };
 }
 
+function organizationMeta(organization, datasets = []) {
+    const name = pick(organization.title_en, organization.title_fr) || organization.name || 'Organization';
+    const organizationPath = '/organizations/' + encodeURIComponent(organization.name);
+    const total = Number(organization.dataset_count) || 0;
+    const queryable = Number(organization.queryable_dataset_count) || 0;
+    const mappable = Number(organization.mappable_dataset_count) || 0;
+    const capabilities = [
+        queryable ? queryable + ' queryable dataset' + (queryable === 1 ? '' : 's') : '',
+        mappable ? mappable + ' with interactive maps' : ''
+    ].filter(Boolean).join(' and ');
+    const description = truncate(
+        'Explore ' + total.toLocaleString('en-CA') + ' open dataset' + (total === 1 ? '' : 's') +
+        ' from ' + name + ' on CanQuery' + (capabilities ? ', including ' + capabilities : '') + '.',
+        DESCRIPTION_MAX
+    );
+    const items = (datasets || []).slice(0, 12).map((dataset, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: pick(dataset.title_en, dataset.title_fr) || dataset.name || dataset.id,
+        url: SITE_URL + '/datasets/' + encodeURIComponent(dataset.name || dataset.id)
+    }));
+    const collection = {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: name + ' open data',
+        description,
+        url: SITE_URL + organizationPath,
+        about: {
+            '@type': 'GovernmentOrganization',
+            name,
+            identifier: organization.id
+        },
+        mainEntity: {
+            '@type': 'ItemList',
+            numberOfItems: total,
+            itemListElement: items
+        }
+    };
+    return {
+        title: siteTitle(name + ' open data'),
+        description,
+        canonical: SITE_URL + organizationPath,
+        ogType: 'website',
+        noindex: total === 0,
+        jsonLd: [collection, buildBreadcrumbJsonLd([
+            { name: 'Organizations', path: '/organizations' },
+            { name, path: organizationPath }
+        ])]
+    };
+}
+
 function notFoundMeta(pathname) {
     return {
-        title: 'Not found - canquery',
+        title: 'Not found - CanQuery',
         description: DEFAULT_DESC,
         canonical: canonicalFor(pathname),
         ogType: 'website',
         noindex: true,
+    };
+}
+
+function serviceUnavailableMeta(pathname) {
+    return {
+        title: 'Temporarily unavailable - CanQuery',
+        description: 'This CanQuery page is temporarily unavailable. Please try again shortly.',
+        canonical: canonicalFor(pathname),
+        ogType: 'website',
+        noindex: true
     };
 }
 
@@ -429,7 +683,7 @@ function buildManagedTags(meta) {
     tags.push('<meta property="og:description" content="' + description + '" />');
     tags.push('<meta property="og:type" content="' + ogType + '" />');
     tags.push('<meta property="og:url" content="' + url + '" />');
-    tags.push('<meta property="og:site_name" content="canquery" />');
+    tags.push('<meta property="og:site_name" content="CanQuery" />');
     tags.push('<meta property="og:image" content="' + image + '" />');
     tags.push('<meta name="twitter:card" content="summary_large_image" />');
     tags.push('<meta name="twitter:title" content="' + title + '" />');
@@ -442,17 +696,25 @@ function buildManagedTags(meta) {
 // Replace the <!-- seo:start --> ... <!-- seo:end --> block in the SPA
 // template with freshly built tags. If the markers are absent (template
 // changed), return the template untouched - serving valid default HTML.
-function renderHtml(template, meta) {
+function renderHtml(template, meta, bodyHtml = '') {
     const re = /<!-- seo:start -->[\s\S]*?<!-- seo:end -->/;
-    if (!re.test(template)) return template;
-    const block = buildManagedTags(meta)
-        .map((line) => '    ' + line)
-        .join('\n');
-    // The replacement must be a function: a string replacement interprets
-    // $&, $', $` and $$ as substitution patterns, and dataset text can form
-    // them (escapeHtml turns "$'000" into "$&#39;000", whose "$&" would
-    // re-inject the whole matched block into the page).
-    return template.replace(re, () => '<!-- seo:start -->\n' + block + '\n    <!-- seo:end -->');
+    let html = template;
+    if (re.test(html)) {
+        const block = buildManagedTags(meta)
+            .map((line) => '    ' + line)
+            .join('\n');
+        // The replacement must be a function: a string replacement interprets
+        // $&, $', $` and $$ as substitution patterns, and catalogue text can
+        // otherwise re-inject the matched block.
+        html = html.replace(re, () => '<!-- seo:start -->\n' + block + '\n    <!-- seo:end -->');
+    }
+    if (bodyHtml && /<div id="root">\s*<\/div>/.test(html)) {
+        html = html.replace(
+            /<div id="root">\s*<\/div>/,
+            () => '<div id="root">' + bodyHtml + '</div>'
+        );
+    }
+    return html;
 }
 
 module.exports = {
@@ -462,12 +724,14 @@ module.exports = {
     DEFAULT_DESC,
     escapeHtml,
     jsonLdScript,
+    plainText,
     truncate,
     classifyRoute,
     canonicalFor,
     buildWebsiteJsonLd,
     buildOrganizationJsonLd,
     buildDatasetJsonLd,
+    datasetDescription,
     buildBreadcrumbJsonLd,
     isGenericResourceName,
     resourceTitleBase,
@@ -478,7 +742,9 @@ module.exports = {
     datasetMeta,
     resourceMeta,
     placeMeta,
+    organizationMeta,
     notFoundMeta,
+    serviceUnavailableMeta,
     buildManagedTags,
     renderHtml,
 };

--- a/server/services/seoSnapshot.js
+++ b/server/services/seoSnapshot.js
@@ -1,0 +1,270 @@
+const seo = require('./seoMeta');
+const { classifyResource } = require('./resourceCapabilities');
+
+const MAX_LINKS = 12;
+const MAX_SUMMARY = 1200;
+
+function text(value) {
+    return seo.escapeHtml(seo.plainText(value));
+}
+
+function pathLink(path, label) {
+    const cleanLabel = seo.plainText(label);
+    if (!path || !cleanLabel) return '';
+    return '<a href="' + seo.escapeHtml(path) + '">' + seo.escapeHtml(cleanLabel) + '</a>';
+}
+
+function breadcrumb(items) {
+    const entries = (items || []).filter(item => item && item.label);
+    if (!entries.length) return '';
+    return '<nav aria-label="Breadcrumb"><ol>' + entries.map((item, index) => {
+        const content = item.path && index < entries.length - 1
+            ? pathLink(item.path, item.label)
+            : '<span aria-current="page">' + text(item.label) + '</span>';
+        return '<li>' + content + '</li>';
+    }).join('') + '</ol></nav>';
+}
+
+function factList(facts) {
+    const entries = (facts || []).filter(fact => fact && fact.value !== null && fact.value !== undefined && fact.value !== '');
+    if (!entries.length) return '';
+    return '<dl>' + entries.map(fact => '<div><dt>' + text(fact.label) + '</dt><dd>' + text(fact.value) +
+        '</dd></div>').join('') + '</dl>';
+}
+
+function linkList(title, links) {
+    const entries = (links || []).filter(link => link && link.path && link.label).slice(0, MAX_LINKS);
+    if (!entries.length) return '';
+    return '<section><h2>' + text(title) + '</h2><ul>' + entries.map(link =>
+        '<li>' + pathLink(link.path, link.label) + (link.detail ? ' <span>' + text(link.detail) + '</span>' : '') + '</li>'
+    ).join('') + '</ul></section>';
+}
+
+function shell({ breadcrumbs, title, summary, facts, linksTitle, links, relatedLinks }) {
+    return '<main class="cq-seo-snapshot max-w-5xl mx-auto px-4 py-8" data-cq-seo-snapshot="true">' +
+        breadcrumb(breadcrumbs) + '<article><h1>' + text(title) + '</h1>' +
+        (summary ? '<p>' + text(seo.truncate(summary, MAX_SUMMARY)) + '</p>' : '') +
+        factList(facts) + linkList(linksTitle, links) +
+        linkList('Related open data', relatedLinks) + '</article></main>';
+}
+
+function datasetSnapshot(dataset, resources) {
+    const title = seo.plainText(dataset.title_en) || seo.plainText(dataset.title_fr) || dataset.name || dataset.id;
+    const organization = seo.plainText(dataset.org_title_en) || seo.plainText(dataset.org_title_fr);
+    const links = (resources || []).slice(0, MAX_LINKS).map(resource => ({
+        path: '/resources/' + encodeURIComponent(resource.id),
+        label: seo.plainText(resource.name_en) || seo.plainText(resource.name_fr) || resource.format || resource.id,
+        detail: resource.format || classifyResource(resource).capability
+    }));
+    const placeLinks = (Array.isArray(dataset.places) ? dataset.places : []).map(place => ({
+        path: '/places/' + encodeURIComponent(place.slug || place.id),
+        label: seo.plainText(place.name_en) || seo.plainText(place.name_fr) || place.slug
+    }));
+    const organizationLinks = organization && dataset.org_name ? [{
+        path: '/organizations/' + encodeURIComponent(dataset.org_name),
+        label: organization
+    }] : [];
+    return shell({
+        breadcrumbs: [{ label: 'Datasets', path: '/' }, { label: title }],
+        title,
+        summary: seo.datasetDescription(dataset, resources, MAX_SUMMARY),
+        facts: [
+            organization ? {
+                label: 'Publisher',
+                value: organization
+            } : null,
+            { label: 'Resources', value: (resources || []).length },
+            dataset.metadata_modified ? {
+                label: 'Updated',
+                value: new Date(dataset.metadata_modified).toLocaleDateString('en-CA')
+            } : null
+        ],
+        linksTitle: 'Resources',
+        links,
+        relatedLinks: organizationLinks.concat(placeLinks)
+    });
+}
+
+function resourceSnapshot(resource) {
+    const name = seo.plainText(resource.name_en) || seo.plainText(resource.name_fr) || resource.id;
+    const datasetName = seo.plainText(resource.dataset_title_en) || seo.plainText(resource.dataset_title_fr) || resource.dataset_name || resource.dataset_id;
+    const datasetSlug = resource.dataset_name || resource.dataset_id;
+    const organization = seo.plainText(resource.org_title_en) || seo.plainText(resource.org_title_fr);
+    const capability = classifyResource(resource).capability;
+    const links = [];
+    if (organization && resource.org_name) {
+        links.push({ path: '/organizations/' + encodeURIComponent(resource.org_name), label: organization });
+    }
+    for (const place of Array.isArray(resource.places) ? resource.places : []) {
+        links.push({
+            path: '/places/' + encodeURIComponent(place.slug || place.id),
+            label: seo.plainText(place.name_en) || seo.plainText(place.name_fr) || place.slug
+        });
+    }
+    return shell({
+        breadcrumbs: [
+            { label: 'Datasets', path: '/' },
+            { label: datasetName, path: '/datasets/' + encodeURIComponent(datasetSlug) },
+            { label: name }
+        ],
+        title: name,
+        summary: seo.resourceDescription(resource),
+        facts: [
+            { label: 'Format', value: resource.format || 'File' },
+            { label: 'Access', value: capability },
+            resource.size_bytes ? { label: 'Size', value: Number(resource.size_bytes).toLocaleString('en-CA') + ' bytes' } : null,
+            resource.last_modified ? { label: 'Updated', value: new Date(resource.last_modified).toLocaleDateString('en-CA') } : null
+        ],
+        linksTitle: 'Related open data',
+        links
+    });
+}
+
+function placeSnapshot(place, datasets) {
+    const name = seo.plainText(place.name_en) || seo.plainText(place.name_fr) || place.slug || place.id;
+    const ancestors = (Array.isArray(place.ancestors) ? place.ancestors : [])
+        .filter(ancestor => ancestor.id !== place.id)
+        .map(ancestor => ({
+            label: seo.plainText(ancestor.name_en) || seo.plainText(ancestor.name_fr),
+            path: '/places/' + encodeURIComponent(ancestor.slug || ancestor.id)
+        }));
+    const datasetLinks = (datasets || []).map(dataset => ({
+        path: '/datasets/' + encodeURIComponent(dataset.name || dataset.id),
+        label: seo.plainText(dataset.title_en) || seo.plainText(dataset.title_fr) || dataset.name || dataset.id
+    }));
+    const childLinks = (Array.isArray(place.children) ? place.children : []).map(child => ({
+        path: '/places/' + encodeURIComponent(child.slug || child.id),
+        label: seo.plainText(child.name_en) || seo.plainText(child.name_fr) || child.slug,
+        detail: Number(child.dataset_count || 0).toLocaleString('en-CA') + ' datasets'
+    }));
+    const count = Number(place.dataset_count) || 0;
+    const maps = Number(place.mappable_dataset_count) || 0;
+    return shell({
+        breadcrumbs: [{ label: 'Places', path: '/places' }, ...ancestors, { label: name }],
+        title: name + ' open data',
+        summary: 'Explore ' + count.toLocaleString('en-CA') + ' open dataset' + (count === 1 ? '' : 's') +
+            ' for ' + name + (maps ? ', including ' + maps.toLocaleString('en-CA') + ' with interactive maps.' : '.'),
+        facts: [
+            { label: 'Datasets', value: count },
+            { label: 'Direct datasets', value: Number(place.direct_dataset_count) || 0 },
+            { label: 'Mappable datasets', value: maps }
+        ],
+        linksTitle: datasetLinks.length ? 'Open datasets' : 'Places in this area',
+        links: datasetLinks.length ? datasetLinks : childLinks
+    });
+}
+
+function organizationSnapshot(organization, datasets) {
+    const name = seo.plainText(organization.title_en) || seo.plainText(organization.title_fr) || organization.name;
+    const links = (datasets || []).map(dataset => ({
+        path: '/datasets/' + encodeURIComponent(dataset.name || dataset.id),
+        label: seo.plainText(dataset.title_en) || seo.plainText(dataset.title_fr) || dataset.name || dataset.id
+    }));
+    const relatedLinks = [];
+    if (organization.place_id) {
+        relatedLinks.push({
+            path: '/places/' + encodeURIComponent(organization.place_slug || organization.place_id),
+            label: seo.plainText(organization.place_name_en) || seo.plainText(organization.place_name_fr) || organization.place_slug
+        });
+    }
+    const total = Number(organization.dataset_count) || 0;
+    return shell({
+        breadcrumbs: [{ label: 'Organizations', path: '/organizations' }, { label: name }],
+        title: name + ' open data',
+        summary: 'Browse ' + total.toLocaleString('en-CA') + ' open dataset' + (total === 1 ? '' : 's') +
+            ' published by ' + name + ' and mirrored by CanQuery.',
+        facts: [
+            { label: 'Datasets', value: total },
+            { label: 'Queryable datasets', value: Number(organization.queryable_dataset_count) || 0 },
+            { label: 'Mappable datasets', value: Number(organization.mappable_dataset_count) || 0 }
+        ],
+        linksTitle: 'Open datasets',
+        links,
+        relatedLinks
+    });
+}
+
+const STATIC_COPY = {
+    home: {
+        title: "Search Canada's open data",
+        summary: 'Find federal, provincial, territorial and municipal datasets, query live tables, and explore spatial resources on maps.',
+        links: [
+            { path: '/places', label: 'Browse open data by place' },
+            { path: '/organizations', label: 'Browse publishing organizations' },
+            { path: '/insights', label: 'Explore popular dataset insights' },
+            { path: '/docs', label: 'Use the CanQuery API' }
+        ]
+    },
+    insights: {
+        title: 'Top downloaded Canadian datasets',
+        summary: 'Explore live charts built from the most-downloaded datasets in the CanQuery catalogue.',
+        links: [{ path: '/', label: 'Search all datasets' }]
+    },
+    organizations: {
+        title: 'Organizations publishing Canadian open data',
+        summary: 'Browse public-sector organizations and the datasets they publish through CanQuery.'
+    },
+    places: {
+        title: 'Canadian open data by place',
+        summary: 'Browse open datasets for provinces, territories, regions and municipalities across Canada.'
+    },
+    docs: {
+        title: 'CanQuery API documentation',
+        summary: 'Use the anonymous JSON API to search datasets, query tables, export filtered data and request map features.',
+        links: [{ path: '/', label: 'Search the catalogue' }]
+    },
+    privacy: {
+        title: 'Privacy and analytics',
+        summary: 'Learn how CanQuery uses cookie-free, self-hosted analytics and honors browser privacy signals.',
+        links: [{ path: '/', label: 'Return to CanQuery' }]
+    }
+};
+
+function staticSnapshot(type, items = []) {
+    const copy = STATIC_COPY[type] || STATIC_COPY.home;
+    const dynamicLinks = items.map(item => {
+        if (type === 'organizations') {
+            return {
+                path: '/organizations/' + encodeURIComponent(item.name),
+                label: seo.plainText(item.title_en) || seo.plainText(item.title_fr) || item.name,
+                detail: Number(item.dataset_count || 0).toLocaleString('en-CA') + ' datasets'
+            };
+        }
+        if (type === 'places') {
+            return {
+                path: '/places/' + encodeURIComponent(item.slug || item.id),
+                label: seo.plainText(item.name_en) || seo.plainText(item.name_fr) || item.slug,
+                detail: Number(item.dataset_count || 0).toLocaleString('en-CA') + ' datasets'
+            };
+        }
+        return null;
+    }).filter(Boolean);
+    return shell({
+        breadcrumbs: type === 'home' ? [] : [{ label: 'CanQuery', path: '/' }, { label: copy.title }],
+        title: copy.title,
+        summary: copy.summary,
+        linksTitle: dynamicLinks.length ? (type === 'places' ? 'Featured places' : 'Publishing organizations') : 'Explore CanQuery',
+        links: dynamicLinks.length ? dynamicLinks : copy.links
+    });
+}
+
+function errorSnapshot(title, summary) {
+    return shell({
+        breadcrumbs: [{ label: 'CanQuery', path: '/' }, { label: title }],
+        title,
+        summary,
+        linksTitle: 'Continue',
+        links: [{ path: '/', label: 'Return to dataset search' }]
+    });
+}
+
+module.exports = {
+    MAX_LINKS,
+    MAX_SUMMARY,
+    datasetSnapshot,
+    resourceSnapshot,
+    placeSnapshot,
+    organizationSnapshot,
+    staticSnapshot,
+    errorSnapshot
+};


### PR DESCRIPTION
## What & why

Dataset, resource, place and organization pages now include useful initial HTML, canonical links and structured data. Organization detail pages add bilingual publisher browsing. Client navigation and Back refresh the page title, canonical and schema; unavailable catalogue lookups return retryable 503 responses, and unknown routes return real 404s.

Search Console reports filter semantic intent before result limits, count distinct reported queries across the full 28-day window, and keep property totals separate from query-page opportunities. Unknown file sizes no longer appear as zero bytes. French mobile dataset rows retain readable titles and localized counts.

## Checklist

- [x] `server`: lint and 566 tests pass
- [x] `client`: lint, 124 tests and production build pass
- [x] 16 PostgreSQL/PostGIS integration tests pass; CI includes reporting and migration idempotence
- [x] Regression tests cover navigation races, failure responses, report limits and query classification parity
- [x] User-facing strings support EN + FR
- [x] No secrets, credentials or private production evidence included

## Notes

Browser verification covered all four page families with JavaScript enabled and disabled, navigation and Back, French at 390px, alias redirects, unknown routes and simulated catalogue outages. Migration 031 is already part of PR #38; this closeout adds no schema migration. The release runbook covers guarded backups, source-scoped recovery, deployment and application rollback.