### PR TITLE
Clarify the positive LMIA employer-list search snippet

### DIFF
--- a/server/services/seoMeta.js
+++ b/server/services/seoMeta.js
@@ -380,9 +380,15 @@ function datasetMeta(dataset, resources) {
     const title = pick(dataset.title_en, dataset.title_fr) || 'Dataset';
     const description = datasetDescription(dataset, resources, DESCRIPTION_MAX);
     const slug = dataset.name || dataset.id;
+    // Keep the official catalogue name in the page and Dataset schema while
+    // giving this frequently searched, long-titled dataset a complete snippet.
+    const snippet = dataset.id === '90fed587-1364-4f33-a9ee-208181dc0b97' ? {
+        title: 'Positive LMIA Employer Lists (TFWP) - CanQuery',
+        description: 'Browse official positive LMIA employer lists by quarter and language, with CSV and Excel downloads from Canada’s open data portal.'
+    } : null;
     return {
-        title: siteTitle(title),
-        description,
+        title: snippet ? snippet.title : siteTitle(title),
+        description: snippet ? snippet.description : description,
         canonical: SITE_URL + '/datasets/' + encodeURIComponent(slug),
         ogType: 'website',
         jsonLd: [


### PR DESCRIPTION
## What & why

The positive-LMIA dataset title is truncated before its distinguishing acronym, and its description starts with a general definition. Give this dataset a concise employer-list title and download-focused description, selected by stable dataset ID. Preserve its canonical URL, official catalogue title, and Dataset structured data.

## Checklist

- [x] `server`: lint and existing tests pass
- [x] `client`: lint, tests, and production build pass
- [x] Existing SEO coverage and the complete release verifier pass; this copy-only change adds no mirrored assertions
- [x] English metadata follows the existing English-default search snippet; bilingual catalogue content is unchanged
- [x] No secrets or credentials added

## Notes

Validated with `npm run verify --prefix server`. No schema, worker, dependency, or application-interface changes.