### PR TITLE
Improve dataset search snippets and dated SEO reporting

### DIFF
--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -260,6 +260,22 @@ sudo -u canquery npm run gsc:sync --prefix /home/canquery/canquery/server -- --d
 sudo -u canquery npm run gsc:report --prefix /home/canquery/canquery/server
 ```
 
+To compare a release against a frozen period, pass `--start YYYY-MM-DD`,
+`--end YYYY-MM-DD`, `--compare-start YYYY-MM-DD`, and `--compare-end YYYY-MM-DD`
+after `npm run gsc:report --`. Both periods must have the same length (1–90
+days), cannot overlap, and cannot extend beyond imported finalized data.
+Every report breakdown uses the selected current period. Imported-day counts
+make gaps visible; missing dates are not confirmed zero traffic.
+
+Use `--output /private/path/report.html` for a separate report and
+`--json /private/path/baseline.json` for a mode-600 baseline that refuses to
+overwrite an existing file. `--releases /private/path/releases.json` (or
+`GSC_RELEASES_PATH`) accepts an array of `{ "date": "YYYY-MM-DD", "label":
+"Release description" }` annotations. Record actual release dates; the report
+labels releases after its selected period. Keep these files private. Report
+generation reads one consistent database snapshot and does not import or
+modify Search Console data.
+
 The client requests only `webmasters.readonly`. The first sync imports 90
 finalized Pacific-time days, including aggregate query-to-page attribution;
 later runs replace a seven-day overlap atomically. Serve the file configured by

--- a/server/__tests__/searchConsoleIntegration.test.js
+++ b/server/__tests__/searchConsoleIntegration.test.js
@@ -125,4 +125,31 @@ integrationDescribe('search visibility PostgreSQL integration', () => {
         ]));
         expect(report.pageOpportunities.map(row => row.value)).not.toContain('https://canquery.com/blogger');
     });
+
+    test('applies explicit comparison dates to totals and every current-period breakdown', async () => {
+        for (const [date, query, clicks, impressions] of [
+            ['2026-08-01', 'prior water data', 7, 100],
+            ['2026-10-01', 'current water data', 13, 200]
+        ]) {
+            const metric = { clicks, impressions, ctr: clicks / impressions, position: 5 };
+            await replaceSearchConsoleDay({
+                dataDate: date, searchType: 'web', total: metric,
+                breakdowns: [{ dimension: 'query', value: query, ...metric },
+                    { dimension: 'page', value: 'https://canquery.com/datasets/' + date, ...metric }],
+                queryPages: [{ query, page: 'https://canquery.com/datasets/' + date, ...metric }]
+            }, db);
+        }
+        const report = await getSearchGrowthReportData(db, {
+            startDate: '2026-10-01', endDate: '2026-10-01',
+            comparisonStartDate: '2026-08-01', comparisonEndDate: '2026-08-01'
+        });
+        expect(report.summary).toMatchObject({ current_clicks: 13, prior_clicks: 7,
+            current_impressions: 200, prior_impressions: 100, current_days: 1, prior_days: 1 });
+        expect(report.topQueries.map(row => row.value)).toEqual(['current water data']);
+        expect(report.topPages.map(row => row.value)).toEqual(['https://canquery.com/datasets/2026-10-01']);
+        expect(report.queryIntentSummary.find(row => row.intent === 'semantic')).toMatchObject({ queries: 1, clicks: 13 });
+        const historical = await getSearchGrowthReportData(db, { startDate: '2026-08-01', endDate: '2026-08-01' });
+        expect(historical.topQueries.map(row => row.value)).toEqual(['prior water data']);
+        expect(historical.daily.every(row => row.data_date <= '2026-08-01')).toBe(true);
+    });
 });

--- a/server/__tests__/searchGrowthReport.test.js
+++ b/server/__tests__/searchGrowthReport.test.js
@@ -57,3 +57,17 @@ it('renders a safe empty report before the first import', () => {
 it('escapes all HTML metacharacters', () => {
     expect(escapeHtml(`<&>"'`)).toBe('&lt;&amp;&gt;&quot;&#39;');
 });
+
+it('labels periods, incomplete imports and releases outside the selected window', () => {
+    const data = sample();
+    data.period = { startDate: '2026-08-13', endDate: '2026-08-19', comparisonStartDate: '2026-08-01', comparisonEndDate: '2026-08-07', days: 7 };
+    data.releases = [{ date: '2026-09-09', label: '<script>release</script>' }];
+    data.summary.current_days = 6;
+    data.summary.prior_days = 7;
+    const html = renderSearchGrowthReport(data);
+    expect(html).toContain('Current: 2026-08-13 to 2026-08-19');
+    expect(html).toContain('Imported days: 6 current; 7 comparison');
+    expect(html).toContain('after this reporting period');
+    expect(html).toContain('&lt;script&gt;release&lt;/script&gt;');
+    expect(html).not.toContain('<script>');
+});

