### PR TITLE
Keep map status badges clear of zoom controls

### DIFF
--- a/client/src/components/MapPanel.jsx
+++ b/client/src/components/MapPanel.jsx
@@ -151,15 +151,17 @@ function LegacyMapPanel({ resourceId, mapInfo }) {
           />
         )}
       </MapContainer>
-      <div className="absolute left-3 top-3 z-[500] flex items-center gap-2 rounded-lg border border-base-content/10 bg-base-100/90 backdrop-blur px-3 py-2 text-xs shadow-lg">
-        {loading ? <span className="loading loading-spinner loading-xs" /> : <MapIcon size={13} className="text-secondary" />}
-        {loading ? t('map.loading') : meta ? meta.returned.toLocaleString() + ' ' + t('map.features') : t('map.live')}
-      </div>
-      {meta?.truncated && (
-        <div className="absolute right-3 top-3 z-[500] rounded-lg bg-warning/90 text-warning-content px-3 py-2 text-xs shadow-lg">
-          {t('map.zoom_in')}
+      <div className="absolute left-16 right-3 top-3 z-[500] flex flex-col items-end gap-2 pointer-events-none">
+        <div className="max-w-full flex items-center gap-2 rounded-lg border border-base-content/10 bg-base-100/90 backdrop-blur px-3 py-2 text-xs shadow-lg">
+          {loading ? <span className="loading loading-spinner loading-xs" /> : <MapIcon size={13} className="text-secondary" />}
+          {loading ? t('map.loading') : meta ? meta.returned.toLocaleString() + ' ' + t('map.features') : t('map.live')}
         </div>
-      )}
+        {meta?.truncated && (
+          <div className="max-w-full rounded-lg bg-warning/90 text-warning-content px-3 py-2 text-xs shadow-lg">
+            {t('map.zoom_in')}
+          </div>
+        )}
+      </div>
       {error && (
         <div className="absolute inset-x-4 bottom-8 z-[500] alert alert-error text-sm shadow-xl">
           {error.status === 413 ? t('map.zoom_in') : t('map.failed')}


### PR DESCRIPTION
## What & why

The feature-count badge covered Leaflet’s zoom-in button, blocking the zoom step described in the Oshawa parks guide. Move the count and truncation messages into a stacked area at the top right, reserve space for the controls, and let pointer events pass through the informational overlays.

## Checklist

- [x] Existing server checks passed in the parent release; this change touches one client component
- [x] Client lint, resource-page tests, and production build pass
- [x] Browser checks verify zoom-button hit testing and clicking at desktop and French mobile widths, including simultaneous count/truncation messages
- [x] Existing EN/FR strings retained
- [x] No secrets, credentials, or production-specific details added

## Notes

Local browser validation uses an explicit map fixture to test layout independently of source availability. Full CI gates the merge. The live Oshawa source will be checked again after deployment. No schema or map-fetching change.