### PR TITLE
Improve local discovery and add bilingual resident guides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           cache-dependency-path: server/package-lock.json
       - run: npm ci
       - run: npm run lint
+      - run: npm run blog:check
       - run: npm test # jest; the suite mocks the database, so no Postgres needed
 
   client:
@@ -74,4 +75,4 @@ jobs:
           cache-dependency-path: server/package-lock.json
       - run: npm ci
       - run: npm run migrate
-      - run: npx jest __tests__/spatialIntegration.test.js __tests__/searchConsoleIntegration.test.js --runInBand
+      - run: npx jest __tests__/spatialIntegration.test.js __tests__/searchConsoleIntegration.test.js __tests__/localSearchIntegration.test.js --runInBand

--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ The Whitehorse, St. John's, and Charlottetown source identities remain configure
 their previously documented ArcGIS feeds are unavailable and no equivalent machine-readable
 catalogue with verified open-data terms is currently admissible.
 
+## Local resident guides
+
+The bilingual [local guides](https://canquery.com/blog) connect practical city
+questions to verified maps and tables: Oshawa park boundaries, Toronto active
+building permits, and Montréal parks and public spaces. French editions have
+separate URLs under `/fr/blog` and reciprocal language links. Articles include
+source attribution, coverage limits, and independently labelled publication,
+article-update, and link-verification dates.
+
+Guides are maintained in `content/blog/` with paired Markdown files and a JSON
+manifest; see its README for the authoring workflow. Full articles are served
+before JavaScript, and `/sitemap-blog.xml` is included in the sitemap index.
+The read-only API exposes `GET /api/v1/blog?lang=en&place=oshawa-on` and
+`GET /api/v1/blog/:lang/:slug` using the normal response envelope.
+
+Catalogue search supports reviewed English/French terms for parks, playgrounds,
+and building permits, with bounded spelling suggestions on empty first pages.
+Results include localized `description`, `preview_resources` map/table IDs,
+and `meta.search` query/suggestions while preserving the existing filters and
+pagination. Result links reflect current resource capabilities.
+
 ## Layout
 
 ```

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -18,6 +18,7 @@ import { useLang } from './i18n.jsx'
 
 // The gallery renders charts (Recharts) - lazy-load it so the chart bundle only
 // ships when someone opens /insights.
+const BlogPage = lazy(() => import('./pages/BlogPage.jsx'));
 const InsightsPage = lazy(() => import('./pages/InsightsPage'))
 
 function ScrollToTop() {
@@ -60,6 +61,10 @@ export default function App() {
             <Route path="/places" element={<PlacesPage />} />
             <Route path="/places/:slug" element={<PlacePage />} />
             <Route path="/docs" element={<DocsPage />} />
+            <Route path="/blog" element={<BlogPage />} />
+            <Route path="/blog/:slug" element={<BlogPage />} />
+            <Route path="/fr/blog" element={<BlogPage language="fr" />} />
+            <Route path="/fr/blog/:slug" element={<BlogPage language="fr" />} />
             <Route path="/privacy" element={<PrivacyPage />} />
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/client/src/api/catalog.js
+++ b/client/src/api/catalog.js
@@ -116,3 +116,11 @@ export async function fetchStats() {
     return null;
   }
 }
+
+export function fetchBlog({ lang = 'en', place } = {}) {
+  return getJSON('/api/v1/blog', { lang, place });
+}
+
+export function fetchBlogArticle(lang, slug) {
+  return getJSON('/api/v1/blog/' + encodeURIComponent(lang) + '/' + encodeURIComponent(slug));
+}

--- a/client/src/components/DatasetRow.jsx
+++ b/client/src/components/DatasetRow.jsx
@@ -13,19 +13,18 @@ export default function DatasetRow({ dataset }) {
     : null;
 
   return (
-    <Link
-      to={'/datasets/' + (dataset.name || dataset.id)}
+    <article
       className="cq-card block p-4 sm:px-5 group"
-      data-analytics-event="dataset_open"
-      data-analytics-dataset-id={dataset.id}
-      data-analytics-dataset-slug={dataset.name || ''}
-      data-analytics-source="catalog_result"
     >
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
         <div className="min-w-0 sm:flex-1">
           <div className="font-semibold text-[0.95rem] leading-snug line-clamp-2 group-hover:text-base-content transition-colors">
-            {title}
+            <Link to={'/datasets/' + (dataset.name || dataset.id)} className="hover:underline"
+              data-analytics-event="dataset_open" data-analytics-dataset-id={dataset.id} data-analytics-source="catalog_result">{title}</Link>
           </div>
+          {(dataset.description?.[lang] || dataset.description?.en || dataset.description?.fr) && (
+            <p className="text-sm text-base-content/65 mt-2 line-clamp-2">{dataset.description?.[lang] || dataset.description?.en || dataset.description?.fr}</p>
+          )}
           <div className="text-[0.8rem] text-base-content/45 mt-1.5 flex items-center gap-x-3 gap-y-1 flex-wrap">
             {orgTitle && (
               <span className="inline-flex items-center gap-1.5 min-w-0">
@@ -36,7 +35,7 @@ export default function DatasetRow({ dataset }) {
             {modifiedDate && (
               <span className="inline-flex items-center gap-1.5">
                 <CalendarIcon size={12} />
-                {modifiedDate}
+                <span title={t('discovery.metadata')}>{t('discovery.metadata')}: {modifiedDate}</span>
               </span>
             )}
             {place && (
@@ -64,12 +63,20 @@ export default function DatasetRow({ dataset }) {
               {t('places.map')}
             </span>
           )}
+          {dataset.preview_resources?.map && <Link className="btn btn-sm btn-outline" to={'/resources/' + encodeURIComponent(dataset.preview_resources.map) + '?view=map'}
+            data-analytics-event="resource_view" data-analytics-view="map" data-analytics-source="catalog_result" data-analytics-resource-id={dataset.preview_resources.map}>
+            {t('discovery.map')}
+          </Link>}
+          {dataset.preview_resources?.table && <Link className="btn btn-sm btn-outline" to={'/resources/' + encodeURIComponent(dataset.preview_resources.table)}
+            data-analytics-event="resource_open" data-analytics-source="catalog_result" data-analytics-resource-id={dataset.preview_resources.table}>
+            {t('discovery.table')}
+          </Link>}
           <ArrowRightIcon
             size={15}
             className="opacity-0 group-hover:opacity-50 transition-opacity hidden sm:block"
           />
         </div>
       </div>
-    </Link>
+    </article>
   );
 }

--- a/client/src/components/DatasetRow.test.jsx
+++ b/client/src/components/DatasetRow.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { expect, test } from 'vitest';
+import DatasetRow from './DatasetRow.jsx';
+
+const dataset = { id: 'parks', name: 'parks', title: { en: 'Park boundaries' },
+  description: { en: 'Explore published park boundaries.' }, resource_count: 1, queryable_count: 0, mappable_count: 1,
+  preview_resources: { map: 'park-map', table: null } };
+
+test('offers only supported resource actions and keeps links separate', () => {
+  render(<MemoryRouter><DatasetRow dataset={dataset} /></MemoryRouter>);
+  expect(screen.getByText(dataset.description.en)).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: 'Explore map' })).toHaveAttribute('href', '/resources/park-map?view=map');
+  expect(screen.queryByRole('link', { name: 'View records' })).toBeNull();
+  expect(document.querySelector('a a')).toBeNull();
+  expect(screen.getByRole('link', { name: dataset.title.en })).toHaveAttribute('href', '/datasets/parks');
+});

--- a/client/src/components/Footer.jsx
+++ b/client/src/components/Footer.jsx
@@ -73,7 +73,7 @@ function StarCount() {
 }
 
 export default function Footer() {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   return (
     <footer className="mt-20 border-t border-base-content/8 bg-base-200/40">
       <div className="max-w-7xl mx-auto px-4 py-12 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
@@ -155,6 +155,9 @@ export default function Footer() {
               <Link to="/docs" className="text-base-content/65 hover:text-base-content transition-colors">
                 {t('nav.docs')}
               </Link>
+            </li>
+            <li>
+              <Link to={lang === 'fr' ? '/fr/blog' : '/blog'} className="text-base-content/65 hover:text-base-content transition-colors">{t('blog.title')}</Link>
             </li>
             <li>
               <Link to="/privacy" className="text-base-content/65 hover:text-base-content transition-colors">

--- a/client/src/components/LocalGuides.jsx
+++ b/client/src/components/LocalGuides.jsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { fetchBlog } from '../api/catalog.js';
+import { useLang } from '../i18n.jsx';
+
+export default function LocalGuides({ place }) {
+  const { t, lang } = useLang();
+  const [articles, setArticles] = useState([]);
+  useEffect(() => {
+    let cancelled = false;
+    setArticles([]);
+    fetchBlog({ lang, place: place || undefined }).then(env => {
+      if (!cancelled) setArticles(env.data);
+    }).catch(() => {});
+    return () => { cancelled = true; };
+  }, [lang, place]);
+  if (!articles.length) return null;
+  return <section className="mt-8 text-left" aria-label={t('blog.title')}>
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <h2 className="font-display font-semibold text-xl">{t('discovery.title')}</h2>
+      <Link className="link text-sm" to={lang === 'fr' ? '/fr/blog' : '/blog'}>{t('blog.title')} →</Link>
+    </div>
+    <div className={'grid gap-4 mt-4 ' + (articles.length > 1 ? 'md:grid-cols-3' : '')}>
+      {articles.map(article => <article className="cq-card p-5" key={article.id}>
+        <a className="cq-pill !text-xs" href={'/?' + new URLSearchParams({ place: article.place, q: article.query })}
+          data-analytics-event="catalog_filter" data-analytics-filter="topic" data-analytics-value={article.topic} data-analytics-place={article.place}>
+          {article.placeName} · {article.topicName}
+        </a>
+        <h3 className="font-semibold mt-4"><Link className="hover:underline" to={article.path}>{article.title}</Link></h3>
+        <p className="text-sm text-base-content/60 mt-2 leading-relaxed">{article.description}</p>
+        <Link className="link text-sm inline-block mt-4" to={article.path}>{t('blog.read')} →</Link>
+      </article>)}
+    </div>
+  </section>;
+}

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { useLang } from '../i18n.jsx';
 import { useTheme } from '../theme.jsx';
 import { MapleLeaf, ExternalIcon, SparklesIcon, SunIcon, MoonIcon } from './Icons.jsx';
@@ -7,7 +7,16 @@ import { track } from '../utils/analytics.js';
 const navClass = ({ isActive }) => 'cq-nav-link' + (isActive ? ' cq-nav-active' : '');
 
 export default function Navbar() {
-  const { lang, setLang, t } = useLang();
+  const { lang, setLang, t, blogTranslations } = useLang();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const isBlog = /^\/(fr\/)?blog(?:\/|$)/.test(pathname);
+  const chooseLanguage = language => {
+    track('ui_language', { language });
+    if (isBlog && blogTranslations?.pathname === pathname) navigate(blogTranslations.paths[language]);
+    else if (isBlog) navigate(language === 'fr' ? '/fr/blog' : '/blog');
+    setLang(language);
+  };
   const { dark, toggle } = useTheme();
   return (
     <header className="cq-glass sticky top-0 z-40">
@@ -33,6 +42,9 @@ export default function Navbar() {
           </NavLink>
           <NavLink to="/places" className={navClass}>
             {t('nav.places')}
+          </NavLink>
+          <NavLink to={lang === 'fr' ? '/fr/blog' : '/blog'} className={navClass}>
+            {t('blog.title')}
           </NavLink>
           <NavLink to="/docs" className={navClass}>
             {t('nav.docs')}
@@ -65,14 +77,16 @@ export default function Navbar() {
           <div className="cq-seg ml-1">
             <button
               className={'cq-seg-btn' + (lang === 'en' ? ' cq-seg-active' : '')}
-              onClick={() => { track('ui_language', { language: 'en' }); setLang('en'); }}
+              onClick={() => chooseLanguage('en')}
+              disabled={isBlog && /\/blog\/[^/]+/.test(pathname) && blogTranslations?.pathname !== pathname}
               aria-pressed={lang === 'en'}
             >
               EN
             </button>
             <button
               className={'cq-seg-btn' + (lang === 'fr' ? ' cq-seg-active' : '')}
-              onClick={() => { track('ui_language', { language: 'fr' }); setLang('fr'); }}
+              onClick={() => chooseLanguage('fr')}
+              disabled={isBlog && /\/blog\/[^/]+/.test(pathname) && blogTranslations?.pathname !== pathname}
               aria-pressed={lang === 'fr'}
             >
               FR

--- a/client/src/components/RouteHead.test.jsx
+++ b/client/src/components/RouteHead.test.jsx
@@ -99,3 +99,14 @@ test.each(['network', 'mismatched canonical', 'malformed schema'])('clears stale
   expect(document.querySelector('script[type="application/ld+json"]')).toBeNull();
   expect(document.querySelector('meta[name=robots]')).toBeNull();
 });
+
+test('preserves translated alternates while replacing the canonical on client navigation', async () => {
+  fetch.mockResolvedValue(response('/datasets/roads', 'Road guide', 200,
+    '<link rel="alternate" hreflang="en-CA" href="https://canquery.com/blog/roads">' +
+    '<link rel="alternate" hreflang="fr-CA" href="https://canquery.com/fr/blog/routes">'));
+  start();
+  fireEvent.click(screen.getByText('Dataset'));
+  await waitFor(() => expect(document.title).toBe('Road guide'));
+  expect(document.querySelectorAll('link[rel=canonical]')).toHaveLength(1);
+  expect(document.querySelector('link[hreflang="fr-CA"]').href).toBe('https://canquery.com/fr/blog/routes');
+});

--- a/client/src/hooks/usePaginatedCollection.js
+++ b/client/src/hooks/usePaginatedCollection.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 export default function usePaginatedCollection(fetchPage, deps) {
+  const [meta, setMeta] = React.useState(null);
   const [items, setItems] = React.useState([]);
   const [loading, setLoading] = React.useState(true);
   const [loadingMore, setLoadingMore] = React.useState(false);
@@ -13,9 +14,11 @@ export default function usePaginatedCollection(fetchPage, deps) {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setMeta(null);
     fetchPage(null).then(env => {
       if (cancelled || seqRef.current !== mySeq) return;
       setItems(env.data || []);
+      setMeta(env.meta || null);
       setNextCursor(env.pagination ? env.pagination.nextCursor : null);
     }).catch(err => {
       if (cancelled || seqRef.current !== mySeq) return;
@@ -41,5 +44,5 @@ export default function usePaginatedCollection(fetchPage, deps) {
     }
   }, [nextCursor, loadingMore, fetchPage]);
 
-  return { items, loading, loadingMore, error, hasMore: Boolean(nextCursor), loadMore };
+  return { items, meta, loading, loadingMore, error, hasMore: Boolean(nextCursor), loadMore };
 }

--- a/client/src/i18n.jsx
+++ b/client/src/i18n.jsx
@@ -10,6 +10,25 @@ export const STRINGS = {
     'nav.insights': 'Insights',
     'nav.organizations': 'Organizations',
     'nav.places': 'Places',
+    "blog.title": "Local guides",
+    "blog.eyebrow": "Your city, explained with data",
+    "blog.intro": "Practical ways to explore your city with official open data. Start with a local question, then open the map or records behind it.",
+    "blog.read": "Read the guide",
+    "blog.not_found": "Guide not found",
+    "blog.failed": "This guide could not be loaded. Please try again.",
+    "blog.loading": "Loading guide",
+    "blog.by": "By",
+    "blog.published": "Published",
+    "blog.updated": "Article updated",
+    "blog.verified": "Data links checked",
+    "blog.dataset": "View the source dataset",
+    "blog.more": "More data for",
+    "discovery.title": "Explore something local",
+    "discovery.map": "Explore map",
+    "discovery.table": "View records",
+    "discovery.suggest": "Try this spelling:",
+    "discovery.metadata": "Catalogue metadata updated",
+
     'nav.docs': 'API docs',
     'breadcrumbs.label': 'Breadcrumb',
     'theme.toggle': 'Toggle light / dark theme',
@@ -274,6 +293,25 @@ export const STRINGS = {
     'nav.insights': 'Aperçus',
     'nav.organizations': 'Organisations',
     'nav.places': 'Lieux',
+    "blog.title": "Guides locaux",
+    "blog.eyebrow": "Votre ville, expliquée par les données",
+    "blog.intro": "Des façons pratiques de découvrir votre ville grâce aux données ouvertes officielles. Partez d’une question locale, puis consultez la carte ou les dossiers associés.",
+    "blog.read": "Lire le guide",
+    "blog.not_found": "Guide introuvable",
+    "blog.failed": "Impossible de charger ce guide. Veuillez réessayer.",
+    "blog.loading": "Chargement du guide",
+    "blog.by": "Par",
+    "blog.published": "Publié le",
+    "blog.updated": "Article mis à jour le",
+    "blog.verified": "Liens vérifiés le",
+    "blog.dataset": "Consulter le jeu de données source",
+    "blog.more": "Autres données pour",
+    "discovery.title": "Explorez votre milieu",
+    "discovery.map": "Explorer la carte",
+    "discovery.table": "Consulter les dossiers",
+    "discovery.suggest": "Essayez cette orthographe :",
+    "discovery.metadata": "Métadonnées du catalogue mises à jour",
+
     'nav.docs': 'API',
     'breadcrumbs.label': 'Fil d’Ariane',
     'theme.toggle': 'Basculer le thème clair / sombre',
@@ -544,7 +582,10 @@ const lookup = (lang, key) => {
 const LangContext = createContext({ lang: 'en', setLang: () => {}, t: (key) => lookup('en', key) });
 
 export function LangProvider({ children }) {
+  const [blogTranslations, setBlogTranslations] = useState(null);
   const [lang, setLangState] = useState(() => {
+    if (/^\/fr\/blog(?:\/|$)/.test(window.location.pathname)) return 'fr';
+    if (/^\/blog(?:\/|$)/.test(window.location.pathname)) return 'en';
     try {
       return localStorage.getItem('cq-lang') === 'fr' ? 'fr' : 'en';
     } catch {
@@ -561,7 +602,7 @@ export function LangProvider({ children }) {
     }
   }, []);
   const t = useCallback((key) => lookup(lang, key), [lang]);
-  return <LangContext.Provider value={{ lang, setLang, t }}>{children}</LangContext.Provider>;
+  return <LangContext.Provider value={{ lang, setLang, t, blogTranslations, setBlogTranslations }}>{children}</LangContext.Provider>;
 }
 
 export function useLang() {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -847,3 +847,17 @@ a.cq-card:hover,
     transition: none;
   }
 }
+
+/* Authored guides use the same readable column with and without JavaScript. */
+.cq-article { line-height: 1.8; overflow-wrap: anywhere; }
+.cq-article p, .cq-article ul, .cq-article ol { margin-block: 1.2rem; }
+.cq-article h2 { font-family: 'Space Grotesk Variable', sans-serif; font-weight: 650; font-size: 1.45rem; line-height: 1.35; margin-top: 2.5rem; margin-bottom: 1rem; }
+.cq-article h3 { font-weight: 650; font-size: 1.1rem; margin-top: 1.8rem; }
+.cq-article a { text-decoration: underline; text-underline-offset: 3px; }
+.cq-article a:hover { color: var(--color-primary); }
+.cq-article a:focus-visible { outline: 2px solid currentColor; outline-offset: 4px; }
+.cq-article ol { list-style: decimal; padding-left: 1.5rem; }
+.cq-article ul { list-style: disc; padding-left: 1.5rem; }
+.cq-article li { padding-left: .3rem; margin-block: .8rem; }
+.cq-article img { max-width: 100%; height: auto; border-radius: .75rem; }
+.cq-article table { display: block; overflow-x: auto; }

--- a/client/src/pages/BlogPage.jsx
+++ b/client/src/pages/BlogPage.jsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { fetchBlog, fetchBlogArticle } from '../api/catalog.js';
+import { useLang } from '../i18n.jsx';
+import { NotFoundError } from '../api/client.js';
+import LoadingSpinner from '../components/LoadingSpinner.jsx';
+import { track } from '../utils/analytics.js';
+
+export default function BlogPage({ language = 'en' }) {
+  const { slug } = useParams();
+  const { pathname } = useLocation();
+  const { t, setLang, setBlogTranslations } = useLang();
+  const [content, setContent] = useState(null);
+  const [error, setError] = useState(null);
+  const indexPath = language === 'fr' ? '/fr/blog' : '/blog';
+
+  useEffect(() => { setLang(language); }, [language, setLang]);
+  useEffect(() => {
+    let cancelled = false;
+    setContent(null);
+    setError(null);
+    const request = slug ? fetchBlogArticle(language, slug) : fetchBlog({ lang: language });
+    request.then(env => {
+      if (cancelled) return;
+      setContent({ pathname, data: env.data });
+      setBlogTranslations({ pathname, paths: slug ? env.data.translations : { en: '/blog', fr: '/fr/blog' } });
+    }).catch(err => { if (!cancelled) setError({ pathname, cause: err }); });
+    return () => { cancelled = true; setBlogTranslations(null); };
+  }, [slug, language, pathname, setBlogTranslations]);
+
+  if (error?.pathname === pathname) return <div className="max-w-3xl mx-auto px-4 py-12">
+    <h1 className="text-3xl font-display font-bold">{error.cause instanceof NotFoundError ? t('blog.not_found') : t('blog.failed')}</h1>
+    <Link to={indexPath} className="link mt-6 inline-block">{t('blog.title')}</Link>
+  </div>;
+  if (!content || content.pathname !== pathname) return <LoadingSpinner label={t('blog.loading')} />;
+  if (!slug) return <div className="max-w-6xl mx-auto px-4 py-10">
+    <p className="cq-chip">{t('blog.eyebrow')}</p>
+    <h1 className="font-display text-4xl sm:text-5xl font-bold mt-4">{t('blog.title')}</h1>
+    <p className="text-lg text-base-content/65 mt-4 max-w-2xl">{t('blog.intro')}</p>
+    <div className="grid md:grid-cols-3 gap-5 mt-10">
+      {content.data.map(article => <article key={article.id} className="cq-card p-6 flex flex-col items-start">
+        <span className="cq-chip">{article.placeName}</span>
+        <h2 className="font-display text-xl font-semibold mt-4"><Link className="hover:underline" to={article.path}>{article.title}</Link></h2>
+        <p className="text-sm text-base-content/65 mt-3 mb-6 leading-relaxed">{article.description}</p>
+        <Link className="link mt-auto" to={article.path}>{t('blog.read')} →</Link>
+      </article>)}
+    </div>
+  </div>;
+
+  const article = content.data;
+  const date = value => new Date(value + 'T12:00:00Z').toLocaleDateString(language === 'fr' ? 'fr-CA' : 'en-CA', { dateStyle: 'long', timeZone: 'UTC' });
+  const otherLanguage = language === 'fr' ? 'en' : 'fr';
+  return <div className="max-w-3xl mx-auto px-4 py-10">
+    <nav aria-label={t('breadcrumbs.label')}><Link to={indexPath} className="link text-sm">{t('blog.title')}</Link></nav>
+    <article className="mt-7">
+      <div className="flex flex-wrap gap-2"><Link className="cq-chip" to={'/places/' + article.place}>{article.placeName}</Link><span className="cq-chip">{article.topicName}</span></div>
+      <h1 className="font-display text-3xl sm:text-4xl font-bold leading-tight mt-5">{article.title}</h1>
+      <p className="text-lg text-base-content/65 leading-relaxed mt-5">{article.description}</p>
+      <div className="text-sm text-base-content/60 space-y-1 mt-5">
+        <p>{t('blog.by')} <Link to="/" className="link">CanQuery</Link> · {t('blog.published')} <time dateTime={article.published}>{date(article.published)}</time></p>
+        <p>{t('blog.updated')} <time dateTime={article.updated}>{date(article.updated)}</time></p>
+        <p>{t('blog.verified')} <time dateTime={article.verified}>{date(article.verified)}</time></p>
+      </div>
+      <Link className="link inline-block mt-4 text-sm" to={article.translations[otherLanguage]} hrefLang={otherLanguage}>
+        {otherLanguage === 'fr' ? 'Lire en français' : 'Read in English'}
+      </Link>
+      <div className="cq-article mt-8" dangerouslySetInnerHTML={{ __html: article.bodyHtml }} onClick={event => {
+        const anchor = event.target.closest('a');
+        if (anchor?.getAttribute('href')?.startsWith('/resources/')) {
+          track('blog_explore', { article: article.id, language, place: article.place, topic: article.topic, view: article.view });
+        }
+      }} />
+      <aside className="cq-card p-6 mt-10 space-y-4">
+        <Link className="btn btn-primary w-full sm:w-auto h-auto min-h-10 py-2" to={article.explore}
+          data-analytics-event="blog_explore" data-analytics-article={article.id} data-analytics-language={language}
+          data-analytics-place={article.place} data-analytics-topic={article.topic} data-analytics-view={article.view}>
+          {article.view === 'map' ? t('discovery.map') : t('discovery.table')} →
+        </Link>
+        <p><Link className="link text-sm" to={article.dataset}>{t('blog.dataset')}</Link></p>
+        <p><Link className="link text-sm" to={'/places/' + article.place}>{t('blog.more')} {article.placeName}</Link></p>
+      </aside>
+    </article>
+  </div>;
+}

--- a/client/src/pages/BlogPage.test.jsx
+++ b/client/src/pages/BlogPage.test.jsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
+import { beforeEach, expect, test, vi } from 'vitest';
+import BlogPage from './BlogPage.jsx';
+import Navbar from '../components/Navbar.jsx';
+import { LangProvider } from '../i18n.jsx';
+import { ThemeProvider } from '../theme.jsx';
+
+vi.mock('../api/catalog.js', () => ({ fetchBlog: vi.fn(), fetchBlogArticle: vi.fn() }));
+import { fetchBlog, fetchBlogArticle } from '../api/catalog.js';
+const article = lang => ({ id: 'parks', lang, title: lang === 'fr' ? 'Les parcs de la ville' : 'City parks guide',
+  description: 'A practical guide', place: 'oshawa-on', placeName: 'Oshawa', topic: 'parks', topicName: 'Parks',
+  published: '2026-09-09', updated: '2026-09-09', verified: '2026-09-09',
+  path: lang === 'fr' ? '/fr/blog/parcs' : '/blog/parks',
+  translations: { en: '/blog/parks', fr: '/fr/blog/parcs' },
+  explore: '/resources/park-map?view=map', view: 'map', dataset: '/datasets/parks',
+  bodyHtml: '<h2>Read the boundaries</h2><p>Complete instructions and source limitations.</p>' });
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+  fetchBlog.mockImplementation(async ({ lang }) => ({ data: [article(lang)] }));
+  fetchBlogArticle.mockImplementation(async lang => ({ data: article(lang) }));
+});
+
+function Back() {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>Back</button>;
+}
+function start(path) {
+  render(<MemoryRouter initialEntries={[path]}><ThemeProvider><LangProvider><Navbar /><Back /><Routes>
+    <Route path="/blog" element={<BlogPage />} />
+    <Route path="/blog/:slug" element={<BlogPage />} />
+    <Route path="/fr/blog" element={<BlogPage language="fr" />} />
+    <Route path="/fr/blog/:slug" element={<BlogPage language="fr" />} />
+  </Routes></LangProvider></ThemeProvider></MemoryRouter>);
+}
+
+test('renders the full article, dates, attribution and the actual map action', async () => {
+  start('/blog/parks');
+  expect(await screen.findByRole('heading', { name: 'City parks guide' })).toBeInTheDocument();
+  expect(screen.getByText('Complete instructions and source limitations.')).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /Explore map/ })).toHaveAttribute('href', '/resources/park-map?view=map');
+  expect(screen.getByRole('link', { name: 'View the source dataset' })).toHaveAttribute('href', '/datasets/parks');
+  expect(document.querySelectorAll('time')).toHaveLength(3);
+});
+
+test('the URL determines article language, including navbar switching and Back', async () => {
+  localStorage.setItem('cq-lang', 'en');
+  start('/fr/blog/parcs');
+  expect(await screen.findByRole('heading', { name: 'Les parcs de la ville' })).toBeInTheDocument();
+  expect(document.documentElement.lang).toBe('fr');
+  fireEvent.click(screen.getByRole('button', { name: 'EN', exact: true }));
+  expect(await screen.findByRole('heading', { name: 'City parks guide' })).toBeInTheDocument();
+  expect(fetchBlogArticle).toHaveBeenLastCalledWith('en', 'parks');
+  fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+  await waitFor(() => expect(document.documentElement.lang).toBe('fr'));
+  expect(await screen.findByRole('heading', { name: 'Les parcs de la ville' })).toBeInTheDocument();
+});
+
+test('the blog index links to complete guides', async () => {
+  start('/blog');
+  expect(await screen.findByRole('heading', { name: 'Local guides' })).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('link', { name: 'City parks guide' }));
+  expect(await screen.findByRole('heading', { name: 'Read the boundaries' })).toBeInTheDocument();
+});

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react';
+import LocalGuides from '../components/LocalGuides.jsx';
+import { useState, useEffect, useRef } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { searchDatasets, fetchOrganizations, fetchStats, fetchFeatured, fetchFeaturedPlaces, fetchSources } from '../api/catalog.js';
 import useDebouncedValue from '../hooks/useDebouncedValue.js';
@@ -27,7 +28,7 @@ import {
 } from '../components/Icons.jsx';
 
 const FORMATS = ['CSV', 'XLSX', 'JSON', 'GEOJSON', 'PDF', 'XML'];
-const EXAMPLES = ['housing', 'wildfire', 'electric vehicles', 'water quality', 'census'];
+const EXAMPLES = { en: ['parks', 'playgrounds', 'building permits', 'water quality', 'census'], fr: ['parcs', 'aires de jeux', 'permis de construction', 'qualité de l’eau', 'recensement'] };
 
 function StatCard({ icon, value, label, tone, delay }) {
   const n = useCountUp(value);
@@ -167,7 +168,7 @@ export default function HomePage() {
     return () => { cancelled = true; };
   }, [lang]);
 
-  const { items, loading, loadingMore, error, hasMore, loadMore } = usePaginatedCollection(
+  const { items, meta, loading, loadingMore, error, hasMore, loadMore } = usePaginatedCollection(
     (cursor) =>
       searchDatasets({
         q: debouncedQuery || undefined,
@@ -182,6 +183,15 @@ export default function HomePage() {
       }),
     [debouncedQuery, org, format, keyword, place, source, mappable]
   );
+
+  const reportedSearch = useRef(null);
+  useEffect(() => {
+    if (loading || error || !debouncedQuery || meta?.search?.query !== debouncedQuery.trim() || reportedSearch.current === meta) return;
+    reportedSearch.current = meta;
+    track('catalog_search_result', {
+      place, language: lang, returned: items.length, empty: items.length === 0,
+    });
+  }, [loading, error, debouncedQuery, place, lang, items.length, meta]);
 
   const filtering = Boolean(debouncedQuery || org || format || keyword || place || source || mappable);
   const synced = stats?.last_synced_at ? formatRelativeTime(stats.last_synced_at, lang) : null;
@@ -237,7 +247,7 @@ export default function HomePage() {
 
           <div className="flex flex-wrap gap-2 items-center justify-center mt-4">
             <span className="text-xs text-base-content/35">{t('home.try')}</span>
-            {EXAMPLES.map((ex) => (
+            {EXAMPLES[lang].map((ex) => (
               <button key={ex} className="cq-pill !text-xs" onClick={() => {
                 track('catalog_search', { query: ex, source: 'example' });
                 setQuery(ex);
@@ -319,6 +329,8 @@ export default function HomePage() {
           </section>
         )}
 
+        {!debouncedQuery && !org && !format && !source && !keyword && <LocalGuides place={place} />}
+
         <div className="flex flex-wrap gap-2 items-center mt-10">
           <button
             className={'cq-pill' + (format === '' ? ' cq-pill-active' : '')}
@@ -399,6 +411,10 @@ export default function HomePage() {
               <MapleLeaf size={34} className="mx-auto text-base-content/15" />
               <p className="text-base-content/60">{t('home.no_results')}</p>
               <p className="text-sm text-base-content/35">{t('home.no_results_hint')}</p>
+              {meta?.search?.suggestions?.length > 0 && <div className="flex flex-wrap justify-center items-center gap-2 mt-3">
+                <span>{t('discovery.suggest')}</span>
+                {meta.search.suggestions.map(suggestion => <button className="cq-pill" key={suggestion} onClick={() => setQuery(suggestion)}>{suggestion}</button>)}
+              </div>}
             </div>
           )}
           {items.map((d) => (

--- a/client/src/pages/PlacePage.jsx
+++ b/client/src/pages/PlacePage.jsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import LocalGuides from '../components/LocalGuides.jsx';
+import { useEffect, useState, useRef } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { fetchPlace, fetchSources, searchDatasets } from '../api/catalog.js';
 import { NotFoundError } from '../api/client.js';
@@ -45,7 +46,7 @@ export default function PlacePage() {
     return () => { cancelled = true; };
   }, [slug]);
 
-  const { items, loading, loadingMore, error: searchError, hasMore, loadMore } = usePaginatedCollection(
+  const { items, meta, loading, loadingMore, error: searchError, hasMore, loadMore } = usePaginatedCollection(
     cursor => searchDatasets({
       q: debouncedQuery || undefined,
       place: slug,
@@ -55,6 +56,15 @@ export default function PlacePage() {
     }),
     [slug, debouncedQuery, mappable]
   );
+
+  const reportedSearch = useRef(null);
+  useEffect(() => {
+    if (loading || searchError || !debouncedQuery || meta?.search?.query !== debouncedQuery.trim() || reportedSearch.current === meta) return;
+    reportedSearch.current = meta;
+    track('catalog_search_result', {
+      place: slug, language: lang, returned: items.length, empty: items.length === 0,
+    });
+  }, [loading, searchError, debouncedQuery, slug, lang, items.length, meta]);
 
   if (notFound) return <div className="text-center py-28"><h1 className="text-2xl font-bold font-display">{t('places.not_found')}</h1></div>;
   if (error) return <div className="max-w-5xl mx-auto px-4 py-8"><div className="alert alert-error">{error.message}</div></div>;
@@ -152,6 +162,8 @@ export default function PlacePage() {
         </div>
       )}
 
+      <LocalGuides place={slug} />
+
       <div className="grid sm:grid-cols-[minmax(0,1fr)_auto] gap-3 mt-8">
         <SearchBar value={query} onChange={setQuery} />
         <button
@@ -168,7 +180,13 @@ export default function PlacePage() {
       <section className="space-y-3 mt-6">
         {loading ? [...Array(5)].map((_, index) => <div className="cq-skel h-[82px]" key={index} />) :
           searchError ? <div className="alert alert-error">{searchError.message}</div> :
-            items.length === 0 ? <div className="text-center py-14 text-base-content/50">{t('places.no_datasets')}</div> :
+            items.length === 0 ? <div className="text-center py-14 text-base-content/50">
+                <p>{t('places.no_datasets')}</p>
+                {meta?.search?.suggestions?.length > 0 && <div className="flex flex-wrap justify-center items-center gap-2 mt-3">
+                  <span>{t('discovery.suggest')}</span>
+                  {meta.search.suggestions.map(suggestion => <button className="cq-pill" key={suggestion} onClick={() => setQuery(suggestion)}>{suggestion}</button>)}
+                </div>}
+              </div> :
               items.map(dataset => <DatasetRow key={dataset.id} dataset={dataset} />)}
       </section>
       {hasMore && <div className="text-center mt-6"><button className="btn btn-outline btn-sm rounded-full px-7" onClick={() => { track('catalog_filter', { action: 'load_more', place: slug }); loadMore(); }} disabled={loadingMore}>{loadingMore ? t('home.loading') : t('home.load_more')}</button></div>}

--- a/client/src/pages/PlacePage.test.jsx
+++ b/client/src/pages/PlacePage.test.jsx
@@ -5,6 +5,7 @@ import PlacePage from './PlacePage.jsx';
 import { LangProvider } from '../i18n.jsx';
 
 vi.mock('../api/catalog.js', () => ({
+  fetchBlog: vi.fn(() => Promise.resolve({ data: [] })),
   fetchPlace: vi.fn(),
   fetchSources: vi.fn(),
   searchDatasets: vi.fn(),

--- a/client/src/utils/analytics.js
+++ b/client/src/utils/analytics.js
@@ -1,5 +1,7 @@
 export const ANALYTICS_EVENTS = new Set([
   'catalog_search',
+  'catalog_search_result',
+  'blog_explore',
   'catalog_filter',
   'dataset_open',
   'organization_open',

--- a/client/src/utils/routeHead.js
+++ b/client/src/utils/routeHead.js
@@ -15,7 +15,8 @@ export function readSeoElements(html, responseUrl) {
   const elements = range.nodes.filter(node => {
     if (node.nodeType !== 1) return false;
     if (node.tagName === 'TITLE') return true;
-    if (node.tagName === 'LINK') return node.getAttribute('rel') === 'canonical';
+    if (node.tagName === 'LINK') return node.getAttribute('rel') === 'canonical' ||
+      (node.getAttribute('rel') === 'alternate' && ['en-CA', 'fr-CA', 'x-default'].includes(node.getAttribute('hreflang')));
     if (node.tagName === 'META') {
       return /^(description|robots|twitter:.+)$/.test(node.getAttribute('name') || '') ||
         /^og:/.test(node.getAttribute('property') || '');
@@ -23,7 +24,7 @@ export function readSeoElements(html, responseUrl) {
     return node.tagName === 'SCRIPT' && node.getAttribute('type') === 'application/ld+json';
   });
   const titles = elements.filter(node => node.tagName === 'TITLE');
-  const canonicals = elements.filter(node => node.tagName === 'LINK');
+  const canonicals = elements.filter(node => node.tagName === 'LINK' && node.getAttribute('rel') === 'canonical');
   if (titles.length !== 1 || !titles[0].textContent.trim() || canonicals.length !== 1) {
     throw new Error('Invalid SEO identity');
   }
@@ -33,8 +34,12 @@ export function readSeoElements(html, responseUrl) {
     throw new Error('SEO response belongs to a different page');
   }
   return elements.map(node => {
+    if (node.tagName === 'LINK' && node.getAttribute('rel') === 'alternate' &&
+        new URL(node.getAttribute('href'), responseUrl).origin !== canonical.origin) {
+      throw new Error('Invalid alternate origin');
+    }
     const copy = document.createElement(node.tagName.toLowerCase());
-    for (const name of ['name', 'content', 'property', 'rel', 'href', 'type']) {
+    for (const name of ['name', 'content', 'property', 'rel', 'href', 'hreflang', 'type']) {
       if (node.hasAttribute(name)) copy.setAttribute(name, node.getAttribute(name));
     }
     if (node.tagName === 'SCRIPT') JSON.parse(node.textContent);

--- a/content/blog/README.md
+++ b/content/blog/README.md
@@ -1,0 +1,38 @@
+# Local guides
+
+Articles live here as paired English/French Markdown files. `index.json` is the
+single manifest for the blog API, initial HTML, translations, related guides,
+and sitemap. The server renders the same Markdown for initial HTML and React.
+
+## Write or update a guide
+
+1. Choose a specific resident task supported by an admitted dataset. Verify the
+   official publisher, source description, and actual table/map workflow.
+2. Add one manifest entry with a stable `id`, `place`, `topic`, localized search
+   `query`, dataset link, and exploration link. Add `en` and `fr` editions with
+   unique slugs, titles, descriptions, place names, and topic names.
+3. Write `<id>.en.md` and `<id>.fr.md`. Start headings at `##`; the page supplies
+   the title. Use plain language, useful steps, official source links, and
+   relevant coverage limits. Do not infer real-world changes from metadata dates.
+4. Set `status` to `draft` while preparing content. Drafts are excluded from
+   public APIs, HTML, related-guide cards, and sitemaps. Both translations must
+   exist before the content verifier passes, including for drafts.
+5. Record the actual publication date, last substantive article update, and
+   date the data links/workflow were checked. Dates use `YYYY-MM-DD`; routine
+   deployments must not advance them. Use the organizational byline CanQuery.
+6. Run `npm run blog:check --prefix server` and the release verifier. Review both
+   editions on mobile and without JavaScript, then publish through the normal PR
+   and deployment process.
+
+Raw HTML is disabled. Links accept HTTPS/HTTP, same-origin paths, or fragment
+anchors. Images must use same-origin paths and meaningful alternative text.
+Keep article bodies independent of live catalogue availability. Update or
+withdraw guides when a source no longer supports the described task.
+
+English routes use `/blog/:slug`; French routes use `/fr/blog/:slug`. Translation
+URLs have their own canonical and reciprocal `hreflang` annotations. Do not
+rename a published slug without adding and testing a permanent redirect.
+
+New topics and spelling suggestions belong in `server/services/localSearch.js`.
+Keep the vocabulary reviewed and bounded, preserve additional query terms, and
+test both useful matches and misleading stem matches against PostgreSQL.

--- a/content/blog/index.json
+++ b/content/blog/index.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "toronto-building-permits",
+    "status": "published",
+    "place": "toronto-on",
+    "topic": "building-permits",
+    "query": {
+      "en": "building permits",
+      "fr": "permis de construction"
+    },
+    "view": "table",
+    "published": "2026-09-09",
+    "updated": "2026-09-09",
+    "verified": "2026-09-09",
+    "dataset": "/datasets/toronto-open-data-building-permits-active-permits",
+    "explore": "/resources/ckan-toronto-open-data-resource-6d0229af-bc54-46de-9c2b-26759b01dd05",
+    "editions": {
+      "en": {
+        "slug": "toronto-building-permits",
+        "title": "How to look up active building permits in Toronto",
+        "description": "Look up Toronto building applications and permits by street, understand the records, and open the official source through CanQuery.",
+        "placeName": "Toronto",
+        "topicName": "Building permits"
+      },
+      "fr": {
+        "slug": "permis-construction-toronto",
+        "title": "Comment consulter les permis de construction actifs à Toronto",
+        "description": "Recherchez les demandes et permis de construction de Toronto par rue et apprenez à lire les données officielles dans CanQuery.",
+        "placeName": "Toronto",
+        "topicName": "Permis de construction"
+      }
+    }
+  },
+  {
+    "id": "oshawa-parks",
+    "status": "published",
+    "place": "oshawa-on",
+    "topic": "parks",
+    "query": {
+      "en": "parks",
+      "fr": "parcs"
+    },
+    "view": "map",
+    "published": "2026-09-09",
+    "updated": "2026-09-09",
+    "verified": "2026-09-09",
+    "dataset": "/datasets/arcgis-088980627c7d494abc89ce1277068ebc-9",
+    "explore": "/resources/arcgis-088980627c7d494abc89ce1277068ebc-9-data?view=map",
+    "editions": {
+      "en": {
+        "slug": "oshawa-parks-map",
+        "title": "Explore Oshawa’s parks using open map data",
+        "description": "Open Oshawa’s park map, explore city-owned park boundaries, and understand what the municipal inventory can tell you before a visit.",
+        "placeName": "Oshawa",
+        "topicName": "Parks"
+      },
+      "fr": {
+        "slug": "carte-parcs-oshawa",
+        "title": "Explorer les parcs d’Oshawa avec les données ouvertes",
+        "description": "Explorez les limites des parcs municipaux d’Oshawa et découvrez ce que l’inventaire officiel permet de vérifier avant une visite.",
+        "placeName": "Oshawa",
+        "topicName": "Parcs"
+      }
+    }
+  },
+  {
+    "id": "montreal-parks",
+    "status": "published",
+    "place": "montreal-qc",
+    "topic": "parks",
+    "query": {
+      "en": "parks",
+      "fr": "parcs"
+    },
+    "view": "table",
+    "published": "2026-09-09",
+    "updated": "2026-09-09",
+    "verified": "2026-09-09",
+    "dataset": "/datasets/montreal-open-data-grands-parcs-parcs-d-arrondissements-et-espaces-publics",
+    "explore": "/resources/ckan-montreal-open-data-resource-f34c3555-c285-4ef3-a55c-f0f5c440ad2d",
+    "editions": {
+      "en": {
+        "slug": "montreal-parks-public-spaces",
+        "title": "Find Montréal parks and public spaces in open data",
+        "description": "Find Montréal park records by name, understand the French column labels, and check the limits of the city’s parks and public-spaces catalogue.",
+        "placeName": "Montréal",
+        "topicName": "Parks and public spaces"
+      },
+      "fr": {
+        "slug": "parcs-espaces-publics-montreal",
+        "title": "Trouver les parcs et espaces publics de Montréal",
+        "description": "Recherchez un parc montréalais par son nom, consultez les données municipales et comprenez les limites du catalogue des espaces publics.",
+        "placeName": "Montréal",
+        "topicName": "Parcs et espaces publics"
+      }
+    }
+  }
+]