--- a/server/__tests__/searchReportPeriod.test.js
+++ b/server/__tests__/searchReportPeriod.test.js
@@ -1,0 +1,32 @@
+const { resolveReportPeriod, validateReleaseAnnotations } = require('../services/searchReportPeriod');
+
+test('defaults to adjacent finalized 28-day periods', () => {
+    expect(resolveReportPeriod('2026-09-06')).toEqual({
+        startDate: '2026-08-10', endDate: '2026-09-06',
+        comparisonStartDate: '2026-07-13', comparisonEndDate: '2026-08-09', days: 28
+    });
+});
+
+test('supports explicit equal-length nonadjacent release cohorts', () => {
+    expect(resolveReportPeriod('2026-10-15', {
+        startDate: '2026-10-01', endDate: '2026-10-07',
+        comparisonStartDate: '2026-08-01', comparisonEndDate: '2026-08-07'
+    })).toMatchObject({ days: 7, comparisonStartDate: '2026-08-01' });
+});
+
+test.each([
+    { startDate: '2026-02-30' }, { endDate: '2026-09-07' },
+    { startDate: '2026-09-07' }, { startDate: '2025-01-01' },
+    { comparisonEndDate: '2026-08-01' },
+    { comparisonStartDate: '2026-08-10', comparisonEndDate: '2026-09-06' },
+    { comparisonStartDate: '2026-08-01', comparisonEndDate: '2026-08-02' }
+])('rejects misleading or impossible reporting periods: %j', options => {
+    expect(() => resolveReportPeriod('2026-09-06', options)).toThrow();
+});
+
+test('validates and sorts release annotations without trusting their HTML', () => {
+    expect(validateReleaseAnnotations([{ date: '2026-09-11', label: '<release>' }]))
+        .toEqual([{ date: '2026-09-11', label: '<release>' }]);
+    expect(() => validateReleaseAnnotations([{ date: 'bad', label: 'Release' }])).toThrow();
+    expect(() => validateReleaseAnnotations([{ date: '2026-09-11', label: '' }])).toThrow();
+});

--- a/server/__tests__/seoMeta.test.js
+++ b/server/__tests__/seoMeta.test.js
@@ -1,5 +1,21 @@
 const seo = require('../services/seoMeta');
 
+test('makes Markdown descriptions readable without exposing link destinations or executable markup', () => {
+    expect(seo.plainText('**Note**: Read [contract history](https://example.test/long-url).\n\n---\n<script>bad()</script>Use `CSV` &amp; tables.'))
+        .toBe('Note: Read contract history. Use CSV & tables.');
+});
+
+test('keeps the recorded file language, format and map action in long resource snippets', () => {
+    const resource = { id: 'r', name_en: 'Long official employer list name '.repeat(20),
+        format: 'XLSX', language: ['fr'], ingest_status: 'ready', map_provider: 'arcgis' };
+    const meta = seo.resourceMeta(resource);
+    expect(meta.title).toContain('(French, XLSX) - CanQuery');
+    expect(meta.title.length).toBeLessThanOrEqual(80);
+    expect(meta.description).toMatch(/^Explore the interactive map\./);
+    expect(meta.description).toContain('French XLSX table');
+    expect(meta.description.length).toBeLessThanOrEqual(160);
+});
+
 describe('seoMeta - route classification', () => {
     it('classifies the known SPA routes', () => {
         expect(seo.classifyRoute('/')).toEqual({ type: 'home' });
@@ -171,9 +187,9 @@ describe('seoMeta - resource titles, capabilities and breadcrumbs', () => {
     test.each([
         [{ ...base, ingest_status: 'ready' }, /query, filter, chart and export.*live CSV table/i],
         [{ ...base, datastore_active: true }, /query, filter, chart and export.*live CSV table/i],
-        [base, /Load this CSV resource.*live table.*query, filter, chart and export/i],
+        [base, /Load this CSV resource.*live table/i],
         [{ ...base, format: 'PDF', map_provider: 'arcgis' }, /interactive map.*original PDF file/i],
-        [{ ...base, format: 'PDF' }, /metadata.*original PDF file.*public-sector publisher/i]
+        [{ ...base, format: 'PDF' }, /metadata.*original PDF file/i]
     ])('writes truthful capability-specific copy for %#', (resource, expected) => {
         expect(seo.resourceMeta(resource).description).toMatch(expected);
     });

--- a/server/db/searchConsoleQueries.js
+++ b/server/db/searchConsoleQueries.js
@@ -1,5 +1,6 @@
 const pool = require('./pool');
 const { classifyRows, searchIntentSql, INTENTS } = require('../services/searchIntent');
+const { resolveReportPeriod } = require('../services/searchReportPeriod');
 
 async function latestSearchConsoleDate(db = pool) {
     const result = await db.query("SELECT max(data_date)::text AS data_date FROM search_console_daily WHERE search_type = 'web'");
@@ -100,11 +101,11 @@ async function replaceSearchConsoleDay(day, db = pool) {
     }
 }
 
-async function aggregateBreakdown(db, dimension, { zeroClick = false, limit = 25, intent = null } = {}) {
+async function aggregateBreakdown(db, dimension, { zeroClick = false, limit = 25, intent = null, startDate = null, endDate = null } = {}) {
     if (intent && (dimension !== 'query' || !INTENTS.includes(intent))) throw new Error('Invalid query intent');
     const result = await db.query(`
         WITH latest AS (
-            SELECT max(data_date) AS d FROM search_console_daily WHERE search_type = 'web'
+            SELECT coalesce($4::date, max(data_date)) AS d FROM search_console_daily WHERE search_type = 'web'
         )
         SELECT value,
                sum(clicks)::float8 AS clicks,
@@ -114,17 +115,17 @@ async function aggregateBreakdown(db, dimension, { zeroClick = false, limit = 25
                     ELSE sum(position * impressions) / sum(impressions) END::float8 AS position
         FROM search_console_breakdowns, latest
         WHERE search_type = 'web' AND dimension = $1
-          AND data_date BETWEEN latest.d - 27 AND latest.d
-          ${intent ? 'AND ' + searchIntentSql('value') + ' = $3' : ''}
+          AND data_date BETWEEN coalesce($3::date, latest.d - 27) AND latest.d
+          ${intent ? 'AND ' + searchIntentSql('value') + ' = $5' : ''}
         GROUP BY value
         ${zeroClick ? 'HAVING sum(clicks) = 0 AND sum(impressions) > 0' : ''}
         ORDER BY ${zeroClick ? 'impressions' : 'clicks'} DESC, impressions DESC, value
         LIMIT $2
-    `, intent ? [dimension, limit, intent] : [dimension, limit]);
+    `, intent ? [dimension, limit, startDate, endDate, intent] : [dimension, limit, startDate, endDate]);
     return result.rows;
 }
 
-async function getSearchGrowthReportData(db = pool) {
+async function getSearchGrowthReportData(db = pool, options = {}) {
     const latestResult = await db.query(`
         SELECT max(data_date)::text AS latest_date, max(synced_at) AS last_synced_at
         FROM search_console_daily WHERE search_type = 'web'
@@ -138,6 +139,8 @@ async function getSearchGrowthReportData(db = pool) {
             countries: [], devices: [], routes: []
         };
     }
+    const period = resolveReportPeriod(latestDate, options);
+    const { startDate, endDate, comparisonStartDate, comparisonEndDate } = period;
     const [
         dailyResult, summaryResult, topQueries, topPages, zeroClickQueries,
         pageOpportunitiesResult, queryPageOpportunitiesResult,
@@ -146,26 +149,28 @@ async function getSearchGrowthReportData(db = pool) {
         db.query(`
             SELECT data_date::text, clicks, impressions, ctr, position
             FROM search_console_daily
-            WHERE search_type = 'web' AND data_date >= $1::date - 89
+            WHERE search_type = 'web' AND data_date BETWEEN $1::date - 89 AND $1::date
             ORDER BY data_date
-        `, [latestDate]),
+        `, [endDate]),
         db.query(`
             SELECT
-                coalesce(sum(clicks) FILTER (WHERE data_date BETWEEN $1::date - 27 AND $1::date), 0)::float8 AS current_clicks,
-                coalesce(sum(impressions) FILTER (WHERE data_date BETWEEN $1::date - 27 AND $1::date), 0)::float8 AS current_impressions,
-                coalesce(sum(clicks) FILTER (WHERE data_date BETWEEN $1::date - 55 AND $1::date - 28), 0)::float8 AS prior_clicks,
-                coalesce(sum(impressions) FILTER (WHERE data_date BETWEEN $1::date - 55 AND $1::date - 28), 0)::float8 AS prior_impressions,
-                coalesce(sum(position * impressions) FILTER (WHERE data_date BETWEEN $1::date - 27 AND $1::date) /
-                    nullif(sum(impressions) FILTER (WHERE data_date BETWEEN $1::date - 27 AND $1::date), 0), 0)::float8 AS current_position,
-                coalesce(sum(position * impressions) FILTER (WHERE data_date BETWEEN $1::date - 55 AND $1::date - 28) /
-                    nullif(sum(impressions) FILTER (WHERE data_date BETWEEN $1::date - 55 AND $1::date - 28), 0), 0)::float8 AS prior_position
+                count(*) FILTER (WHERE data_date BETWEEN $2::date AND $1::date)::int AS current_days,
+                count(*) FILTER (WHERE data_date BETWEEN $3::date AND $4::date)::int AS prior_days,
+                coalesce(sum(clicks) FILTER (WHERE data_date BETWEEN $2::date AND $1::date), 0)::float8 AS current_clicks,
+                coalesce(sum(impressions) FILTER (WHERE data_date BETWEEN $2::date AND $1::date), 0)::float8 AS current_impressions,
+                coalesce(sum(clicks) FILTER (WHERE data_date BETWEEN $3::date AND $4::date), 0)::float8 AS prior_clicks,
+                coalesce(sum(impressions) FILTER (WHERE data_date BETWEEN $3::date AND $4::date), 0)::float8 AS prior_impressions,
+                coalesce(sum(position * impressions) FILTER (WHERE data_date BETWEEN $2::date AND $1::date) /
+                    nullif(sum(impressions) FILTER (WHERE data_date BETWEEN $2::date AND $1::date), 0), 0)::float8 AS current_position,
+                coalesce(sum(position * impressions) FILTER (WHERE data_date BETWEEN $3::date AND $4::date) /
+                    nullif(sum(impressions) FILTER (WHERE data_date BETWEEN $3::date AND $4::date), 0), 0)::float8 AS prior_position
             FROM search_console_daily WHERE search_type = 'web'
-        `, [latestDate]),
-        aggregateBreakdown(db, 'query', { intent: 'semantic' }),
-        aggregateBreakdown(db, 'page'),
-        aggregateBreakdown(db, 'query', { zeroClick: true, intent: 'semantic' }),
+        `, [endDate, startDate, comparisonStartDate, comparisonEndDate]),
+        aggregateBreakdown(db, 'query', { intent: 'semantic', startDate, endDate }),
+        aggregateBreakdown(db, 'page', { startDate, endDate }),
+        aggregateBreakdown(db, 'query', { zeroClick: true, intent: 'semantic', startDate, endDate }),
         db.query(`
-            WITH latest AS (SELECT $1::date AS d)
+            WITH latest AS (SELECT $1::date AS d, $2::date AS start_date)
             SELECT value,
                    sum(clicks)::float8 AS clicks,
                    sum(impressions)::float8 AS impressions,
@@ -175,7 +180,7 @@ async function getSearchGrowthReportData(db = pool) {
                         ELSE sum(position * impressions) / sum(impressions) END::float8 AS position
             FROM search_console_breakdowns, latest
             WHERE search_type = 'web' AND dimension = 'page'
-              AND data_date BETWEEN latest.d - 27 AND latest.d
+              AND data_date BETWEEN latest.start_date AND latest.d
               AND (value ~ '/datasets/[^/?#]+' OR value ~ '/resources/[^/?#]+'
                    OR value ~ '/places/[^/?#]+' OR value ~ '/organizations/[^/?#]+'
                    OR value ~ '^https?://[^/]+/(fr/)?blog/[^/?#]+')
@@ -185,9 +190,9 @@ async function getSearchGrowthReportData(db = pool) {
                         ELSE sum(clicks) / sum(impressions) END < 0.01
             ORDER BY impressions DESC, clicks, value
             LIMIT 50
-        `, [latestDate]),
+        `, [endDate, startDate]),
         db.query(`
-            WITH latest AS (SELECT $1::date AS d)
+            WITH latest AS (SELECT $1::date AS d, $2::date AS start_date)
             SELECT query_text AS query, page_url AS page,
                    sum(clicks)::float8 AS clicks,
                    sum(impressions)::float8 AS impressions,
@@ -197,7 +202,7 @@ async function getSearchGrowthReportData(db = pool) {
                         ELSE sum(position * impressions) / sum(impressions) END::float8 AS position
             FROM search_console_query_pages, latest
             WHERE search_type = 'web'
-              AND data_date BETWEEN latest.d - 27 AND latest.d
+              AND data_date BETWEEN latest.start_date AND latest.d
               AND ${searchIntentSql('query_text')} = 'semantic'
             GROUP BY query_text, page_url
             HAVING sum(impressions) >= 5
@@ -205,11 +210,11 @@ async function getSearchGrowthReportData(db = pool) {
                AND sum(clicks) / nullif(sum(impressions), 0) < 0.01
             ORDER BY impressions DESC, clicks, query_text, page_url
             LIMIT 100
-        `, [latestDate]),
-        aggregateBreakdown(db, 'country', { limit: 15 }),
-        aggregateBreakdown(db, 'device', { limit: 10 }),
+        `, [endDate, startDate]),
+        aggregateBreakdown(db, 'country', { limit: 15, startDate, endDate }),
+        aggregateBreakdown(db, 'device', { limit: 10, startDate, endDate }),
         db.query(`
-            WITH latest AS (SELECT $1::date AS d), page_totals AS (
+            WITH latest AS (SELECT $1::date AS d, $2::date AS start_date), page_totals AS (
                 SELECT CASE
                     WHEN scb.value ~ '^https?://[^/]+/(fr/)?blog(/|[?#]|$)' THEN 'Local guides'
                     WHEN scb.value ~ '/places/[^/?#]+' THEN 'Place pages'
@@ -224,7 +229,7 @@ async function getSearchGrowthReportData(db = pool) {
                     sum(scb.position * scb.impressions)::float8 AS position_weight
                 FROM search_console_breakdowns scb, latest
                 WHERE scb.search_type = 'web' AND scb.dimension = 'page'
-                  AND scb.data_date BETWEEN latest.d - 27 AND latest.d
+                  AND scb.data_date BETWEEN latest.start_date AND latest.d
                 GROUP BY 1, scb.value
             )
             SELECT family AS value,
@@ -235,23 +240,23 @@ async function getSearchGrowthReportData(db = pool) {
                    CASE WHEN sum(impressions) = 0 THEN 0 ELSE sum(clicks) / sum(impressions) END::float8 AS ctr,
                    CASE WHEN sum(impressions) = 0 THEN 0 ELSE sum(position_weight) / sum(impressions) END::float8 AS position
             FROM page_totals GROUP BY family ORDER BY impressions DESC, clicks DESC
-        `, [latestDate]),
-        aggregateBreakdown(db, 'query', { intent: 'brand' }),
+        `, [endDate, startDate]),
+        aggregateBreakdown(db, 'query', { intent: 'brand', startDate, endDate }),
         db.query(`
             WITH reported_queries AS (
                 SELECT value, sum(clicks)::float8 AS clicks, sum(impressions)::float8 AS impressions
                 FROM search_console_breakdowns
                 WHERE search_type = 'web' AND dimension = 'query'
-                  AND data_date BETWEEN $1::date - 27 AND $1::date
+                  AND data_date BETWEEN $2::date AND $1::date
                 GROUP BY value
             )
             SELECT ${searchIntentSql('value')} AS intent, count(*)::int AS queries,
                    sum(clicks)::float8 AS clicks, sum(impressions)::float8 AS impressions,
                    coalesce(sum(clicks) / nullif(sum(impressions), 0), 0)::float8 AS ctr
             FROM reported_queries GROUP BY intent
-        `, [latestDate])
+        `, [endDate, startDate])
     ]);
-    const summary = summaryResult.rows[0];
+    const summary = summaryResult.rows[0] || {};
     summary.current_ctr = summary.current_impressions ? summary.current_clicks / summary.current_impressions : 0;
     summary.prior_ctr = summary.prior_impressions ? summary.prior_clicks / summary.prior_impressions : 0;
     const classifiedTopQueries = classifyRows(topQueries);
@@ -259,6 +264,7 @@ async function getSearchGrowthReportData(db = pool) {
     const classifiedQueryPages = classifyRows(queryPageOpportunitiesResult.rows, 'query');
     return {
         latestDate,
+        period,
         lastSyncedAt: latestResult.rows[0].last_synced_at,
         daily: dailyResult.rows,
         summary,

--- a/server/scripts/build-search-growth-report.js
+++ b/server/scripts/build-search-growth-report.js
@@ -4,6 +4,7 @@ const path = require('path');
 const pool = require('../db/pool');
 const { getSearchGrowthReportData } = require('../db/searchConsoleQueries');
 const { renderSearchGrowthReport } = require('../services/searchGrowthReport');
+const { validateReleaseAnnotations } = require('../services/searchReportPeriod');
 
 async function writeAtomically(filePath, html) {
     await fs.promises.mkdir(path.dirname(filePath), { recursive: true, mode: 0o750 });
@@ -14,9 +15,43 @@ async function writeAtomically(filePath, html) {
 
 async function main() {
     try {
-        const outputPath = process.env.GSC_REPORT_PATH;
+        const args = process.argv.slice(2);
+        const flags = ['--start', '--end', '--compare-start', '--compare-end', '--releases', '--output', '--json'];
+        const values = {};
+        for (let i = 0; i < args.length; i += 2) {
+            if (!flags.includes(args[i]) || !args[i + 1] || args[i + 1].startsWith('--')) throw new Error('Invalid report arguments');
+            values[args[i]] = args[i + 1];
+        }
+        const outputPath = values['--output'] || process.env.GSC_REPORT_PATH;
         if (!outputPath) throw new Error('GSC_REPORT_PATH is required');
-        const data = await getSearchGrowthReportData(pool);
+        const releasesPath = values['--releases'] || process.env.GSC_RELEASES_PATH;
+        const releases = releasesPath ? validateReleaseAnnotations(JSON.parse(await fs.promises.readFile(releasesPath, 'utf8'))) : [];
+        const client = await pool.connect();
+        let data;
+        try {
+            await client.query('BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY');
+            // Serialize queries on this transaction's single PostgreSQL connection.
+            let pending = Promise.resolve();
+            const db = { query: (...args) => {
+                pending = pending.then(() => client.query(...args));
+                return pending;
+            } };
+            data = await getSearchGrowthReportData(db, {
+                startDate: values['--start'], endDate: values['--end'],
+                comparisonStartDate: values['--compare-start'], comparisonEndDate: values['--compare-end']
+            });
+            await client.query('COMMIT');
+        } catch (err) {
+            await client.query('ROLLBACK');
+            throw err;
+        } finally {
+            client.release();
+        }
+        data.releases = releases;
+        if (values['--json']) {
+            // Baselines include private query text. Never silently replace one.
+            await fs.promises.writeFile(values['--json'], JSON.stringify(data, null, 2) + '\n', { mode: 0o600, flag: 'wx' });
+        }
         await writeAtomically(outputPath, renderSearchGrowthReport(data));
         console.log('wrote private search-growth report through ' + (data.latestDate || 'no data'));
     } catch (err) {

--- a/server/services/catalogText.js
+++ b/server/services/catalogText.js
@@ -1,0 +1,37 @@
+const MarkdownIt = require('markdown-it');
+
+const markdown = new MarkdownIt({ html: false, linkify: false });
+const collapse = value => String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+
+// Use Markdown's parsed text, never rendered HTML, in snippets and API summaries.
+// Link destinations and formatting disappear; their readable labels remain.
+function plainText(value) {
+    const source = String(value == null ? '' : value)
+        .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
+        .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
+        .replace(/<br\s*\/?\s*>|<\/(?:div|h[1-6]|li|p|section|td|th)>/gi, ' ')
+        .replace(/<[^>]*>/g, ' ');
+    const read = tokens => tokens.map(token => {
+        if (token.children) return read(token.children);
+        if (['text', 'code_inline', 'code_block', 'fence'].includes(token.type)) return token.content;
+        if (['softbreak', 'hardbreak'].includes(token.type) || token.block) return ' ';
+        return '';
+    }).join('');
+    return collapse(read(markdown.parse(source, {})));
+}
+
+function truncate(value, max) {
+    const text = collapse(value);
+    if (text.length <= max) return text;
+    return text.slice(0, max - 1).replace(/\s+\S*$/, '') + '…';
+}
+
+function resourceLanguages(resource) {
+    const values = Array.isArray(resource.language) ? resource.language : [resource.language];
+    const codes = values.map(value => String(value || '').toLowerCase());
+    return ['en', 'fr'].filter(lang => codes.some(code =>
+        (lang === 'en' ? /^(en(?:[-_]ca)?|eng|english)$/ : /^(fr(?:[-_]ca)?|fra|fre|french|français)$/).test(code)
+    ));
+}
+
+module.exports = { plainText, collapse, truncate, resourceLanguages };

--- a/server/services/searchGrowthReport.js
+++ b/server/services/searchGrowthReport.js
@@ -30,7 +30,7 @@ function change(current, prior, inverse = false) {
 
 function metricCard(label, current, prior, formatter = number, inverse = false) {
     return '<div class="metric"><span>' + escapeHtml(label) + '</span><strong>' +
-        escapeHtml(formatter(current)) + '</strong><small>vs prior 28 days ' +
+        escapeHtml(formatter(current)) + '</strong><small>vs comparison period ' +
         change(current, prior, inverse) + '</small></div>';
 }
 
@@ -88,7 +88,7 @@ function intentTable(rows) {
     const body = (rows || []).map(row => '<tr><td>' + escapeHtml(row.intent) + '</td><td>' +
         number(row.queries) + '</td><td>' + number(row.clicks) + '</td><td>' +
         number(row.impressions) + '</td><td>' + percent(row.ctr) + '</td></tr>').join('');
-    return '<section class="panel"><h2>Reported query intent: 28 days</h2>' +
+    return '<section class="panel"><h2>Reported query intent: selected period</h2>' +
         '<p>Counts cover distinct reported queries. Query metrics can be incomplete and do not equal property totals; query-page opportunities are a separate subset.</p>' + (body
         ? '<div class="table-wrap"><table><thead><tr><th>Intent</th><th>Queries</th><th>Clicks</th><th>Impressions</th><th>CTR</th></tr></thead><tbody>' + body + '</tbody></table></div>'
         : '<p class="empty">No query intent data yet.</p>') + '</section>';
@@ -98,6 +98,18 @@ function renderSearchGrowthReport(data, generatedAt = new Date()) {
     const stale = data.lastSyncedAt && generatedAt.getTime() - new Date(data.lastSyncedAt).getTime() > 48 * 60 * 60 * 1000;
     const status = !data.latestDate ? 'No imported data' : stale ? 'Import may be stale' : 'Import current';
     const summary = data.summary;
+    const period = data.period;
+    const periodHtml = period ? '<section class="panel"><h2>Comparison periods</h2><p>Current: ' +
+        escapeHtml(period.startDate) + ' to ' + escapeHtml(period.endDate) + '. Comparison: ' +
+        escapeHtml(period.comparisonStartDate) + ' to ' + escapeHtml(period.comparisonEndDate) +
+        ' (' + number(period.days) + ' days each).</p><p>Imported days: ' + number(summary?.current_days) +
+        ' current; ' + number(summary?.prior_days) + ' comparison. Missing days are unknown, not verified zero traffic.</p>' +
+        '<p>Property totals, page totals and reported-query metrics use different aggregation and must not be added together. ' +
+        'Reported queries omit some traffic. These comparisons are observational, not proof that a release caused a change.</p></section>' : '';
+    const releaseHtml = (data.releases || []).length ? '<section class="panel"><h2>Release annotations</h2><ul>' +
+        data.releases.map(release => '<li>' + escapeHtml(release.date) + ' — ' + escapeHtml(release.label) +
+            (period && release.date > period.endDate ? ' (after this reporting period)' : '') + '</li>').join('') + '</ul></section>' : '';
+
     const metrics = summary ? [
         metricCard('Clicks', summary.current_clicks, summary.prior_clicks),
         metricCard('Impressions', summary.current_impressions, summary.prior_impressions),
@@ -113,9 +125,9 @@ function renderSearchGrowthReport(data, generatedAt = new Date()) {
         '</style></head><body><main><h1>Search growth</h1><p class="meta">Private canquery operator report. Finalized through ' +
         escapeHtml(data.latestDate || 'none') + '. Generated ' + escapeHtml(generatedAt.toISOString()) +
         '. <span class="status">' + escapeHtml(status) + '</span></p><section class="metrics">' + metrics +
-        '</section><section class="panel"><h2>Daily clicks: last 90 finalized days</h2>' + trendSvg(data.daily || []) + '</section>' +
-        '<div class="grid">' + table('Top semantic queries: 28 days', data.topQueries || [], { valueLabel: 'Query' }) +
-        table('Top pages: 28 days', data.topPages || [], { valueLabel: 'Page' }) + '</div><div class="grid">' +
+        '</section>' + periodHtml + releaseHtml + '<section class="panel"><h2>Daily clicks: up to 90 days ending with the selected period</h2>' + trendSvg(data.daily || []) + '</section>' +
+        '<div class="grid">' + table('Top semantic queries: selected period', data.topQueries || [], { valueLabel: 'Query' }) +
+        table('Top pages: selected period', data.topPages || [], { valueLabel: 'Page' }) + '</div><div class="grid">' +
         table('Semantic zero-click opportunities', data.zeroClickQueries || [], { valueLabel: 'Query' }) +
         table('High-impression, low-CTR pages', data.pageOpportunities || [], { valueLabel: 'Page', limit: 50 }) +
         '</div>' + queryPageTable(data.queryPageOpportunities || []) + '<div class="grid">' +

--- a/server/services/searchReportPeriod.js
+++ b/server/services/searchReportPeriod.js
@@ -1,0 +1,33 @@
+const { validateDate, addDays } = require('./searchConsoleService');
+
+const daysBetween = (start, end) => Math.round((Date.parse(end) - Date.parse(start)) / 86400000) + 1;
+
+function resolveReportPeriod(latestDate, options = {}) {
+    if (!latestDate) return null;
+    const endDate = validateDate(options.endDate || latestDate, 'report end');
+    const startDate = validateDate(options.startDate || addDays(endDate, -27), 'report start');
+    const days = daysBetween(startDate, endDate);
+    if (days < 1 || days > 90) throw new Error('Report period must contain 1 to 90 days');
+    if (endDate > latestDate) throw new Error('Report end exceeds the latest imported finalized date');
+    if (Boolean(options.comparisonStartDate) !== Boolean(options.comparisonEndDate)) {
+        throw new Error('Supply both comparison dates');
+    }
+    const comparisonEndDate = validateDate(options.comparisonEndDate || addDays(startDate, -1), 'comparison end');
+    const comparisonStartDate = validateDate(options.comparisonStartDate || addDays(comparisonEndDate, 1 - days), 'comparison start');
+    if (comparisonEndDate >= startDate || daysBetween(comparisonStartDate, comparisonEndDate) !== days) {
+        throw new Error('Comparison must be an earlier, non-overlapping period of the same length');
+    }
+    return { startDate, endDate, comparisonStartDate, comparisonEndDate, days };
+}
+
+function validateReleaseAnnotations(value) {
+    if (!Array.isArray(value) || value.length > 100) throw new Error('Release annotations must be an array of at most 100 entries');
+    return value.map(entry => {
+        if (!entry || typeof entry.label !== 'string' || !entry.label.trim() || entry.label.length > 200) {
+            throw new Error('Release annotations require a label of 1 to 200 characters');
+        }
+        return { date: validateDate(entry.date, 'release date'), label: entry.label.trim() };
+    }).sort((a, b) => a.date.localeCompare(b.date));
+}
+
+module.exports = { resolveReportPeriod, validateReleaseAnnotations };

--- a/server/services/seoMeta.js
+++ b/server/services/seoMeta.js
@@ -5,6 +5,7 @@
 // injector (controllers/spaController.js) and any other caller.
 const { toAbsoluteUrl } = require('../utils/resolveUrl');
 const { classifyResource } = require('./resourceCapabilities');
+const { plainText, collapse, truncate, resourceLanguages } = require('./catalogText');
 
 const SITE_URL = (process.env.SITE_URL || 'https://canquery.com').replace(/\/+$/, '');
 const SITE_NAME = 'CanQuery';
@@ -40,64 +41,6 @@ function jsonLdScript(obj) {
     return '<script type="application/ld+json">' + json + '</script>';
 }
 
-function collapse(value) {
-    return String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
-}
-
-const HTML_ENTITIES = Object.freeze({
-    amp: '&', apos: "'", copy: '©', gt: '>', lt: '<', nbsp: ' ', quot: '"', reg: '®',
-    agrave: 'à', acirc: 'â', auml: 'ä', ccedil: 'ç', eacute: 'é', egrave: 'è',
-    ecirc: 'ê', euml: 'ë', icirc: 'î', iuml: 'ï', ocirc: 'ô', ouml: 'ö',
-    ugrave: 'ù', ucirc: 'û', uuml: 'ü', yuml: 'ÿ',
-    laquo: '«', raquo: '»', lsquo: '‘', rsquo: '’', ldquo: '“', rdquo: '”',
-    ndash: '–', mdash: '—', hellip: '…', bull: '•', middot: '·'
-});
-
-function decodeHtmlEntities(value) {
-    return String(value == null ? '' : value).replace(
-        /&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);/gi,
-        (match, entity) => {
-            if (entity[0] === '#') {
-                const hex = entity[1].toLowerCase() === 'x';
-                const codePoint = Number.parseInt(entity.slice(hex ? 2 : 1), hex ? 16 : 10);
-                const control = codePoint < 32 && ![9, 10, 13].includes(codePoint);
-                const surrogate = codePoint >= 0xd800 && codePoint <= 0xdfff;
-                if (!Number.isInteger(codePoint) || control || surrogate || codePoint > 0x10ffff) return ' ';
-                try {
-                    return String.fromCodePoint(codePoint);
-                } catch {
-                    return ' ';
-                }
-            }
-            const normalized = entity.toLowerCase();
-            if (!Object.prototype.hasOwnProperty.call(HTML_ENTITIES, normalized)) return match;
-            const decoded = HTML_ENTITIES[normalized];
-            return entity[0] === entity[0].toUpperCase() && /^[a-zà-ÿ]$/i.test(decoded)
-                ? decoded.toLocaleUpperCase('fr-CA')
-                : decoded;
-        }
-    );
-}
-
-// Catalogue descriptions sometimes contain small HTML fragments. Search
-// metadata and the crawl snapshot must use the visible text, never upstream
-// markup or script/style contents.
-function plainText(value) {
-    const withoutExecutable = String(value == null ? '' : value)
-        .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, ' ')
-        .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, ' ')
-        .replace(/<br\s*\/?\s*>/gi, ' ')
-        .replace(/<\/(?:div|h[1-6]|li|p|section|td|th)>/gi, ' ')
-        .replace(/<[^>]*>/g, ' ');
-    return collapse(decodeHtmlEntities(withoutExecutable));
-}
-
-function truncate(value, max) {
-    const s = collapse(value);
-    if (s.length <= max) return s;
-    return s.slice(0, max - 1).replace(/\s+\S*$/, '') + '…';
-}
-
 // English-default site: prefer the EN value, fall back to FR when EN is blank.
 function pick(en, fr) {
     return plainText(en) || plainText(fr) || '';
@@ -109,7 +52,7 @@ function siteTitle(value) {
 
 const GENERIC_RESOURCE_NAMES = new Set([
     'data', 'dataset', 'download', 'english', 'en', 'file', 'french', 'fr',
-    'francais', 'français', 'resource', 'csv', 'xls', 'xlsx', 'json', 'geojson',
+    'francais', 'français', 'ensembles de données', 'ensemble de données', 'resource', 'csv', 'xls', 'xlsx', 'json', 'geojson',
     'xml', 'pdf', 'zip'
 ]);
 
@@ -127,14 +70,15 @@ function titleContainsFormat(value, format) {
     return new RegExp('(^|[^a-z0-9])' + escaped + '([^a-z0-9]|$)', 'i').test(value);
 }
 
-function resourceTitleBase(resource) {
+function resourceTitleBase(resource, max = null) {
     const name = pick(resource.name_en, resource.name_fr);
     const datasetTitle = pick(resource.dataset_title_en, resource.dataset_title_fr);
     const format = collapse(resource.format).toUpperCase();
-    let base = isGenericResourceName(name, format) ? datasetTitle : name;
-    base = base || datasetTitle || 'Resource';
-    if (format && !titleContainsFormat(base, format)) base += ' (' + format + ')';
-    return base;
+    const base = (isGenericResourceName(name, format) ? datasetTitle : name) || datasetTitle || 'Resource';
+    const languages = resourceLanguages(resource).map(lang => lang === 'fr' ? 'French' : 'English');
+    const suffixParts = [...languages, format && !titleContainsFormat(base, format) ? format : ''].filter(Boolean);
+    const suffix = suffixParts.length ? ' (' + suffixParts.join(', ') + ')' : '';
+    return (max ? truncate(base, Math.max(12, max - suffix.length)) : base) + suffix;
 }
 
 function buildBreadcrumbJsonLd(items) {
@@ -454,29 +398,21 @@ function resourceDescription(resource) {
     const capability = classifyResource(resource).capability;
     const name = pick(resource.name_en, resource.name_fr);
     const datasetTitle = pick(resource.dataset_title_en, resource.dataset_title_fr);
-    const organization = pick(resource.org_title_en, resource.org_title_fr);
-    const resourceLabel = isGenericResourceName(name, resource.format) ? '' : name;
-    const subject = [resourceLabel, datasetTitle && datasetTitle !== resourceLabel
-        ? 'from ' + datasetTitle
-        : '', organization ? 'by ' + organization : ''].filter(Boolean).join(' ') ||
-        datasetTitle || name || 'This open-data resource';
-    const format = plainText(resource.format).toUpperCase();
-    const formatLabel = format ? format + ' ' : '';
-    let description;
+    const subject = (isGenericResourceName(name, resource.format) ? datasetTitle : name) || datasetTitle || 'open data';
+    const language = resourceLanguages(resource).map(lang => lang === 'fr' ? 'French' : 'English').join('/');
+    const format = [language, plainText(resource.format).toUpperCase()].filter(Boolean).join(' ');
+    const mapped = Boolean(resource.map_provider || resource.map?.available);
+    let action;
     if (capability === 'datastore' || capability === 'ingested') {
-        description = subject + '. Query, filter, chart and export this live ' + formatLabel +
-            'table on CanQuery.';
+        action = 'Query, filter, chart and export this live ' + (format ? format + ' ' : '') + 'table';
     } else if (capability === 'ingestable') {
-        description = subject + '. Load this ' + formatLabel +
-            'resource into a live table to query, filter, chart and export it.';
-    } else if (capability === 'mapped') {
-        description = subject + '. Explore it on an interactive map and access the original ' +
-            formatLabel + 'file on CanQuery.';
+        action = 'Load this ' + (format ? format + ' ' : '') + 'resource into a live table';
     } else {
-        description = subject + '. View its metadata and access the original ' + formatLabel +
-            'file from the public-sector publisher.';
+        action = 'View metadata and access the original ' + (format ? format + ' ' : '') + 'file';
     }
-    return truncate(description, DESCRIPTION_MAX);
+    // Mapping is independent of the table capability and must survive truncation.
+    if (mapped) action = 'Explore the interactive map. ' + action;
+    return truncate(action + ': ' + subject + '.', DESCRIPTION_MAX);
 }
 
 function buildResourceJsonLd(resource, description) {
@@ -516,7 +452,7 @@ function resourceMeta(resource) {
     const datasetSlug = resource.dataset_name || resource.dataset_id;
     const description = resourceDescription(resource);
     return {
-        title: siteTitle(resourceTitleBase(resource)),
+        title: resourceTitleBase(resource, TITLE_MAX - TITLE_SUFFIX.length) + TITLE_SUFFIX,
         description,
         canonical: SITE_URL + '/resources/' + encodeURIComponent(resource.id),
         ogType: 'website',


### PR DESCRIPTION
## What & why

Catalogue snippets can expose Markdown syntax or lose useful file details behind long official names. Clean readable text, preserve recorded language/format in titles, and put supported table/map/download actions before truncation.

The private Search Console report now accepts explicit equal-length comparison periods, shows imported-day coverage, supports escaped release annotations, and can save a private baseline without overwriting it. Report generation reads one consistent database snapshot.

## Checklist

- [x] `server`: lint and 592 tests pass
- [x] `client`: lint, all 137 tests, and production build pass
- [x] 22 disposable PostgreSQL/PostGIS integration checks pass
- [x] Added tests for Markdown cleanup, long multilingual snippets, period validation, report escaping, and historical-window aggregation
- [x] Existing English-default metadata conventions preserved; bilingual presentation follows separately
- [x] No secrets, credentials, or production-specific details added

## Notes

No API or schema change. Existing report invocations retain the latest finalized 28-day default. This is the first of three SEO program changes.