--- a/content/blog/montreal-parks.en.md
+++ b/content/blog/montreal-parks.en.md
@@ -1,0 +1,33 @@
+Looking for a Montréal park in the city's open data? The **Grands parcs, parcs d’arrondissements et espaces publics** catalogue brings together records for parks and public spaces. You can search those records in CanQuery and follow the municipal source to understand their coverage.
+
+This guide starts with the published table. It is useful for finding names and reading the associated categories; it does not promise current opening hours, facilities, or conditions at a park.
+
+## Find a park by name
+
+1. [Open Montréal’s parks and public-spaces table](/resources/ckan-montreal-open-data-resource-f34c3555-c285-4ef3-a55c-f0f5c440ad2d).
+2. Enter a park name, or a distinctive part of its name, in the search box above the table. Source values remain in their published language, so try the French name when you know it.
+3. Look at **Nom**, the name field, to identify relevant records. A text search can also match another column, so check the name before assuming a result is the place you wanted.
+4. Inspect the other fields and follow a record’s **Lien**, where one is supplied, for more context. Copy the link into your browser if the table displays it as text.
+5. Save the current search by copying the page URL. The CSV export can take up to 10,000 matching rows into a spreadsheet.
+
+The table can be read directly through the source’s query service. Start with its general text search; more detailed column filtering may require loading a copy into CanQuery.
+
+## Read the French field labels
+
+The interface can be switched to English, but the City’s column names and record values retain their original language. **Nom** means name. **Type** identifies a type, while **PROPRIETE**, **GESTION**, and **COMPETENCE** are source fields associated with ownership, management, and responsibility. Consult the publisher's metadata before interpreting unfamiliar codes.
+
+An area value such as **SUPERFICIE** also needs its source definition and units before you use it in a calculation. A large number on its own is not enough to compare two parks reliably.
+
+## Know the coverage limits
+
+The City explains that this dataset is not fully representative of parks in Montréal's related municipalities. Its boundaries are intended for representation and should not be used to establish a precise legal boundary. Those limits matter when you cannot find a location or when a park appears to cover an unexpected area.
+
+The separate [inventory of furniture in large parks](https://donnees.montreal.ca/dataset/mobilierurbaingp) is a different dataset, much of which was updated in 2013. Do not treat an item in that inventory as confirmation that a bench, fountain, or other amenity is available today.
+
+## Check the publication behind the records
+
+Open the [official Montréal parks and public-spaces dataset](https://donnees.montreal.ca/dataset/grands-parcs-parcs-d-arrondissements-et-espaces-publics) for its description, available geographic downloads, and the City's linked visualization. CanQuery’s [dataset page](/datasets/montreal-open-data-grands-parcs-parcs-d-arrondissements-et-espaces-publics) keeps the source attribution and resources together.
+
+A metadata update date concerns the catalogue listing, not necessarily the condition of each park. This guide’s “Data links checked” date records our check of the links and exploration steps. For current access and services, consult the City’s information for the particular park.
+
+Continue with the [Montréal place page](/places/montreal-qc) to explore other local data. Contains information published by the Ville de Montréal under [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).

--- a/content/blog/montreal-parks.fr.md
+++ b/content/blog/montreal-parks.fr.md
@@ -1,0 +1,33 @@
+Vous cherchez un parc montréalais dans les données ouvertes de la Ville? Le catalogue **Grands parcs, parcs d’arrondissements et espaces publics** rassemble des dossiers sur les parcs et les espaces publics. CanQuery permet de rechercher ces dossiers et de retrouver leur source municipale pour en comprendre la couverture.
+
+Ce guide commence par la table publiée. Elle est utile pour retrouver des noms et lire les catégories associées; elle ne garantit pas les heures d’ouverture, les équipements ou l’état actuel d’un parc.
+
+## Rechercher un parc par son nom
+
+1. [Ouvrez la table des parcs et espaces publics de Montréal](/resources/ckan-montreal-open-data-resource-f34c3555-c285-4ef3-a55c-f0f5c440ad2d).
+2. Saisissez le nom d’un parc, ou une partie distinctive de son nom, dans le champ de recherche au-dessus de la table. Les valeurs gardent leur langue de publication; essayez le nom français si vous le connaissez.
+3. Repérez les dossiers pertinents dans le champ **Nom**. Une recherche textuelle peut aussi trouver une correspondance dans une autre colonne : vérifiez donc le nom avant de conclure qu’il s’agit du lieu recherché.
+4. Examinez les autres champs et suivez le **Lien** d’un dossier, lorsqu’il est fourni, pour obtenir davantage de contexte. Si la table affiche ce lien sous forme de texte, copiez-le dans votre navigateur.
+5. Copiez l’adresse de la page pour conserver cette recherche. L’export CSV permet de consulter jusqu’à 10 000 lignes correspondantes dans un tableur.
+
+La table est consultable directement au moyen du service de requêtes de la source. Commencez par la recherche textuelle générale; des filtres plus détaillés par colonne peuvent nécessiter le chargement d’une copie dans CanQuery.
+
+## Comprendre les champs
+
+Les noms de colonnes et les valeurs conservent la langue dans laquelle la Ville les publie, même si vous changez la langue de l’interface. **Nom** permet d’identifier un espace. **Type** indique un type, tandis que **PROPRIETE**, **GESTION** et **COMPETENCE** sont des champs de la source associés à la propriété, à la gestion et à la responsabilité. Consultez les métadonnées municipales avant d’interpréter des codes peu familiers.
+
+Une valeur comme **SUPERFICIE** doit aussi être accompagnée de sa définition et de ses unités avant de servir à un calcul. Un nombre élevé, à lui seul, ne suffit pas à comparer correctement deux parcs.
+
+## Tenir compte des limites de couverture
+
+La Ville précise que ce jeu de données ne représente pas entièrement les parcs des villes liées de Montréal. Ses limites servent à la représentation et ne doivent pas être utilisées pour établir une limite légale précise. Ces réserves sont utiles lorsqu’un lieu n’apparaît pas ou qu’un parc semble couvrir une zone inattendue.
+
+L’[inventaire distinct du mobilier urbain des grands parcs](https://donnees.montreal.ca/dataset/mobilierurbaingp) est un autre jeu de données, dont une grande partie a été mise à jour en 2013. La présence d’un banc, d’une fontaine ou d’un autre équipement dans cet inventaire ne confirme pas sa disponibilité aujourd’hui.
+
+## Vérifier la publication municipale
+
+La [fiche officielle des parcs et espaces publics de Montréal](https://donnees.montreal.ca/dataset/grands-parcs-parcs-d-arrondissements-et-espaces-publics) fournit la description, les téléchargements géographiques et un lien vers la visualisation de la Ville. La [fiche CanQuery du jeu de données](/datasets/montreal-open-data-grands-parcs-parcs-d-arrondissements-et-espaces-publics) rassemble les ressources et leur attribution.
+
+La date de mise à jour des métadonnées concerne la fiche du catalogue, pas nécessairement l’état de chaque parc. La date « Liens vérifiés » de ce guide indique quand les liens et les étapes ont été contrôlés. Pour connaître les accès et services actuels, consultez les renseignements de la Ville sur le parc concerné.
+
+Poursuivez votre exploration sur la [page de Montréal](/places/montreal-qc). Contient des renseignements publiés par la Ville de Montréal sous [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/).

--- a/content/blog/oshawa-parks.en.md
+++ b/content/blog/oshawa-parks.en.md
@@ -1,0 +1,33 @@
+A map of park boundaries can help you understand how green spaces fit into an Oshawa neighbourhood. The City's **Oshawa Park Locations** dataset identifies city-owned parks as areas on a map, including neighbourhood, community, and city parks.
+
+CanQuery brings that published layer into an interactive map. You can explore an area, select a park shape, and read the information attached to it without first downloading a geographic data file.
+
+## Explore the park map
+
+1. [Open the Oshawa parks map](/resources/arcgis-088980627c7d494abc89ce1277068ebc-9-data?view=map).
+2. Pan to the part of Oshawa you want to explore. On a phone, use the zoom controls and move the map to narrow the area.
+3. Select a coloured park shape to open its details. The source’s **FULLNAME** field contains the name field; **LOCATION** provides location information where supplied.
+4. Zoom in if the map asks you to narrow the view. CanQuery requests a bounded set of features for the visible area, so a broad view may not display every shape at once.
+5. Follow the dataset link to inspect the publisher, source attribution, and available download.
+
+The map is a view of the City's published layer. It does not require you to load the separate CSV resource into CanQuery.
+
+## Understand the shapes and fields
+
+This layer represents park areas rather than a list of entrances. A boundary can help you recognize a park in relation to nearby streets, but it does not identify an accessible entrance, an open gate, or a suitable walking route.
+
+The details use the source's field names. Some names, such as **HOLDINGTYP** and **HOLDINGDES**, describe the municipal inventory and may be less familiar than a park's public name. Missing or unclear values should remain unknown; they are not evidence that a facility or service does not exist.
+
+## Use the map as a starting point for a visit
+
+Park boundaries alone do not tell you whether washrooms are open, a playground is under repair, or an event is taking place. Confirm time-sensitive details with the City before making a trip that depends on them.
+
+The metadata update date shown on the dataset describes its catalogue record. It is different from the date CanQuery retrieves features for your map view, and neither should be interpreted as a fresh inspection of park conditions. The guide’s verification date records a check that this exploration workflow works.
+
+## Find the source and more local data
+
+The [official Oshawa Park Locations page](https://city-oshawa.opendata.arcgis.com/datasets/oshawa::oshawa-park-locations) explains the layer's purpose and provides access to the City's publication. The [CanQuery dataset page](/datasets/arcgis-088980627c7d494abc89ce1277068ebc-9) keeps that source and attribution alongside the resource.
+
+Visit [Oshawa’s place page](/places/oshawa-on) for more local datasets. When sharing the park map, include the park name you selected: the map link opens the resource, but does not currently preserve your precise map position or selection.
+
+Contains information licensed under the [Open Government Licence – The Corporation of the City of Oshawa](https://map.oshawa.ca/OpenData/Open%20Government%20Licence%20version%202.0%20-%20Oshawa.pdf).

--- a/content/blog/oshawa-parks.fr.md
+++ b/content/blog/oshawa-parks.fr.md
@@ -1,0 +1,33 @@
+Une carte des limites des parcs peut vous aider à comprendre la place des espaces verts dans un quartier d’Oshawa. Le jeu de données municipal **Oshawa Park Locations** représente les parcs appartenant à la Ville sous forme de surfaces cartographiques, notamment les parcs de quartier, communautaires et municipaux.
+
+CanQuery affiche cette couche publiée sur une carte interactive. Vous pouvez explorer un secteur, sélectionner la forme d’un parc et lire les renseignements associés sans télécharger au préalable un fichier géographique.
+
+## Explorer la carte des parcs
+
+1. [Ouvrez la carte des parcs d’Oshawa](/resources/arcgis-088980627c7d494abc89ce1277068ebc-9-data?view=map).
+2. Déplacez la carte jusqu’au secteur qui vous intéresse. Sur un téléphone, utilisez les commandes de zoom et déplacez la carte pour préciser la zone.
+3. Sélectionnez la surface colorée d’un parc pour ouvrir sa fiche. Le champ **FULLNAME** est le champ du nom; **LOCATION** fournit des renseignements sur l’emplacement lorsqu’ils sont disponibles.
+4. Agrandissez la carte si un message vous invite à préciser la vue. CanQuery demande un nombre limité d’éléments pour la zone visible; une vue très large peut donc ne pas montrer toutes les surfaces à la fois.
+5. Suivez le lien du jeu de données pour consulter la source, l’attribution et le téléchargement disponible.
+
+La carte présente la couche publiée par la Ville. Vous n’avez pas besoin de charger la ressource CSV distincte dans CanQuery pour l’utiliser.
+
+## Comprendre les surfaces et les champs
+
+Cette couche représente des espaces de parc, plutôt qu’une liste d’entrées. Une limite peut vous aider à situer un parc par rapport aux rues voisines, mais elle n’indique pas une entrée accessible, une barrière ouverte ou un itinéraire piétonnier approprié.
+
+Les fiches conservent les noms de champs de la source. Certains, comme **HOLDINGTYP** et **HOLDINGDES**, concernent l’inventaire municipal et peuvent être moins familiers que le nom public du parc. Une valeur absente ou peu claire reste inconnue : elle ne prouve pas qu’un équipement ou un service n’existe pas.
+
+## Préparer une visite
+
+Les limites d’un parc ne permettent pas de savoir si les toilettes sont ouvertes, si une aire de jeux est en réparation ou si un événement est prévu. Vérifiez les renseignements qui peuvent changer auprès de la Ville avant un déplacement qui en dépend.
+
+La date de mise à jour des métadonnées concerne la fiche du catalogue. Elle est distincte du moment où CanQuery récupère les éléments visibles sur votre carte. Aucune de ces dates ne correspond nécessairement à une inspection récente du parc. La date de vérification du guide indique que le parcours de consultation a été contrôlé.
+
+## Retrouver la source et d’autres données locales
+
+La [page officielle Oshawa Park Locations](https://city-oshawa.opendata.arcgis.com/datasets/oshawa::oshawa-park-locations) explique l’objet de la couche et donne accès à sa publication municipale. La [fiche CanQuery du jeu de données](/datasets/arcgis-088980627c7d494abc89ce1277068ebc-9) conserve les liens et l’attribution à côté de la ressource.
+
+Consultez la [page d’Oshawa](/places/oshawa-on) pour découvrir d’autres données locales. Si vous partagez la carte, indiquez aussi le nom du parc sélectionné : son lien ouvre la ressource, mais ne conserve pas encore la position précise de la carte ni votre sélection.
+
+Contient des renseignements visés par la [Licence du gouvernement ouvert – The Corporation of the City of Oshawa](https://map.oshawa.ca/OpenData/Open%20Government%20Licence%20version%202.0%20-%20Oshawa.pdf).

--- a/content/blog/toronto-building-permits.en.md
+++ b/content/blog/toronto-building-permits.en.md
@@ -1,0 +1,31 @@
+You have noticed work on a Toronto street and want to learn what the city's records say about it. The **Building Permits – Active Permits** dataset is a useful starting point. It contains active building applications and permits, with information collected from applications and updated during the city's review and inspection work.
+
+CanQuery lets you search this official table in your browser. You can start with a street name, inspect matching records, and follow the source link when you need more context.
+
+## Start with the active-permits table
+
+1. [Open Toronto’s active building permits in CanQuery](/resources/ckan-toronto-open-data-resource-6d0229af-bc54-46de-9c2b-26759b01dd05).
+2. Use the search box above the table to enter a street name. This searches the table’s text, so a match can appear in a description as well as an address field.
+3. Check the street and building-number fields in each result. A street can have several applications, and a single property can have more than one permit record.
+4. Read the permit type, status, and work description together. Use the table’s horizontal scroll to see columns that do not fit on a smaller screen.
+5. Copy the page URL to return to the same search. You can also use the CSV export to work with the results in a spreadsheet; the export is limited to 10,000 rows.
+
+Start with the general table search. The availability of more detailed column filters depends on whether the resource is loaded into CanQuery. Reading the live table does not require an account or a manual download.
+
+## What an active record means
+
+The source includes **applications as well as permits**. Finding a record does not, by itself, establish that a permit has been issued or that construction has started. Look at the individual status and description instead of treating inclusion in this table as a single yes-or-no answer.
+
+This is also an active-records dataset, not a complete history of every building project. An empty search does not prove that a property has never had a permit. Before drawing a conclusion, check your spelling, try a shorter street name, and review the publisher’s description of the dataset.
+
+## Check dates and the official source
+
+A catalogue metadata date describes a change to the dataset’s listing. It should not be read as the inspection date of a particular property. Likewise, the “Data links checked” date on this guide records our check of the links and workflow, not a fresh verification of every permit.
+
+For the dataset’s collection method, available resources, and publisher information, open the [City of Toronto’s official active-permits page](https://open.toronto.ca/dataset/building-permits-active-permits/). Questions about a specific application belong with the City; CanQuery provides access to the published records.
+
+## Continue exploring Toronto
+
+Use the [Toronto place page](/places/toronto-on) to discover other local datasets. If you are sharing a finding, include the [CanQuery dataset page](/datasets/toronto-open-data-building-permits-active-permits), the official source, and the date you consulted it so another reader can check the same evidence.
+
+Contains information licensed under the [Open Government Licence – Toronto](https://open.toronto.ca/open-data-licence/).

--- a/content/blog/toronto-building-permits.fr.md
+++ b/content/blog/toronto-building-permits.fr.md
@@ -1,0 +1,31 @@
+Vous avez remarqué des travaux dans une rue de Toronto et souhaitez savoir ce qu’en disent les dossiers municipaux. Le jeu de données **Building Permits – Active Permits** constitue un point de départ utile. Il regroupe les demandes et permis de construction actifs, à partir des renseignements recueillis dans les demandes et des mises à jour effectuées pendant l’examen et les inspections de la Ville.
+
+CanQuery permet de consulter cette table officielle dans votre navigateur. Vous pouvez commencer par un nom de rue, examiner les résultats et suivre le lien vers la source pour obtenir davantage de contexte.
+
+## Ouvrir la table des permis actifs
+
+1. [Ouvrez les permis de construction actifs de Toronto dans CanQuery](/resources/ckan-toronto-open-data-resource-6d0229af-bc54-46de-9c2b-26759b01dd05).
+2. Saisissez un nom de rue dans le champ de recherche au-dessus de la table. La recherche porte sur le texte des données : une correspondance peut donc apparaître dans une description plutôt que dans l’adresse.
+3. Vérifiez les champs du nom de rue et du numéro d’immeuble. Une rue peut compter plusieurs demandes, et une même propriété peut avoir plusieurs dossiers de permis.
+4. Lisez ensemble le type de permis, son statut et la description des travaux. Faites défiler la table horizontalement pour afficher les colonnes qui ne tiennent pas sur un petit écran.
+5. Copiez l’adresse de la page pour retrouver cette recherche. L’export CSV permet aussi de consulter les résultats dans un tableur; il est limité à 10 000 lignes.
+
+Commencez par la recherche générale de la table. La disponibilité de filtres plus précis par colonne dépend du chargement de la ressource dans CanQuery. La consultation de la table en direct ne nécessite ni compte ni téléchargement manuel. Les noms de colonnes et les valeurs de cette source torontoise restent dans leur langue de publication.
+
+## Comprendre la présence d’un dossier
+
+La source comprend **des demandes ainsi que des permis**. La présence d’un dossier ne suffit pas à établir qu’un permis a été délivré ou que les travaux ont commencé. Consultez le statut et la description de chaque dossier pour comprendre ce qu’il représente.
+
+Il s’agit aussi de dossiers actifs, et non d’un historique complet de tous les travaux. Une recherche vide ne prouve pas qu’une propriété n’a jamais fait l’objet d’un permis. Vérifiez l’orthographe, essayez un nom de rue plus court et consultez la description fournie par la Ville avant de tirer une conclusion.
+
+## Vérifier les dates et la source
+
+La date de mise à jour des métadonnées concerne la fiche du jeu de données. Elle ne correspond pas nécessairement à la date d’inspection d’une propriété. De même, la date « Liens vérifiés » de ce guide indique quand nous avons vérifié les liens et le parcours de consultation, pas chaque permis.
+
+La [page officielle des permis actifs de la Ville de Toronto](https://open.toronto.ca/dataset/building-permits-active-permits/) fournit les renseignements sur la collecte, les ressources et leur publication. Pour une question concernant une demande précise, adressez-vous à la Ville; CanQuery donne accès aux dossiers publiés.
+
+## Poursuivre votre recherche à Toronto
+
+La [page de Toronto](/places/toronto-on) permet de découvrir d’autres données locales. Lorsque vous partagez un résultat, incluez la [fiche du jeu de données dans CanQuery](/datasets/toronto-open-data-building-permits-active-permits), la source officielle et la date de consultation pour que d’autres personnes puissent vérifier les mêmes renseignements.
+
+Contient des renseignements visés par la [Licence du gouvernement ouvert – Toronto](https://open.toronto.ca/open-data-licence/).

--- a/deploy/RELEASE_RUNBOOK_v39.md
+++ b/deploy/RELEASE_RUNBOOK_v39.md
@@ -1,0 +1,55 @@
+# v39: local discovery and resident guides
+
+This release adds English/French topic matching, literal-match ranking, bounded
+spelling suggestions, search-result descriptions and resource links, local guide
+cards, and three paired resident guides. It introduces no database migration,
+source registry change, catalogue write, or worker change.
+
+## Verify
+
+- Preserve existing work and use an isolated checkout from current main.
+- Run `npm ci` in both packages, then `npm run verify --prefix server`.
+- Use disposable PostgreSQL 16/PostGIS 3.5 with migrations applied. Run the
+  spatial, Search Console, and local-search integration suites with the
+  established test database environment variables.
+- Compare representative old/new catalogue searches inside a read-only database
+  transaction. Check local relevance, bilingual equivalence, filter retention,
+  and latency for both common queries and unfiltered browsing.
+- Check both blog indexes and all six article editions with JavaScript enabled
+  and disabled. Verify full article content, a single h1/canonical, language,
+  alternate URLs, JSON-LD, mobile layout, navigation and Back, and article 404s.
+- Follow all three guide workflows. Confirm each resource still has the
+  advertised capability and that official source links remain correct.
+- Review the diff and merge after all CI jobs pass. Keep operational evidence,
+  raw catalogue snapshots, and analytics reports outside the public repository.
+
+## Deploy
+
+Require a clean production checkout, service-user ownership, healthy public
+health/ops endpoints, and active API/worker services. Create fresh catalogue and
+analytics custom-format backups under the existing backup lock; validate both
+with `pg_restore --list`, encrypt off-host copies with the established credential,
+and verify ciphertext and decrypted-plaintext hashes before changing the checkout.
+
+As the service user, fetch and fast-forward to the reviewed merge, install both
+locked dependency sets, and run the release verifier. Restart the API after its
+client build succeeds. Existing workers continue under their systemd owners.
+Confirm checkout cleanliness, ownership, service states and public health.
+
+Validate `/sitemap-blog.xml` (two indexes and six article editions) and its entry
+in `/sitemap.xml`. Repeat public bilingual searches and browser acceptance.
+Rebuild the private Search Console report with the existing read-only grant.
+Record the release commit, backup manifests, test results and public observations.
+
+## Rollback and follow-up
+
+For an application regression, return to the recorded previous release,
+reinstall its locked dependencies, rebuild the client and restart the API.
+Retain catalogue data, schema, ingestion state and map data.
+
+Compare the first seven finalized post-release days and the first full 28-day
+cohort. Group both blog locales as Local guides in Search Console reporting.
+Measure guide-to-resource clicks and subsequent intentional map/table use with
+existing analytics opt-outs. Publication does not establish an SEO outcome.
+Sitemap submission remains an owner-authenticated Search Console action with
+the existing read-only OAuth grant.

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -14,6 +14,9 @@ echo -e "${BLUE}=== CanQuery Release Verification ===${NC}"
 echo "Root directory: ${ROOT_DIR}"
 echo ""
 
+# Validate the repository-authored guides before build or deployment.
+node "${ROOT_DIR}/server/scripts/check-blog.js"
+
 # 1. Server Linter
 echo -e "${BLUE}[1/5] Running Server ESLint...${NC}"
 cd "${ROOT_DIR}/server"

--- a/server/__tests__/blog.test.js
+++ b/server/__tests__/blog.test.js
@@ -1,0 +1,122 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const express = require('express');
+const request = require('supertest');
+const { readArticles, listArticles, getArticle, permittedUrl } = require('../services/blogContent');
+const { resolvePage, serveSpa } = require('../controllers/spaController');
+const { renderHtml } = require('../services/seoMeta');
+const app = require('../app');
+const template = '<!doctype html><html lang="en"><head><!-- seo:start --><!-- seo:end --></head><body><div id="root"></div></body></html>';
+
+test('publishes three paired guides with verified resource links', () => {
+    expect(readArticles()).toHaveLength(6);
+    expect(listArticles()).toHaveLength(3);
+    expect(listArticles({ lang: 'fr', place: 'oshawa-on' })).toHaveLength(1);
+    for (const lang of ['en', 'fr']) for (const article of listArticles({ lang })) {
+        const full = getArticle(lang, article.slug);
+        expect(full.bodyHtml).toContain('<h2>');
+        expect(full.bodyHtml.length).toBeGreaterThan(2500);
+        expect(full.bodyHtml).toContain('/resources/');
+        expect(full.translations.en).toMatch(/^\/blog\//);
+        expect(full.translations.fr).toMatch(/^\/fr\/blog\//);
+        expect(article.bodyHtml).toBeUndefined();
+    }
+});
+
+test.each(['en', 'fr'])('renders complete %s articles and metadata without any catalogue query', async lang => {
+    const articles = listArticles({ lang });
+    const unavailable = new Proxy({}, { get() { throw new Error('Catalogue must not be accessed'); } });
+    for (const article of articles) {
+        const page = await resolvePage(article.path, unavailable);
+        const html = renderHtml(template, page.meta, page.body);
+        expect(page.status).toBe(200);
+        expect(html).toContain('<html lang="' + lang + '">');
+        expect(html.match(/<h1\b/g)).toHaveLength(1);
+        expect(html).toContain(getArticle(lang, article.slug).bodyHtml);
+        expect(page.meta.alternates).toHaveProperty('fr-CA');
+        expect(page.meta.jsonLd.find(item => item['@type'] === 'BlogPosting')).toMatchObject({
+            author: { '@type': 'Organization', name: 'CanQuery' }, datePublished: article.published
+        });
+    }
+});
+
+test('serves article APIs, geographic listing, real 404s and the blog sitemap', async () => {
+    const article = listArticles()[0];
+    expect((await request(app).get('/api/v1/blog?lang=fr&place=montreal-qc')).body.data).toHaveLength(1);
+    const result = await request(app).get('/api/v1/blog/en/' + article.slug);
+    expect(result.status).toBe(200);
+    expect(result.body.meta.license).toBeNull();
+    expect(result.body.data.bodyHtml).toContain('<h2>');
+    expect((await request(app).get('/api/v1/blog?lang=de')).status).toBe(400);
+    expect((await request(app).get('/api/v1/blog/en/missing')).status).toBe(404);
+    const sitemap = await request(app).get('/sitemap-blog.xml');
+    expect(sitemap.status).toBe(200);
+    expect(sitemap.text.match(/<loc>/g)).toHaveLength(8);
+    expect(sitemap.text).toContain('/fr/blog/');
+});
+
+test('keeps missing article status and canonical redirects correct at the HTTP boundary', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'canquery-blog-'));
+    fs.writeFileSync(path.join(dir, 'index.html'), template);
+    try {
+        const server = express();
+        server.use(serveSpa(dir));
+        const missing = await request(server).get('/fr/blog/missing');
+        expect(missing.status).toBe(404);
+        expect(missing.text).toContain('noindex');
+        const redirect = await request(server).get('/blog/?from=test');
+        expect(redirect.status).toBe(301);
+        expect(redirect.headers.location).toBe('/blog?from=test');
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('rejects bad manifests, missing translations and external images; escapes authored HTML', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'canquery-blog-content-'));
+    fs.cpSync(path.join(__dirname, '../../content/blog'), root, { recursive: true });
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, 'index.json')));
+    const write = value => fs.writeFileSync(path.join(root, 'index.json'), JSON.stringify(value));
+    try {
+        write([...manifest, manifest[0]]);
+        expect(() => readArticles(root)).toThrow(/Duplicate/);
+        const invalid = JSON.parse(JSON.stringify(manifest));
+        delete invalid[0].editions.fr;
+        write(invalid);
+        expect(() => readArticles(root)).toThrow();
+        write(manifest);
+        const file = path.join(root, manifest[0].id + '.en.md');
+        fs.writeFileSync(file, '![map](https://example.test/map.png)');
+        expect(() => readArticles(root)).toThrow(/self-hosted/);
+        fs.writeFileSync(file, '<script>alert(1)</script>');
+        expect(readArticles(root)[0].bodyHtml).toContain('&lt;script&gt;');
+        expect(permittedUrl('javascript:alert(1)')).toBe(false);
+        expect(permittedUrl('//example.test')).toBe(false);
+        expect(permittedUrl('/\\example.test')).toBe(false);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('excludes draft editions from listings, pages and sitemaps', () => {
+    const read = fs.readFileSync;
+    const manifestPath = path.join(__dirname, '../../content/blog/index.json');
+    const manifest = JSON.parse(read(manifestPath, 'utf8'));
+    manifest[0].status = 'draft';
+    const spy = jest.spyOn(fs, 'readFileSync').mockImplementation((file, ...args) =>
+        file === manifestPath ? JSON.stringify(manifest) : read(file, ...args));
+    try {
+        jest.isolateModules(() => {
+            const content = require('../services/blogContent');
+            const { resolveBlogPage } = require('../services/blogPresentation');
+            const { sitemapBlog } = require('../controllers/sitemapController');
+            const res = { set: jest.fn(), send: jest.fn() };
+            sitemapBlog({}, res);
+            for (const lang of ['en', 'fr']) {
+                const slug = manifest[0].editions[lang].slug;
+                const articlePath = (lang === 'fr' ? '/fr' : '') + '/blog/' + slug;
+                expect(content.listArticles({ lang })).toHaveLength(2);
+                expect(content.getArticle(lang, slug)).toBeNull();
+                expect(resolveBlogPage(articlePath).status).toBe(404);
+                expect(res.send.mock.calls[0][0]).not.toContain(articlePath);
+            }
+        });
+    } finally { spy.mockRestore(); }
+});

--- a/server/__tests__/catalogApi.test.js
+++ b/server/__tests__/catalogApi.test.js
@@ -213,3 +213,12 @@ describe('Catalog API', () => {
         expect(res.body.error).toBe('Origin not allowed');
     });
 });
+
+it('returns spelling suggestions only on an empty first page while retaining the selected place', async () => {
+    queries.searchDatasets.mockResolvedValue([]);
+    const first = await request(app).get('/api/v1/datasets?q=playgrouds&place=toronto-on');
+    expect(first.body.meta.search).toEqual({ query: 'playgrouds', suggestions: ['playgrounds'] });
+    expect(queries.searchDatasets).toHaveBeenLastCalledWith(expect.objectContaining({ place: 'toronto-on', q: 'playgrouds' }));
+    const later = await request(app).get('/api/v1/datasets?q=playgrouds&cursor=20');
+    expect(later.body.meta.search.suggestions).toEqual([]);
+});

--- a/server/__tests__/localSearch.test.js
+++ b/server/__tests__/localSearch.test.js
@@ -1,0 +1,23 @@
+const { searchExpression, literalPatterns, spellingSuggestions } = require('../services/localSearch');
+
+test('expands resident topics while retaining other query words', () => {
+    expect(searchExpression('parks school')).toContain("'parcs'");
+    expect(searchExpression('parks school')).toMatch(/ & \('school'\)$/);
+    expect(searchExpression('permis de construction')).toContain("'building' <-> 'permits'");
+    expect(searchExpression('parking permits')).not.toContain("'construction'");
+});
+
+test('builds literal whole-word patterns so parks does not mean parking', () => {
+    const [pattern] = literalPatterns('parks');
+    expect(pattern.startsWith('\\m(')).toBe(true);
+    expect(pattern.endsWith(')\\M')).toBe(true);
+    expect(literalPatterns("parks' | ! ; DROP TABLE")).toHaveLength(3);
+});
+
+test('suggests one-edit vocabulary corrections without replacing valid queries', () => {
+    expect(spellingSuggestions('playgrouds')).toContain('playgrounds');
+    expect(spellingSuggestions('parc')).toEqual([]);
+    expect(spellingSuggestions('parks')).toEqual([]);
+    expect(spellingSuggestions('xx')).toEqual([]);
+    expect(spellingSuggestions('completely unrelated')).toEqual([]);
+});

--- a/server/__tests__/localSearchIntegration.test.js
+++ b/server/__tests__/localSearchIntegration.test.js
@@ -1,0 +1,72 @@
+const { Pool } = require('pg');
+const { searchDatasets } = require('../db/catalogReadQueries');
+const url = process.env.SPATIAL_TEST_DATABASE_URL;
+const integrationDescribe = url ? describe : describe.skip;
+
+integrationDescribe('resident search PostgreSQL integration', () => {
+    let pool, db;
+    const prefix = 'resident_test_' + process.pid;
+    const id = name => prefix + '_' + name;
+    const search = (q, args = {}) => searchDatasets({
+        q, org: prefix, limit: 20, offset: 0, ...args
+    }, db);
+
+    beforeAll(async () => {
+        pool = new Pool({ connectionString: url });
+        db = await pool.connect();
+        await db.query('BEGIN');
+        await db.query('INSERT INTO organizations (id, name) VALUES ($1, $1)', [prefix]);
+        const datasets = [
+            ['parks', 'Green Spaces', null, 'Neighbourhood parks and green spaces beside a school.', null, 'sgc-cd-3520'],
+            ['parking', 'Parking Lot Facilities', null, 'Park your vehicle. Parking lots for vehicles.', null, 'sgc-cd-3520'],
+            ['fr', null, 'Parcs et espaces publics', null, 'Les grands parcs et les espaces verts de Montréal.', 'sgc-csd-2466023'],
+            ['play', 'Recreation Facilities', null, 'Outdoor playgrounds for children.', null, 'sgc-cd-3520'],
+            ['permits', 'Building Permits', null, 'Active building applications and permits.', null, 'sgc-cd-3520']
+        ];
+        for (const [key, en, fr, notesEn, notesFr, place] of datasets) {
+            await db.query(`INSERT INTO datasets (id, name, org_id, title_en, title_fr, notes_en, notes_fr)
+                VALUES ($1, $1, $2, $3, $4, $5, $6)`, [id(key), prefix, en, fr, notesEn, notesFr]);
+            await db.query(`INSERT INTO dataset_places (source_id, dataset_id, place_id, relationship, assignment_method)
+                VALUES ('open-canada', $1, $2, 'direct', 'manual')`, [id(key), place]);
+            await db.query(`INSERT INTO resources (id, dataset_id, format, url, datastore_active)
+                VALUES ($1, $2, 'CSV', 'https://example.test/data.csv', $3)`, [id(key + '_resource'), id(key), key === 'permits']);
+        }
+        await db.query(`INSERT INTO resource_maps (resource_id, provider, service_url, geometry_type)
+            VALUES ($1, 'arcgis', 'https://example.test/FeatureServer/0', 'polygon')`, [id('parks_resource')]);
+    });
+
+    afterAll(async () => {
+        if (db) { await db.query('ROLLBACK'); db.release(); }
+        if (pool) await pool.end();
+    });
+
+    test('ranks literal parks ahead of parking, retaining indexed recall', async () => {
+        const rows = await search('parks', { place: 'toronto-on' });
+        expect(rows[0].id).toBe(id('parks'));
+        expect(rows.map(row => row.id)).toContain(id('parking'));
+        expect(rows[0].preview_map_id).toBe(id('parks_resource'));
+        expect(rows[0].preview_table_id).toBeNull();
+    });
+
+    test('finds French records using English and English records using French', async () => {
+        expect((await search('parks', { place: 'montreal-qc' })).map(row => row.id)).toEqual([id('fr')]);
+        expect((await search('parcs', { place: 'toronto-on' }))[0].id).toBe(id('parks'));
+        expect((await search('permis de construction'))[0]).toMatchObject({ id: id('permits'), preview_table_id: id('permits_resource') });
+    });
+
+    test('keeps extra words, geography, format, map filters and pagination', async () => {
+        expect((await search('parks school')).map(row => row.id)).toEqual([id('parks')]);
+        expect(await search('building permits', { place: 'montreal-qc' })).toEqual([]);
+        expect(await search('parks', { format: 'PDF' })).toEqual([]);
+        expect((await search('parks', { mappable: true })).map(row => row.id)).toEqual([id('parks')]);
+        const first = await search('parks', { limit: 1 });
+        const second = await search('parks', { limit: 1, offset: 1 });
+        expect(first[0].id).not.toBe(second[0].id);
+    });
+
+    test('handles empty browsing, punctuation and stop words without SQL errors', async () => {
+        expect((await search(null)).length).toBe(5);
+        expect(await search("' | ! ;")).toEqual([]);
+        expect(await search('the')).toEqual([]);
+    });
+});

--- a/server/__tests__/searchConsoleIntegration.test.js
+++ b/server/__tests__/searchConsoleIntegration.test.js
@@ -107,4 +107,22 @@ integrationDescribe('search visibility PostgreSQL integration', () => {
         });
         expect(await getOrganizationByName(org + '_missing', admin)).toBeNull();
     });
+
+    test('groups both blog locales without including similarly named routes', async () => {
+        const metric = { clicks: 0, impressions: 60, ctr: 0, position: 5 };
+        const pages = ['/blog', '/fr/blog', '/blog/oshawa-parks-map', '/fr/blog/carte-parcs-oshawa', '/blogger'];
+        await replaceSearchConsoleDay({
+            dataDate: '2026-09-03', searchType: 'web', total: { ...metric, impressions: 300 },
+            breakdowns: pages.map(page => ({ dimension: 'page', value: 'https://canquery.com' + page, ...metric })),
+            queryPages: []
+        }, db);
+        const report = await getSearchGrowthReportData(db);
+        expect(report.routes.find(row => row.value === 'Local guides')).toMatchObject({
+            pages_with_impressions: 4, impressions: 240
+        });
+        expect(report.pageOpportunities.map(row => row.value)).toEqual(expect.arrayContaining([
+            'https://canquery.com/blog/oshawa-parks-map', 'https://canquery.com/fr/blog/carte-parcs-oshawa'
+        ]));
+        expect(report.pageOpportunities.map(row => row.value)).not.toContain('https://canquery.com/blogger');
+    });
 });

--- a/server/__tests__/seoSnapshot.test.js
+++ b/server/__tests__/seoSnapshot.test.js
@@ -1,6 +1,12 @@
 const snapshot = require('../services/seoSnapshot');
 
 describe('server-rendered crawl snapshots', () => {
+    it('links pilot places to their guide without adding unrelated guides', () => {
+        expect(snapshot.placeSnapshot({ id: 'p1', slug: 'oshawa-on', name_en: 'Oshawa' }, []))
+            .toContain('href="/blog/oshawa-parks-map"');
+        expect(snapshot.placeSnapshot({ id: 'p2', name_en: 'Elsewhere' }, []))
+            .not.toContain('href="/blog/');
+    });
     it('escapes catalogue text and bounds linked resources', () => {
         const resources = Array.from({ length: 30 }, (_, index) => ({
             id: 'r' + index,

--- a/server/app.js
+++ b/server/app.js
@@ -89,6 +89,7 @@ app.use('/api/v1/ops', opsRouter);
 app.use('/api/v1/insights', insightsRouter);
 app.use('/api/v1/places', placesRouter);
 app.use('/api/v1/sources', sourcesRouter);
+app.use('/api/v1/blog', require('./routes/blog'));
 
 // Crawl-facing files (robots.txt + sitemaps) live at the site root and read
 // from Postgres; mounted before the SPA so they win over the static catch-all.

--- a/server/controllers/catalogController.js
+++ b/server/controllers/catalogController.js
@@ -27,7 +27,7 @@ const listDatasets = async (req, res) => {
     });
     res.set('Cache-Control', 'public, max-age=300');
     const sources = Array.from(new Set(result.items.flatMap(item => item.provenance.sources.map(source => source.id))));
-    res.json(envelope(result.items, { nextCursor: result.nextCursor, meta: { sources } }));
+    res.json(envelope(result.items, { nextCursor: result.nextCursor, meta: { sources, search: { query: cleanStr(q) || '', suggestions: result.suggestions } } }));
 };
 
 const provenanceMeta = (value) => {

--- a/server/controllers/sitemapController.js
+++ b/server/controllers/sitemapController.js
@@ -1,6 +1,7 @@
 const catchAsync = require('../utils/catchAsync');
 const AppError = require('../utils/AppError');
 const catalogRead = require('../db/catalogReadQueries');
+const { listArticles } = require('../services/blogContent');
 const { SITE_URL } = require('../services/seoMeta');
 
 // Sitemap files cap at 50,000 URLs each; we chunk datasets well under that and
@@ -61,7 +62,8 @@ const sitemapIndex = catchAsync(async (req, res) => {
     const locs = [
         SITE_URL + '/sitemap-pages.xml',
         SITE_URL + '/sitemap-places.xml',
-        SITE_URL + '/sitemap-organizations.xml'
+        SITE_URL + '/sitemap-organizations.xml',
+        SITE_URL + '/sitemap-blog.xml'
     ];
     for (let i = 1; i <= datasetPages; i++) locs.push(SITE_URL + '/sitemap-datasets-' + i + '.xml');
     for (let i = 1; i <= resourcePages; i++) locs.push(SITE_URL + '/sitemap-resources-' + i + '.xml');
@@ -161,7 +163,18 @@ const sitemapResources = catchAsync(async (req, res, next) => {
     res.send(urlset(entries));
 });
 
+const sitemapBlog = (req, res) => {
+    const articles = ['en', 'fr'].flatMap(lang => listArticles({ lang }));
+    const updated = articles.map(article => article.updated).sort().at(-1);
+    const entries = ['/blog', '/fr/blog'].map(path => ({ loc: SITE_URL + path, lastmod: updated }));
+    for (const article of articles) entries.push({ loc: SITE_URL + article.path, lastmod: article.updated });
+    res.set('Content-Type', 'application/xml; charset=utf-8');
+    res.set('Cache-Control', 'public, max-age=3600');
+    res.send(urlset(entries));
+};
+
 module.exports = {
+    sitemapBlog,
     robots,
     sitemapIndex,
     sitemapPages,

--- a/server/controllers/spaController.js
+++ b/server/controllers/spaController.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const seoMeta = require('../services/seoMeta');
 const seoSnapshot = require('../services/seoSnapshot');
+const { resolveBlogPage } = require('../services/blogPresentation');
 const catalogRead = require('../db/catalogReadQueries');
 
 // The built index.html is immutable for the life of the process (a deploy
@@ -42,6 +43,8 @@ function searchArgs(overrides) {
 // in one pass. The same HTML is sent to every user agent; React replaces the
 // bounded snapshot when the application starts.
 async function resolvePage(reqPath, deps = catalogRead) {
+    const blog = resolveBlogPage(reqPath);
+    if (blog) return blog;
     const route = seoMeta.classifyRoute(reqPath);
     if (route.type === 'dataset') {
         const dataset = await deps.getDatasetByIdOrName(route.id);

--- a/server/db/catalogReadQueries.js
+++ b/server/db/catalogReadQueries.js
@@ -1,3 +1,4 @@
+const { searchExpression, literalPatterns } = require('../services/localSearch');
 const pool = require('./pool');
 
 const PROVENANCE_SELECT = `COALESCE((
@@ -64,9 +65,20 @@ const PLACE_CTES = `WITH RECURSIVE selected_place AS (
              CASE dp.relationship WHEN 'direct' THEN 0 ELSE 1 END
 )`;
 
-async function searchDatasets({ q, org, format, keyword, place, source, mappable, limit, offset }) {
-    const result = await pool.query(`${PLACE_CTES}
+async function searchDatasets({ q, org, format, keyword, place, source, mappable, limit, offset }, db = pool) {
+    const result = await db.query(`${PLACE_CTES}
         SELECT d.id, d.name, d.title_en, d.title_fr, d.metadata_modified,
+               d.notes_en, d.notes_fr,
+               (SELECT r.id FROM resources r JOIN resource_maps rm ON rm.resource_id = r.id
+                WHERE r.dataset_id = d.id ORDER BY r.id LIMIT 1) AS preview_map_id,
+               (SELECT r.id FROM resources r LEFT JOIN ingested_resources ir ON ir.resource_id = r.id
+                WHERE r.dataset_id = d.id AND (r.datastore_active OR ir.status = 'ready')
+                ORDER BY (ir.status = 'ready') DESC NULLS LAST, r.id LIMIT 1) AS preview_table_id,
+               CASE WHEN $1::text IS NULL THEN 0 ELSE (SELECT coalesce(sum(
+                    CASE WHEN concat_ws(' ', d.title_en, d.title_fr) ~* pattern THEN 8 ELSE 0 END +
+                    CASE WHEN concat_ws(' ', array_to_string(d.keywords_en, ' '), array_to_string(d.keywords_fr, ' ')) ~* pattern THEN 4 ELSE 0 END +
+                    CASE WHEN concat_ws(' ', d.notes_en, d.notes_fr) ~* pattern THEN 1 ELSE 0 END
+                ), 0) FROM unnest($11::text[]) AS pattern) END AS literal_rank,
                o.name AS org_name, o.title_en AS org_title_en, o.title_fr AS org_title_fr,
                (SELECT count(*)::int FROM resources r WHERE r.dataset_id = d.id) AS resource_count,
                (SELECT count(*)::int FROM resources r
@@ -86,7 +98,7 @@ async function searchDatasets({ q, org, format, keyword, place, source, mappable
         FROM datasets d
         LEFT JOIN organizations o ON o.id = d.org_id
         LEFT JOIN place_matches pm ON pm.dataset_id = d.id
-        WHERE ($1::text IS NULL OR d.search_tsv @@ (plainto_tsquery('english', $1) || plainto_tsquery('french', $1)))
+        WHERE ($1::text IS NULL OR d.search_tsv @@ (to_tsquery('english', $10) || to_tsquery('french', $10)))
           AND ($2::text IS NULL OR o.name = $2)
           AND ($3::text IS NULL OR EXISTS (
                SELECT 1 FROM resources r2
@@ -99,13 +111,14 @@ async function searchDatasets({ q, org, format, keyword, place, source, mappable
                SELECT 1 FROM resources r3 JOIN resource_maps rm3 ON rm3.resource_id = r3.id
                WHERE r3.dataset_id = d.id))
         ORDER BY pm.depth ASC NULLS LAST,
+                 literal_rank DESC,
                  CASE WHEN $1::text IS NULL THEN NULL
-                      ELSE ts_rank(d.search_tsv, plainto_tsquery('english', $1) || plainto_tsquery('french', $1))
+                      ELSE ts_rank(d.search_tsv, to_tsquery('english', $10) || to_tsquery('french', $10))
                  END DESC NULLS LAST,
                  d.metadata_modified DESC NULLS LAST,
                  d.id ASC
         LIMIT $8 OFFSET $9
-    `, [q || null, org || null, format || null, keyword || null, place || null, source || null, mappable || null, limit, offset]);
+    `, [q || null, org || null, format || null, keyword || null, place || null, source || null, mappable || null, limit, offset, searchExpression(q) || null, literalPatterns(q)]);
     return result.rows;
 }
 

--- a/server/db/searchConsoleQueries.js
+++ b/server/db/searchConsoleQueries.js
@@ -177,7 +177,8 @@ async function getSearchGrowthReportData(db = pool) {
             WHERE search_type = 'web' AND dimension = 'page'
               AND data_date BETWEEN latest.d - 27 AND latest.d
               AND (value ~ '/datasets/[^/?#]+' OR value ~ '/resources/[^/?#]+'
-                   OR value ~ '/places/[^/?#]+' OR value ~ '/organizations/[^/?#]+')
+                   OR value ~ '/places/[^/?#]+' OR value ~ '/organizations/[^/?#]+'
+                   OR value ~ '^https?://[^/]+/(fr/)?blog/[^/?#]+')
             GROUP BY value
             HAVING sum(impressions) >= 50
                AND CASE WHEN sum(impressions) = 0 THEN 0
@@ -210,6 +211,7 @@ async function getSearchGrowthReportData(db = pool) {
         db.query(`
             WITH latest AS (SELECT $1::date AS d), page_totals AS (
                 SELECT CASE
+                    WHEN scb.value ~ '^https?://[^/]+/(fr/)?blog(/|[?#]|$)' THEN 'Local guides'
                     WHEN scb.value ~ '/places/[^/?#]+' THEN 'Place pages'
                     WHEN scb.value ~ '/organizations/[^/?#]+' THEN 'Organization pages'
                     WHEN scb.value ~ '/datasets/[^/?#]+' THEN 'Dataset pages'

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,6 +19,7 @@
                 "express-rate-limit": "^7.4.0",
                 "google-auth-library": "^10.9.1",
                 "helmet": "^8.0.0",
+                "markdown-it": "14.3.1",
                 "pbf": "5.1.2",
                 "pg": "^8.13.0",
                 "pg-copy-streams": "^7.0.0",
@@ -2957,6 +2958,17 @@
                 "once": "^1.4.0"
             }
         },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/error-ex": {
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -5200,6 +5212,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/linkify-it": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+            "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
+        },
         "node_modules/listenercount": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
@@ -5347,6 +5377,37 @@
                 "tmpl": "1.0.5"
             }
         },
+        "node_modules/markdown-it": {
+            "version": "14.3.1",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.1.tgz",
+            "integrity": "sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.5.0",
+                "linkify-it": "^5.0.2",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/markdown-it/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5355,6 +5416,11 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/mdurl": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+            "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg=="
         },
         "node_modules/media-typer": {
             "version": "1.1.0",
@@ -6065,6 +6131,14 @@
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
             "engines": {
                 "node": ">=6"
             }
@@ -6883,6 +6957,11 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
+        },
+        "node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
         },
         "node_modules/undici-types": {
             "version": "7.24.6",

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,8 @@
         "gsc:sync": "node scripts/sync-search-console.js",
         "gsc:report": "node scripts/build-search-growth-report.js",
         "lint": "eslint .",
-        "verify": "bash ../scripts/verify-release.sh"
+        "verify": "bash ../scripts/verify-release.sh",
+        "blog:check": "node scripts/check-blog.js"
     },
     "dependencies": {
         "@aws-sdk/client-s3": "3.1118.0",
@@ -43,6 +44,7 @@
         "express-rate-limit": "^7.4.0",
         "google-auth-library": "^10.9.1",
         "helmet": "^8.0.0",
+        "markdown-it": "14.3.1",
         "pbf": "5.1.2",
         "pg": "^8.13.0",
         "pg-copy-streams": "^7.0.0",

--- a/server/routes/blog.js
+++ b/server/routes/blog.js
@@ -1,0 +1,23 @@
+const express = require('express');
+const { listArticles, getArticle } = require('../services/blogContent');
+const { envelope } = require('../utils/envelope');
+const AppError = require('../utils/AppError');
+const router = express.Router();
+
+router.get('/', (req, res, next) => {
+    const lang = req.query.lang || 'en';
+    if (!['en', 'fr'].includes(lang) || (req.query.place != null && typeof req.query.place !== 'string')) {
+        return next(new AppError('Invalid blog filter', 400));
+    }
+    res.set('Cache-Control', 'public, max-age=300');
+    res.json(envelope(listArticles({ lang, place: req.query.place })));
+});
+
+router.get('/:lang/:slug', (req, res, next) => {
+    const article = getArticle(req.params.lang, req.params.slug);
+    if (!article) return next(new AppError('Article not found', 404));
+    res.set('Cache-Control', 'public, max-age=300');
+    res.json(envelope(article));
+});
+
+module.exports = router;

--- a/server/routes/seo.js
+++ b/server/routes/seo.js
@@ -7,6 +7,7 @@ const router = express.Router();
 
 router.get('/robots.txt', sitemap.robots);
 router.get('/sitemap.xml', sitemap.sitemapIndex);
+router.get('/sitemap-blog.xml', sitemap.sitemapBlog);
 router.get('/sitemap-pages.xml', sitemap.sitemapPages);
 router.get('/sitemap-places.xml', sitemap.sitemapPlaces);
 router.get('/sitemap-organizations.xml', sitemap.sitemapOrganizations);

--- a/server/scripts/check-blog.js
+++ b/server/scripts/check-blog.js
@@ -1,0 +1,3 @@
+const { readArticles } = require('../services/blogContent');
+const articles = readArticles();
+console.log('Validated ' + articles.length + ' article editions (' + new Set(articles.map(article => article.id)).size + ' guides).');

--- a/server/services/blogContent.js
+++ b/server/services/blogContent.js
@@ -1,0 +1,90 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const MarkdownIt = require('markdown-it');
+
+const ROOT = path.join(__dirname, '../../content/blog');
+const markdown = new MarkdownIt({ html: false, linkify: false, typographer: false });
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+let cache;
+
+function permittedUrl(url) {
+    return typeof url === 'string' && !url.includes('\\') && ![...url].some(char => char.charCodeAt(0) <= 32) &&
+        (/^https?:\/\/[^/]+/i.test(url) || /^\/(?!\/)/.test(url) || /^#[a-z0-9-]+$/i.test(url));
+}
+
+function validateLinks(tokens) {
+    for (const token of tokens) {
+        if (token.type === 'heading_open' && token.tag === 'h1') throw new Error('Article headings must start at h2');
+        if (token.type === 'link_open' && !permittedUrl(token.attrGet('href'))) throw new Error('Unsupported article link');
+        if (token.type === 'image' && !/^\/(?!\/)/.test(token.attrGet('src') || '')) throw new Error('Article images must be self-hosted');
+        if (token.type === 'image' && !permittedUrl(token.attrGet('src'))) throw new Error('Unsupported article image');
+        if (token.children) validateLinks(token.children);
+    }
+}
+
+function readArticles(root = ROOT) {
+    const manifest = JSON.parse(fs.readFileSync(path.join(root, 'index.json'), 'utf8'));
+    if (!Array.isArray(manifest)) throw new Error('Blog manifest must be an array');
+    const ids = new Set();
+    const paths = new Set();
+    const articles = [];
+    for (const entry of manifest) {
+        if (!slugPattern.test(entry.id) || ids.has(entry.id)) throw new Error('Duplicate or invalid article id');
+        ids.add(entry.id);
+        if (!['draft', 'published'].includes(entry.status)) throw new Error('Invalid article status');
+        if (!slugPattern.test(entry.place) || !slugPattern.test(entry.topic)) throw new Error('Invalid article place or topic');
+        for (const key of ['published', 'updated', 'verified']) {
+            if (!datePattern.test(entry[key] || '') || new Date(entry[key]).toISOString().slice(0, 10) !== entry[key]) {
+                throw new Error('Invalid article date: ' + key);
+            }
+        }
+        if (entry.updated < entry.published) throw new Error('Article update predates publication');
+        for (const lang of ['en', 'fr']) {
+            const edition = entry.editions?.[lang];
+            if (typeof entry.query?.[lang] !== 'string' || !entry.query[lang].trim()) throw new Error('Missing localized topic query');
+            if (!edition || !slugPattern.test(edition.slug) || !edition.title?.trim() ||
+                !edition.description?.trim() || !edition.placeName?.trim() || !edition.topicName?.trim()) {
+                throw new Error('Missing or invalid article translation: ' + entry.id + '/' + lang);
+            }
+            if (!permittedUrl(entry.explore) || !entry.explore.startsWith('/resources/')) throw new Error('Invalid exploration link');
+            if (!entry.dataset?.startsWith('/datasets/') || !permittedUrl(entry.dataset)) throw new Error('Invalid dataset link');
+            const articlePath = (lang === 'fr' ? '/fr' : '') + '/blog/' + edition.slug;
+            if (paths.has(articlePath)) throw new Error('Duplicate article slug');
+            paths.add(articlePath);
+            // File names derive from validated identities, never request paths.
+            const body = fs.readFileSync(path.join(root, entry.id + '.' + lang + '.md'), 'utf8');
+            if (!body.trim()) throw new Error('Empty article');
+            const tokens = markdown.parse(body, {});
+            validateLinks(tokens);
+            articles.push({
+                id: entry.id, lang, path: articlePath, ...edition,
+                place: entry.place, topic: entry.topic, query: entry.query[lang],
+                published: entry.published, updated: entry.updated, verified: entry.verified,
+                author: 'CanQuery', status: entry.status,
+                explore: entry.explore, view: entry.view, dataset: entry.dataset,
+                bodyHtml: markdown.renderer.render(tokens, markdown.options, {}),
+                translations: Object.fromEntries(['en', 'fr'].map(language => [language,
+                    (language === 'fr' ? '/fr' : '') + '/blog/' + entry.editions[language].slug]))
+            });
+        }
+    }
+    return articles;
+}
+
+function allArticles() {
+    if (!cache) cache = readArticles().filter(article => article.status === 'published');
+    return cache;
+}
+
+function listArticles({ lang = 'en', place } = {}) {
+    return allArticles().filter(article => article.lang === lang && (!place || article.place === place))
+        .sort((a, b) => b.published.localeCompare(a.published) || a.id.localeCompare(b.id))
+        .map(({ bodyHtml: _body, status: _status, ...article }) => article);
+}
+
+function getArticle(lang, slug) {
+    return allArticles().find(article => article.lang === lang && article.slug === slug) || null;
+}
+
+module.exports = { readArticles, listArticles, getArticle, permittedUrl };

--- a/server/services/blogPresentation.js
+++ b/server/services/blogPresentation.js
@@ -1,0 +1,74 @@
+const { listArticles, getArticle } = require('./blogContent');
+const { SITE_URL, escapeHtml: esc, truncate } = require('./seoMeta');
+
+const LABELS = {
+    en: { title: 'Local guides', intro: 'Practical ways to explore your city with official open data.',
+        source: 'View the source dataset', explore: 'Explore the data', city: 'More data for',
+        published: 'Published', updated: 'Article updated', verified: 'Data links checked', by: 'By',
+        missing: 'Guide not found' },
+    fr: { title: 'Guides locaux', intro: 'Des façons pratiques de découvrir votre ville grâce aux données ouvertes officielles.',
+        source: 'Consulter le jeu de données source', explore: 'Explorer les données', city: 'Autres données pour',
+        published: 'Publié le', updated: 'Article mis à jour le', verified: 'Liens vérifiés le', by: 'Par',
+        missing: 'Guide introuvable' }
+};
+
+function resolveBlogPage(pathname) {
+    const match = /^\/(fr\/)?blog(?:\/([^/]+))?\/?$/.exec(pathname);
+    if (!match) return null;
+    const lang = match[1] ? 'fr' : 'en';
+    const labels = LABELS[lang];
+    const indexPath = (lang === 'fr' ? '/fr' : '') + '/blog';
+    const article = match[2] ? getArticle(lang, match[2]) : null;
+    if (match[2] && !article) return {
+        status: 404,
+        meta: { title: labels.missing + ' - CanQuery', lang, noindex: true, canonical: SITE_URL + pathname },
+        body: '<main class="max-w-3xl mx-auto px-4 py-12"><h1>' + labels.missing + '</h1></main>'
+    };
+    const canonicalPath = article ? article.path : indexPath;
+    const translations = article?.translations || { en: '/blog', fr: '/fr/blog' };
+    const title = article?.title || labels.title;
+    const description = article?.description || labels.intro;
+    const breadcrumbs = [{ '@type': 'ListItem', position: 1, name: labels.title, item: SITE_URL + indexPath }];
+    if (article) breadcrumbs.push({ '@type': 'ListItem', position: 2, name: title, item: SITE_URL + article.path });
+    const meta = {
+        title: truncate(title, 69) + ' - CanQuery', description: truncate(description, 160),
+        canonical: SITE_URL + canonicalPath, lang, ogType: article ? 'article' : 'website',
+        alternates: { 'en-CA': SITE_URL + translations.en, 'fr-CA': SITE_URL + translations.fr,
+            'x-default': SITE_URL + translations.en },
+        jsonLd: [{ '@context': 'https://schema.org', '@type': 'BreadcrumbList', itemListElement: breadcrumbs }]
+    };
+    if (article) meta.jsonLd.push({
+        '@context': 'https://schema.org', '@type': 'BlogPosting', headline: article.title,
+        description: article.description, inLanguage: lang === 'fr' ? 'fr-CA' : 'en-CA',
+        datePublished: article.published, dateModified: article.updated,
+        author: { '@type': 'Organization', name: 'CanQuery', url: SITE_URL + '/' },
+        publisher: { '@type': 'Organization', name: 'CanQuery', url: SITE_URL + '/' },
+        mainEntityOfPage: SITE_URL + article.path
+    });
+    const alternate = lang === 'fr' ? 'en' : 'fr';
+    const languageLink = '<a href="' + translations[alternate] + '" hreflang="' + alternate +
+        '" class="link">' + (alternate === 'fr' ? 'Lire en français' : 'Read in English') + '</a>';
+    let body = '<main data-cq-blog class="max-w-3xl mx-auto px-4 py-10">';
+    if (article) {
+        body += '<nav aria-label="' + (lang === 'fr' ? 'Fil d’Ariane' : 'Breadcrumbs') + '"><a class="link" href="' + indexPath + '">' + labels.title + '</a></nav>' +
+            '<article><p class="cq-chip mt-6">' + esc(article.placeName) + ' · ' + esc(article.topicName) + '</p>' +
+            '<h1 class="font-display text-3xl sm:text-4xl font-bold mt-4">' + esc(title) + '</h1>' +
+            '<p class="text-base-content/60 mt-4">' + esc(description) + '</p>' +
+            '<p class="text-sm text-base-content/60 mt-4">' + labels.by + ' CanQuery · ' + labels.published + ' ' + article.published + '</p>' +
+            '<p class="text-sm text-base-content/60">' + labels.updated + ' ' + article.updated + ' · ' + labels.verified + ' ' + article.verified + '</p>' +
+            '<p class="mt-4">' + languageLink + '</p>' +
+            '<div class="cq-article mt-8">' + article.bodyHtml + '</div>' +
+            '<p class="mt-8"><a class="btn btn-primary" href="' + esc(article.explore) + '">' + labels.explore + '</a></p>' +
+            '<p class="mt-4"><a class="link" href="' + article.dataset + '">' + labels.source + '</a></p>' +
+            '<p class="mt-4"><a class="link" href="/places/' + article.place + '">' + labels.city + ' ' + esc(article.placeName) + '</a></p></article>';
+    } else {
+        body += '<h1 class="font-display text-4xl font-bold">' + title + '</h1><p class="mt-4">' + description + '</p>' +
+            '<p class="mt-4">' + languageLink + '</p><div class="space-y-5 mt-8">' +
+            listArticles({ lang }).map(item => '<article class="cq-card p-6"><p class="cq-chip">' + esc(item.placeName) +
+                '</p><h2 class="text-xl font-semibold mt-3"><a href="' + item.path + '">' + esc(item.title) +
+                '</a></h2><p class="mt-3">' + esc(item.description) + '</p></article>').join('') + '</div>';
+    }
+    return { status: 200, canonicalPath, meta, body: body + '</main>' };
+}
+
+module.exports = { resolveBlogPage };

--- a/server/services/catalogService.js
+++ b/server/services/catalogService.js
@@ -1,3 +1,5 @@
+const { plainText, truncate } = require('./seoMeta');
+const { spellingSuggestions } = require('./localSearch');
 const catalogReadQueries = require('../db/catalogReadQueries');
 const queryLogQueries = require('../db/queryLogQueries');
 const { packageList } = require('./ckanClient');
@@ -138,6 +140,8 @@ const searchDatasets = async ({ q, org, format, keyword, place, source, mappable
         id: r.id,
         name: r.name,
         title: { en: r.title_en, fr: r.title_fr },
+        description: { en: truncate(plainText(r.notes_en), 240), fr: truncate(plainText(r.notes_fr), 240) },
+        preview_resources: { map: r.preview_map_id || null, table: r.preview_table_id || null },
         organization: r.org_name
             ? { name: r.org_name, title: { en: r.org_title_en, fr: r.org_title_fr } }
             : null,
@@ -149,7 +153,8 @@ const searchDatasets = async ({ q, org, format, keyword, place, source, mappable
         place_match: shapePlaceMatch(r),
         provenance: shapeProvenance(r.provenance_sources)
     }));
-    return { items, nextCursor: hasMore ? String(offset + lim) : null };
+    return { items, nextCursor: hasMore ? String(offset + lim) : null,
+        suggestions: offset === 0 && items.length === 0 ? spellingSuggestions(q) : [] };
 };
 
 const getDataset = async (idOrName) => {

--- a/server/services/localSearch.js
+++ b/server/services/localSearch.js
@@ -1,0 +1,64 @@
+// A small, reviewed vocabulary for resident tasks. Expansion happens inside
+// the existing search; it never changes geographic or publisher filters.
+const TOPICS = [
+    ['parks', 'park', 'parcs', 'parc', 'green spaces', 'green space', 'espaces verts', 'espace vert'],
+    ['playgrounds', 'playground', 'play areas', 'play area', 'aires de jeux', 'aire de jeux'],
+    ['building permits', 'building permit', 'permis de construction', 'permis de bâtir']
+];
+// Inflection is already handled by PostgreSQL. Repeating singular/plural
+// alternatives inflates the planner's match estimate and can bypass the GIN index.
+const SEARCH_TERMS = [
+    ['parks', 'parcs', 'green spaces', 'espaces verts'],
+    ['playgrounds', 'play areas', 'aires de jeux'],
+    ['building permits', 'permis de construction', 'permis de bâtir']
+];
+const words = value => String(value || '').toLocaleLowerCase('fr-CA').match(/[\p{L}\p{N}]+/gu) || [];
+const fold = value => value.normalize('NFD').replace(/\p{M}/gu, '');
+const aliases = TOPICS.flatMap(terms => terms.map(term => ({ term, terms, tokens: words(term) })))
+    .sort((a, b) => b.tokens.length - a.tokens.length);
+
+function searchGroups(query) {
+    const tokens = words(query);
+    const groups = [];
+    for (let i = 0; i < tokens.length;) {
+        const alias = aliases.find(item => item.tokens.every((token, j) =>
+            fold(token) === fold(tokens[i + j] || '')));
+        groups.push(alias ? alias.terms : [tokens[i]]);
+        i += alias ? alias.tokens.length : 1;
+    }
+    return groups;
+}
+
+function searchExpression(query) {
+    return searchGroups(query).map(group => SEARCH_TERMS[TOPICS.indexOf(group)] || group)
+        .map(group => '(' + group.map(term =>
+        words(term).map(token => "'" + token + "'").join(' <-> ')
+    ).join(' | ') + ')').join(' & ');
+}
+
+function literalPatterns(query) {
+    return searchGroups(query).map(group => '\\m(' + group.map(term =>
+        words(term).join('[[:space:]]+')
+    ).join('|') + ')\\M');
+}
+
+function oneEdit(a, b) {
+    if (Math.abs(a.length - b.length) > 1 || a === b) return false;
+    let i = 0, j = 0, edits = 0;
+    while (i < a.length && j < b.length) {
+        if (a[i] === b[j]) { i++; j++; continue; }
+        if (++edits > 1) return false;
+        if (a.length >= b.length) i++;
+        if (b.length >= a.length) j++;
+    }
+    return edits + Number(i < a.length || j < b.length) === 1;
+}
+
+function spellingSuggestions(query) {
+    const normalized = words(query).join(' ');
+    if (normalized.length < 4 || aliases.some(item => fold(item.term) === fold(normalized))) return [];
+    return [...new Set(aliases.filter(item => oneEdit(fold(normalized), fold(item.term)))
+        .map(item => item.term))].slice(0, 3);
+}
+
+module.exports = { searchExpression, literalPatterns, spellingSuggestions };

--- a/server/services/seoMeta.js
+++ b/server/services/seoMeta.js
@@ -679,6 +679,10 @@ function buildManagedTags(meta) {
     tags.push('<title>' + title + '</title>');
     tags.push('<meta name="description" content="' + description + '" />');
     tags.push('<link rel="canonical" href="' + url + '" />');
+    for (const [language, href] of Object.entries(meta.alternates || {})) {
+        tags.push('<link rel="alternate" hreflang="' + escapeHtml(language) + '" href="' + escapeHtml(href) + '" />');
+    }
+    if (meta.lang) tags.push('<meta property="og:locale" content="' + (meta.lang === 'fr' ? 'fr_CA' : 'en_CA') + '" />');
     tags.push('<meta property="og:title" content="' + title + '" />');
     tags.push('<meta property="og:description" content="' + description + '" />');
     tags.push('<meta property="og:type" content="' + ogType + '" />');
@@ -698,7 +702,7 @@ function buildManagedTags(meta) {
 // changed), return the template untouched - serving valid default HTML.
 function renderHtml(template, meta, bodyHtml = '') {
     const re = /<!-- seo:start -->[\s\S]*?<!-- seo:end -->/;
-    let html = template;
+    let html = meta.lang ? template.replace(/<html\b[^>]*>/, '<html lang="' + escapeHtml(meta.lang) + '">') : template;
     if (re.test(html)) {
         const block = buildManagedTags(meta)
             .map((line) => '    ' + line)

--- a/server/services/seoSnapshot.js
+++ b/server/services/seoSnapshot.js
@@ -1,4 +1,5 @@
 const seo = require('./seoMeta');
+const { listArticles } = require('./blogContent');
 const { classifyResource } = require('./resourceCapabilities');
 
 const MAX_LINKS = 12;
@@ -150,7 +151,8 @@ function placeSnapshot(place, datasets) {
             { label: 'Mappable datasets', value: maps }
         ],
         linksTitle: datasetLinks.length ? 'Open datasets' : 'Places in this area',
-        links: datasetLinks.length ? datasetLinks : childLinks
+        links: datasetLinks.length ? datasetLinks : childLinks,
+        relatedLinks: listArticles({ place: place.slug || place.id }).map(article => ({ path: article.path, label: article.title }))
     });
 }
 
@@ -190,6 +192,7 @@ const STATIC_COPY = {
         summary: 'Find federal, provincial, territorial and municipal datasets, query live tables, and explore spatial resources on maps.',
         links: [
             { path: '/places', label: 'Browse open data by place' },
+            { path: '/blog', label: 'Read local resident guides' },
             { path: '/organizations', label: 'Browse publishing organizations' },
             { path: '/insights', label: 'Explore popular dataset insights' },
             { path: '/docs', label: 'Use the CanQuery API' }


### PR DESCRIPTION
## What & why

Residents can now reach useful local data from practical guides and clearer search results. A search for parks ranks literal park and green-space matches above parking, and reviewed English/French terms connect parks, playgrounds, and building permits across catalogue languages. Empty first pages offer bounded spelling suggestions while retaining geographic and source filters. Results include plain-text summaries and links to supported maps or tables.

Adds three complete guides for Toronto active building permits, Oshawa park boundaries, and Montréal parks/public spaces, each in English and French. The repository-authored articles supply full initial HTML, localized URLs, reciprocal hreflang, BlogPosting/breadcrumb metadata, a blog sitemap, and links from navigation, home, and pilot place pages. Content documents its official sources, coverage limits, and distinct publication/update/link-check dates. Analytics records search outcomes and guide-to-resource clicks; Search Console reporting groups both blog locales.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

Validation: 579 ordinary server tests plus 21 tests against disposable PostgreSQL 16/PostGIS 3.5; 129 client tests; both linters; content validation; production build. Browser checks cover both indexes and all six article editions with JavaScript enabled and disabled, keyboard navigation, language switching and Back, French mobile layout, mobile search results, and the three live resource workflows.

Read-only catalogue comparisons confirm the relevance changes. Duplicate expanded terms were removed after a query-plan regression; sampled local parks searches then completed in roughly 90–120 ms. No schema migration or source/worker change. `deploy/RELEASE_RUNBOOK_v39.md` covers deployment, rollback, and later 7/28-day measurement; publication itself is not evidence of an SEO gain.