### PR TITLE
Make the complete catalogue discoverable through pagination and sitemaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,4 +75,4 @@ jobs:
           cache-dependency-path: server/package-lock.json
       - run: npm ci
       - run: npm run migrate
-      - run: npx jest __tests__/spatialIntegration.test.js __tests__/searchConsoleIntegration.test.js __tests__/localSearchIntegration.test.js --runInBand
+      - run: npx jest __tests__/spatialIntegration.test.js __tests__/searchConsoleIntegration.test.js __tests__/localSearchIntegration.test.js __tests__/catalogDiscoveryIntegration.test.js --runInBand

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,7 @@ import Navbar from './components/Navbar'
 import Footer from './components/Footer'
 import HomePage from './pages/HomePage'
 import DatasetPage from './pages/DatasetPage'
+import DatasetsPage from './pages/DatasetsPage.jsx'
 import ResourcePage from './pages/ResourcePage'
 import OrganizationsPage from './pages/OrganizationsPage'
 import OrganizationPage from './pages/OrganizationPage'
@@ -23,10 +24,11 @@ const BlogPage = lazy(() => import('./pages/BlogPage.jsx'));
 const InsightsPage = lazy(() => import('./pages/InsightsPage'))
 
 function ScrollToTop() {
-  const { pathname } = useLocation()
+  const { pathname, search } = useLocation()
+  const page = new URLSearchParams(search).get('page')
   useEffect(() => {
     window.scrollTo(0, 0)
-  }, [pathname])
+  }, [pathname, page])
   return null
 }
 
@@ -55,6 +57,7 @@ export default function App() {
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/insights" element={<InsightsPage />} />
+            <Route path="/datasets" element={<DatasetsPage />} />
             <Route path="/datasets/:idOrName" element={<DatasetPage />} />
             <Route path="/resources/:id" element={<ResourcePage />} />
             <Route path="/organizations" element={<OrganizationsPage />} />

--- a/client/src/api/catalog.js
+++ b/client/src/api/catalog.js
@@ -28,8 +28,8 @@ export function fetchJob(id) {
   return getJSON('/api/v1/jobs/' + encodeURIComponent(id));
 }
 
-export function fetchOrganizations({ place, source, limit, cursor } = {}) {
-  return getJSON('/api/v1/organizations', { place, source, limit, cursor });
+export function fetchOrganizations({ q, place, source, limit, cursor } = {}) {
+  return getJSON('/api/v1/organizations', { q, place, source, limit, cursor });
 }
 
 export function fetchOrganization(name) {

--- a/client/src/components/CatalogPagination.jsx
+++ b/client/src/components/CatalogPagination.jsx
@@ -1,0 +1,20 @@
+import { Link } from 'react-router-dom';
+import { useLang } from '../i18n.jsx';
+import { pagePath } from '../utils/catalogPagination.js';
+
+export default function CatalogPagination({ page, hasMore, path, onPage, loading = false }) {
+  const { t } = useLang();
+  if (!page || (page === 1 && !hasMore)) return null;
+  const control = (number, label, key = label) => onPage ? (
+    <button key={key} type="button" className="btn btn-outline btn-sm" disabled={loading} onClick={() => onPage(number)}>{label}</button>
+  ) : <Link key={key} className="btn btn-outline btn-sm" to={pagePath(path, number)}>{label}</Link>;
+  return <nav aria-label={t('pagination.label')} className="flex flex-wrap items-center justify-center gap-2 mt-6">
+    {page > 1 && control(page - 1, t('pagination.previous'))}
+    {page > 2 && control(1, '1')}
+    {page > 3 && <span aria-hidden="true">…</span>}
+    {page > 1 && control(page - 1, String(page - 1), 'previous-number')}
+    <span aria-current="page" className="cq-chip cq-chip-mono">{t('pagination.page')} {page}</span>
+    {hasMore && control(page + 1, String(page + 1), 'next-number')}
+    {hasMore && control(page + 1, t('pagination.next'))}
+  </nav>;
+}

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -33,6 +33,9 @@ export default function Navbar() {
           <NavLink to="/" end className={navClass}>
             {t('nav.datasets')}
           </NavLink>
+          <NavLink to="/datasets" className={navClass}>
+            {t('nav.browse')}
+          </NavLink>
           <NavLink to="/insights" className={navClass}>
             <SparklesIcon size={13} className="text-secondary" />
             {t('nav.insights')}

--- a/client/src/components/RouteHead.jsx
+++ b/client/src/components/RouteHead.jsx
@@ -3,21 +3,26 @@ import { useLocation } from 'react-router-dom';
 import { clearRouteHead, readSeoElements, replaceSeoHead } from '../utils/routeHead.js';
 
 export default function RouteHead() {
-  const { pathname } = useLocation();
-  const previousPath = useRef(pathname);
+  const { pathname, search } = useLocation();
+  const params = new URLSearchParams();
+  if (/^\/(datasets|organizations|places)(?:\/|$)/.test(pathname)) {
+    for (const value of new URLSearchParams(search).getAll('page')) params.append('page', value);
+  }
+  const target = pathname + (params.size ? '?' + params.toString() : '');
+  const previousPath = useRef(target);
   const siteOrigin = useRef(new URL(
     document.querySelector('link[rel="canonical"]')?.href || window.location.href
   ).origin);
 
   useEffect(() => {
     // The initial response already contains the authoritative server head.
-    if (previousPath.current === pathname) return;
-    previousPath.current = pathname;
+    if (previousPath.current === target) return;
+    previousPath.current = target;
     const controller = new AbortController();
     let disposed = false;
     const timeout = setTimeout(() => controller.abort(), 10000);
 
-    fetch(pathname, {
+    fetch(target, {
       signal: controller.signal,
       credentials: 'same-origin',
       headers: { Accept: 'text/html' },
@@ -32,7 +37,7 @@ export default function RouteHead() {
         if (!disposed && !controller.signal.aborted) replaceSeoHead(elements);
       })
       .catch(() => {
-        if (!disposed) clearRouteHead(pathname, siteOrigin.current);
+        if (!disposed) clearRouteHead(target, siteOrigin.current);
       })
       .finally(() => clearTimeout(timeout));
 
@@ -41,7 +46,7 @@ export default function RouteHead() {
       clearTimeout(timeout);
       controller.abort();
     };
-  }, [pathname]);
+  }, [target]);
 
   return null;
 }

--- a/client/src/components/RouteHead.test.jsx
+++ b/client/src/components/RouteHead.test.jsx
@@ -22,6 +22,7 @@ function Navigation() {
   return <><RouteHead />
     <Link to="/datasets/roads">Dataset</Link>
     <Link to="/resources/r1">Resource</Link>
+    <Link to="/datasets/roads?page=2">Second page</Link>
     <Link to="/resources/r1?sort=name#table">Sort</Link>
     <button onClick={() => navigate(-1)}>Back</button>
   </>;
@@ -109,4 +110,16 @@ test('preserves translated alternates while replacing the canonical on client na
   await waitFor(() => expect(document.title).toBe('Road guide'));
   expect(document.querySelectorAll('link[rel=canonical]')).toHaveLength(1);
   expect(document.querySelector('link[hreflang="fr-CA"]').href).toBe('https://canquery.com/fr/blog/routes');
+});
+
+
+test('updates pagination canonicals on the same pathname and restores them on Back', async () => {
+  start();
+  fireEvent.click(screen.getByText('Dataset'));
+  await waitFor(() => expect(document.title).toBe('Roads'));
+  fireEvent.click(screen.getByText('Second page'));
+  await waitFor(() => expect(document.querySelector('link[rel=canonical]').href).toBe('https://canquery.com/datasets/roads?page=2'));
+  expect(fetch).toHaveBeenLastCalledWith('/datasets/roads?page=2', expect.anything());
+  fireEvent.click(screen.getByText('Back'));
+  await waitFor(() => expect(document.querySelector('link[rel=canonical]').href).toBe('https://canquery.com/datasets/roads'));
 });

--- a/client/src/hooks/useCatalogPage.js
+++ b/client/src/hooks/useCatalogPage.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useLocation, useSearchParams } from 'react-router-dom';
+import { pageNumber, PAGE_SIZE } from '../utils/catalogPagination.js';
+
+// Unfiltered catalogue pages have durable URLs. Search controls keep their
+// existing local state and use buttons, so filters do not create crawl paths.
+export default function useCatalogPage(fetchPage, deps, filtered = false) {
+  const { pathname } = useLocation();
+  const [params, setParams] = useSearchParams();
+  const filterKey = JSON.stringify([pathname, ...deps]);
+  const [selection, setSelection] = useState({ key: null, page: 1 });
+  const page = filtered ? (selection.key === filterKey ? selection.page : 1) : pageNumber(params);
+  const [state, setState] = useState({ key: null, items: [], loading: true, error: null, meta: null, hasMore: false });
+  const requestKey = JSON.stringify([filterKey, page]);
+
+  useEffect(() => {
+    if (!filtered && params.getAll('page').length === 1 && params.get('page') === '1') {
+      const next = new URLSearchParams(params);
+      next.delete('page');
+      setParams(next, { replace: true });
+    }
+  }, [filtered, params, setParams]);
+
+  useEffect(() => {
+    if (selection.key !== filterKey) setSelection({ key: filterKey, page: 1 });
+  }, [filterKey, selection.key]);
+
+  useEffect(() => {
+    if (page === null) return;
+    let cancelled = false;
+    Promise.resolve().then(() => cancelled ? null : fetchPage(String((page - 1) * PAGE_SIZE)))
+      .then(env => {
+        if (!cancelled) setState({ key: requestKey, items: env.data || [], loading: false, error: null,
+          meta: env.meta || null, hasMore: Boolean(env.pagination?.nextCursor) });
+      })
+      .catch(error => {
+        if (!cancelled) setState({ key: requestKey, items: [], loading: false, error, meta: null, hasMore: false });
+      });
+    return () => { cancelled = true; };
+    // fetchPage closes over exactly the criteria supplied in deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requestKey]);
+
+  const current = state.key === requestKey ? state : { items: [], loading: page !== null, error: null, meta: null, hasMore: false };
+  return { ...current, page, path: pathname,
+    notFound: page === null || (!current.loading && !current.error && page > 1 && current.items.length === 0),
+    onPage: filtered ? number => setSelection({ key: filterKey, page: number }) : undefined };
+}

--- a/client/src/i18n.jsx
+++ b/client/src/i18n.jsx
@@ -6,6 +6,15 @@ import { createContext, useContext, useState, useCallback, useEffect } from 'rea
 // including the API docs prose (code samples and field names stay literal).
 export const STRINGS = {
   en: {
+    'nav.browse': 'Browse catalogue',
+    'catalogue.title': 'Browse all Canadian datasets',
+    'catalogue.description': 'Explore the complete catalogue, including downloadable files, live tables and maps.',
+    'pagination.label': 'Catalogue pages',
+    'pagination.previous': 'Previous',
+    'pagination.next': 'Next',
+    'pagination.page': 'Page',
+    'dataset.keyword_search': 'Find datasets tagged',
+
     "preview.title": "Data overview",
     "preview.formats": "Formats",
     "preview.languages": "File languages",
@@ -322,6 +331,15 @@ export const STRINGS = {
     'docs.ep_ops': 'Background-job health for uptime monitors: catalogue jobs plus local-map queue counts, failures and oldest pending/running work. Job status is pending, ok, stale or failed; the latest failed catalogue attempt returns 503 immediately without exposing its raw error. Expected cap skips remain visible without alarming.',
   },
   fr: {
+    'nav.browse': 'Catalogue',
+    'catalogue.title': 'Parcourir tous les jeux de données canadiens',
+    'catalogue.description': 'Explorez le catalogue complet : fichiers à télécharger, tableaux interactifs et cartes.',
+    'pagination.label': 'Pages du catalogue',
+    'pagination.previous': 'Précédente',
+    'pagination.next': 'Suivante',
+    'pagination.page': 'Page',
+    'dataset.keyword_search': 'Rechercher les jeux de données portant le mot-clé',
+
     "preview.title": "Aperçu des données",
     "preview.formats": "Formats",
     "preview.languages": "Langues des fichiers",

--- a/client/src/pages/CataloguePagination.test.jsx
+++ b/client/src/pages/CataloguePagination.test.jsx
@@ -1,0 +1,92 @@
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
+import { beforeEach, expect, test, vi } from 'vitest';
+import DatasetsPage from './DatasetsPage.jsx';
+import OrganizationsPage from './OrganizationsPage.jsx';
+import { LangProvider } from '../i18n.jsx';
+
+vi.mock('../api/catalog.js', () => ({ searchDatasets: vi.fn(), fetchOrganizations: vi.fn() }));
+import { searchDatasets, fetchOrganizations } from '../api/catalog.js';
+
+const row = n => ({ id: 'd' + n, name: 'dataset-' + n, title: { en: 'Dataset ' + n, fr: 'Données ' + n },
+  resource_count: 1, queryable_count: 0, mappable_count: 0, places: [] });
+function Location() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  return <><output data-testid="location">{location.pathname + location.search}</output><button onClick={() => navigate(-1)}>Back</button></>;
+}
+function start(element, path = '/datasets', language = 'en') {
+  localStorage.setItem('cq-lang', language);
+  return render(<LangProvider><MemoryRouter initialEntries={[path]}><Location />{element}</MemoryRouter></LangProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  searchDatasets.mockImplementation(async ({ cursor }) => {
+    const offset = Number(cursor);
+    return { data: offset < 100 ? [row(offset + 1)] : [], pagination: { nextCursor: offset === 0 ? '50' : null } };
+  });
+});
+
+test('page links, direct URLs and Back select the same catalogue slice', async () => {
+  start(<DatasetsPage />);
+  expect(await screen.findByText('Dataset 1')).toBeInTheDocument();
+  const next = screen.getByRole('link', { name: 'Next' });
+  expect(next).toHaveAttribute('href', '/datasets?page=2');
+  fireEvent.click(next);
+  expect(await screen.findByText('Dataset 51')).toBeInTheDocument();
+  expect(screen.queryByText('Dataset 1')).not.toBeInTheDocument();
+  expect(searchDatasets).toHaveBeenLastCalledWith({ cursor: '50', limit: 50 });
+  expect(screen.getByTestId('location')).toHaveTextContent('/datasets?page=2');
+  fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+  expect(await screen.findByText('Dataset 1')).toBeInTheDocument();
+  expect(screen.queryByText('Dataset 51')).not.toBeInTheDocument();
+});
+
+test('opens page two directly with localized pagination', async () => {
+  start(<DatasetsPage />, '/datasets?page=2', 'fr');
+  expect(await screen.findByText('Données 51')).toBeInTheDocument();
+  const pager = screen.getByRole('navigation', { name: 'Pages du catalogue' });
+  expect(within(pager).getByRole('link', { name: 'Précédente' })).toHaveAttribute('href', '/datasets');
+  expect(within(pager).getByText('Page 2')).toHaveAttribute('aria-current', 'page');
+});
+
+test.each(['0', '01', '-1', '2&page=3'])('rejects invalid page %s without an API request', async page => {
+  start(<DatasetsPage />, '/datasets?page=' + page);
+  expect(screen.getByRole('heading', { name: 'Page not found' })).toBeInTheDocument();
+  expect(searchDatasets).not.toHaveBeenCalled();
+});
+
+test('an out-of-range page displays a missing-page state, not an empty successful listing', async () => {
+  start(<DatasetsPage />, '/datasets?page=3');
+  expect(await screen.findByRole('heading', { name: 'Page not found' })).toBeInTheDocument();
+  expect(screen.queryByRole('navigation', { name: 'Catalogue pages' })).not.toBeInTheDocument();
+});
+
+test('a late previous-page response cannot overwrite the selected page', async () => {
+  let finishOld;
+  searchDatasets.mockImplementationOnce(() => new Promise(resolve => { finishOld = resolve; }));
+  start(<DatasetsPage />, '/datasets?page=2');
+  await waitFor(() => expect(searchDatasets).toHaveBeenCalledWith({ cursor: '50', limit: 50 }));
+  fireEvent.click(screen.getByRole('link', { name: 'Previous' }));
+  expect(await screen.findByText('Dataset 1')).toBeInTheDocument();
+  await act(async () => finishOld({ data: [row(51)], pagination: { nextCursor: null } }));
+  expect(screen.queryByText('Dataset 51')).not.toBeInTheDocument();
+});
+
+test('publisher filtering searches beyond the current page and uses buttons for filtered pagination', async () => {
+  fetchOrganizations.mockImplementation(async ({ q, cursor }) => ({
+    data: [{ id: 'o', name: 'publisher', title: { en: q ? 'Remote publisher ' + cursor : 'Local publisher' }, dataset_count: 1 }],
+    pagination: { nextCursor: q && cursor === '0' ? '50' : null }
+  }));
+  start(<OrganizationsPage />, '/organizations?page=2');
+  expect(await screen.findByText('Local publisher')).toBeInTheDocument();
+  fireEvent.change(screen.getByRole('textbox'), { target: { value: 'remote' } });
+  expect(await screen.findByText('Remote publisher 0')).toBeInTheDocument();
+  expect(fetchOrganizations).toHaveBeenLastCalledWith(expect.objectContaining({ q: 'remote', cursor: '0', limit: 50 }));
+  expect(screen.queryByRole('link', { name: 'Next' })).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+  await waitFor(() => expect(fetchOrganizations).toHaveBeenLastCalledWith(expect.objectContaining({ q: 'remote', cursor: '50' })));
+  expect(await screen.findByText('Remote publisher 50')).toBeInTheDocument();
+});

--- a/client/src/pages/DatasetPage.jsx
+++ b/client/src/pages/DatasetPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useParams, Link, useSearchParams } from 'react-router-dom';
+import { useParams, Link, useSearchParams, useNavigate } from 'react-router-dom';
 import { fetchDataset, enqueueIngest } from '../api/catalog.js';
 import { NotFoundError } from '../api/client.js';
 import useJobPolling from '../hooks/useJobPolling.js';
@@ -7,6 +7,8 @@ import useElapsed from '../hooks/useElapsed.js';
 import { formatDuration } from '../utils/time.js';
 import { readUnlockJob, writeUnlockJob, clearUnlockJob } from '../utils/unlockStore.js';
 import { track } from '../utils/analytics.js';
+import CatalogPagination from '../components/CatalogPagination.jsx';
+import { PAGE_SIZE, pageNumber } from '../utils/catalogPagination.js';
 import ResourceBadge from '../components/ResourceBadge.jsx';
 import LoadingSpinner from '../components/LoadingSpinner.jsx';
 import Provenance from '../components/Provenance.jsx';
@@ -34,7 +36,6 @@ const FMT_STYLES = {
   XML: { color: '#c4b5fd', background: 'rgba(167,139,250,0.13)' },
 };
 const FMT_FALLBACK = { color: '#9aa7bd', background: 'rgba(154,167,189,0.12)' };
-const INITIAL_RESOURCE_COUNT = 12;
 
 function FormatTile({ format }) {
   const style = FMT_STYLES[format] || FMT_FALLBACK;
@@ -84,7 +85,8 @@ function DatasetExplorer({ idOrName }) {
   const [unlockJobs, setUnlockJobs] = useState({});
   const [refreshKey, setRefreshKey] = useState(0);
   const [highlightId, setHighlightId] = useState(null);
-  const [showAllResources, setShowAllResources] = useState(false);
+  const navigate = useNavigate();
+  const page = pageNumber(searchParams);
   const handledHighlightRef = useRef(null);
   const openedRef = useRef(false);
 
@@ -137,11 +139,15 @@ function DatasetExplorer({ idOrName }) {
   // one to open, then drop the param so a refresh doesn't re-trigger it.
   useEffect(() => {
     const focusId = searchParams.get('highlight');
-    if (!focusId || !dataset) return;
+    if (!focusId || !dataset || page === null) return;
     if (handledHighlightRef.current === focusId) return;
     const resourceIndex = (dataset.resources || []).findIndex(resource => resource.id === focusId);
-    if (resourceIndex >= INITIAL_RESOURCE_COUNT && !showAllResources) {
-      setShowAllResources(true);
+    const targetPage = Math.floor(resourceIndex / PAGE_SIZE) + 1;
+    if (resourceIndex >= 0 && targetPage !== page) {
+      const next = new URLSearchParams(searchParams);
+      if (targetPage > 1) next.set('page', String(targetPage));
+      else next.delete('page');
+      setSearchParams(next, { replace: true });
       return;
     }
     const el = document.getElementById('res-' + focusId);
@@ -153,7 +159,7 @@ function DatasetExplorer({ idOrName }) {
     const next = new URLSearchParams(searchParams);
     next.delete('highlight');
     setSearchParams(next, { replace: true });
-  }, [dataset, searchParams, setSearchParams, showAllResources]);
+  }, [dataset, searchParams, setSearchParams, page]);
 
   // The un-highlight timer lives on highlightId, not in the effect above:
   // dropping the param re-runs that effect, and a cleanup there would cancel
@@ -164,7 +170,15 @@ function DatasetExplorer({ idOrName }) {
     return () => clearTimeout(timer);
   }, [highlightId]);
 
-  if (notFound) {
+  useEffect(() => {
+    if (searchParams.getAll('page').length === 1 && searchParams.get('page') === '1') {
+      const next = new URLSearchParams(searchParams);
+      next.delete('page');
+      setSearchParams(next, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
+
+  if (notFound || page === null || (dataset && page > 1 && (page - 1) * PAGE_SIZE >= dataset.resources.length)) {
     return (
       <div className="text-center py-28 space-y-3 cq-fade">
         <h1 className="text-2xl font-bold font-display">{t('common.dataset_not_found')}</h1>
@@ -187,16 +201,14 @@ function DatasetExplorer({ idOrName }) {
 
   const handleUnlockDone = () => setRefreshKey(k => k + 1);
   const queryable = (mode) => mode === 'datastore' || mode === 'ingested';
-  const visibleResources = showAllResources
-    ? dataset.resources
-    : dataset.resources.slice(0, INITIAL_RESOURCE_COUNT);
+  const visibleResources = dataset.resources.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-8 space-y-4 cq-fade">
       <Breadcrumbs
         label={t('breadcrumbs.label')}
         items={[
-          { label: t('nav.datasets'), to: '/' },
+          { label: t('nav.datasets'), to: '/datasets' },
           { label: pick(dataset.title) || dataset.name || dataset.id }
         ]}
       />
@@ -265,17 +277,18 @@ function DatasetExplorer({ idOrName }) {
 
       <div className="flex flex-wrap gap-1.5">
         {(contentLang === 'fr' ? dataset.keywords?.fr : dataset.keywords?.en)?.map(kw => (
-          <Link
+          <button
+            type="button"
             key={kw}
-            to={'/?keyword=' + encodeURIComponent(kw)}
+            onClick={() => navigate('/?keyword=' + encodeURIComponent(kw))}
             className="cq-pill !text-xs !font-medium"
-            title={'Find every dataset tagged ' + kw}
+            title={t('dataset.keyword_search') + ' ' + kw}
             data-analytics-event="catalog_search"
             data-analytics-query={kw}
             data-analytics-source="dataset_keyword"
           >
             {kw}
-          </Link>
+          </button>
         ))}
       </div>
 
@@ -294,9 +307,9 @@ function DatasetExplorer({ idOrName }) {
           >
             <FormatTile format={resource.format} />
             <div className="flex-1 min-w-48">
-              <div className="font-medium text-[0.92rem] leading-snug">
+              <Link to={'/resources/' + resource.id} className="font-medium text-[0.92rem] leading-snug hover:underline">
                 {resource.presentation?.title?.[contentLang] || pick(resource.name) || resource.format || resource.id}
-              </div>
+              </Link>
               <div className="text-xs text-base-content/40 mt-0.5 font-mono">
                 {resource.format}
                 {resource.size_bytes ? ' · ' + Math.round(resource.size_bytes / 1024) + ' KB' : ''}
@@ -408,21 +421,7 @@ function DatasetExplorer({ idOrName }) {
           </div>
         ))}
       </div>
-      {dataset.resources.length > INITIAL_RESOURCE_COUNT && (
-        <div className="text-center pt-1">
-          <button
-            className="btn btn-sm btn-outline rounded-full border-base-content/20 px-6"
-            onClick={() => setShowAllResources(value => !value)}
-            aria-expanded={showAllResources}
-            data-analytics-event="resource_view"
-            data-analytics-dataset-id={dataset.id}
-            data-analytics-view={showAllResources ? 'fewer_resources' : 'all_resources'}
-          >
-            {showAllResources ? t('dataset.show_fewer_resources') : t('dataset.show_all_resources')}
-            <span className="cq-chip cq-chip-mono ml-1">{dataset.resources.length}</span>
-          </button>
-        </div>
-      )}
+      <CatalogPagination page={page} hasMore={page * PAGE_SIZE < dataset.resources.length} path={'/datasets/' + encodeURIComponent(dataset.name || dataset.id)} />
       <LocalGuides dataset={dataset.id} />
     </div>
   );

--- a/client/src/pages/DatasetPage.test.jsx
+++ b/client/src/pages/DatasetPage.test.jsx
@@ -81,13 +81,13 @@ describe('DatasetPage ingestion', () => {
     );
 
     const breadcrumb = await screen.findByRole('navigation', { name: ariaLabel });
-    expect(within(breadcrumb).getByRole('link', { name: rootLabel })).toHaveAttribute('href', '/');
+    expect(within(breadcrumb).getByRole('link', { name: rootLabel })).toHaveAttribute('href', '/datasets');
     expect(within(breadcrumb).getByText(currentLabel)).toHaveAttribute('aria-current', 'page');
   });
 
-  test('collapses long resource lists and expands a hidden deep-link target before focusing it', async () => {
+  test('opens the correct resource page for a highlight and keeps every file reachable', async () => {
     const env = datasetEnvelope('datastore');
-    env.data.resources = Array.from({ length: 15 }, (_, index) => ({
+    env.data.resources = Array.from({ length: 55 }, (_, index) => ({
       ...env.data.resources[0],
       id: 'resource-' + (index + 1),
       name: { en: 'Resource ' + (index + 1), fr: null },
@@ -96,16 +96,18 @@ describe('DatasetPage ingestion', () => {
     fetchDataset.mockResolvedValue(env);
 
     render(
-      <MemoryRouter initialEntries={['/datasets/dataset-a?highlight=resource-15']}>
+      <MemoryRouter initialEntries={['/datasets/dataset-a?highlight=resource-55']}>
         <Routes><Route path="/datasets/:idOrName" element={<DatasetPage />} /></Routes>
       </MemoryRouter>
     );
 
-    expect(await screen.findByText('Resource 15')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Show fewer resources/i })).toHaveAttribute('aria-expanded', 'true');
-    fireEvent.click(screen.getByRole('button', { name: /Show fewer resources/i }));
-    expect(screen.queryByText('Resource 15')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Show all resources/i })).toHaveAttribute('aria-expanded', 'false');
+    expect(await screen.findByText('Resource 55')).toBeInTheDocument();
+    expect(screen.getByText('Page 2')).toHaveAttribute('aria-current', 'page');
+    expect(screen.getByRole('link', { name: 'Resource 55' })).toHaveAttribute('href', '/resources/resource-55');
+    fireEvent.click(screen.getByRole('link', { name: 'Previous' }));
+    expect(await screen.findByText('Resource 1')).toBeInTheDocument();
+    expect(screen.queryByText('Resource 55')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Next' })).toHaveAttribute('href', '/datasets/dataset-a?page=2');
   });
 
   test('offers the map before a spatial snapshot has been loaded', async () => {
@@ -172,4 +174,22 @@ describe('DatasetPage ingestion', () => {
     await act(async () => { resolveDatasetB(datasetEnvelope('ingestable', 'b')); });
     expect(await screen.findByRole('heading', { name: 'Dataset B' })).toBeInTheDocument();
   });
+});
+
+
+test('links download-only files and keeps keyword search as an action', async () => {
+  const env = datasetEnvelope('file-only');
+  env.data.resources[0].format = 'PDF';
+  env.data.keywords.en = ['waiting times'];
+  fetchDataset.mockReset();
+  fetchDataset.mockResolvedValue(env);
+  render(<MemoryRouter initialEntries={['/datasets/dataset-a']}><Routes>
+    <Route path="/datasets/:idOrName" element={<DatasetPage />} />
+    <Route path="/" element={<p>Filtered search</p>} />
+  </Routes></MemoryRouter>);
+  expect(await screen.findByRole('link', { name: 'Resource A' })).toHaveAttribute('href', '/resources/resource-a');
+  expect(screen.queryByRole('link', { name: 'waiting times' })).not.toBeInTheDocument();
+  fireEvent.click(screen.getByRole('button', { name: 'waiting times' }));
+  expect(await screen.findByText('Filtered search')).toBeInTheDocument();
+  expect(enqueueIngest).not.toHaveBeenCalled();
 });

--- a/client/src/pages/DatasetsPage.jsx
+++ b/client/src/pages/DatasetsPage.jsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+import { searchDatasets } from '../api/catalog.js';
+import useCatalogPage from '../hooks/useCatalogPage.js';
+import { PAGE_SIZE } from '../utils/catalogPagination.js';
+import CatalogPagination from '../components/CatalogPagination.jsx';
+import DatasetRow from '../components/DatasetRow.jsx';
+import LoadingSpinner from '../components/LoadingSpinner.jsx';
+import { useLang } from '../i18n.jsx';
+
+export default function DatasetsPage() {
+  const { t } = useLang();
+  const collection = useCatalogPage(cursor => searchDatasets({ limit: PAGE_SIZE, cursor }), []);
+  return <div className="max-w-6xl mx-auto px-4 py-8 space-y-5">
+    <h1 className="text-3xl font-bold font-display">{collection.notFound ? t('common.not_found') : t('catalogue.title')}</h1>
+    <p className="text-base-content/65">{t('catalogue.description')}</p>
+    <div className="flex flex-wrap gap-4">
+      <Link to="/" className="link">{t('common.back_search')}</Link>
+      <Link to="/organizations" className="link">{t('nav.organizations')}</Link>
+      <Link to="/places" className="link">{t('nav.places')}</Link>
+    </div>
+    {collection.loading ? <LoadingSpinner /> : collection.error ? <div className="alert alert-error">{collection.error.message}</div> :
+      !collection.notFound && <section className="space-y-3" aria-label={t('orgs.dataset_list')}>
+        {collection.items.map(dataset => <DatasetRow key={dataset.id} dataset={dataset} />)}
+      </section>}
+    {!collection.error && !collection.notFound && <CatalogPagination {...collection} />}
+  </div>;
+}

--- a/client/src/pages/OrganizationPage.jsx
+++ b/client/src/pages/OrganizationPage.jsx
@@ -3,7 +3,9 @@ import { Link, useParams } from 'react-router-dom';
 import { fetchOrganization, searchDatasets } from '../api/catalog.js';
 import { NotFoundError } from '../api/client.js';
 import useDebouncedValue from '../hooks/useDebouncedValue.js';
-import usePaginatedCollection from '../hooks/usePaginatedCollection.js';
+import useCatalogPage from '../hooks/useCatalogPage.js';
+import CatalogPagination from '../components/CatalogPagination.jsx';
+import { PAGE_SIZE } from '../utils/catalogPagination.js';
 import { track } from '../utils/analytics.js';
 import { useLang } from '../i18n.jsx';
 import SearchBar from '../components/SearchBar.jsx';
@@ -55,18 +57,20 @@ export default function OrganizationPage() {
     }
   }, [debouncedQuery, name]);
 
-  const { items, loading, loadingMore, error: searchError, hasMore, loadMore } = usePaginatedCollection(
+  const collection = useCatalogPage(
     cursor => searchDatasets({
       q: debouncedQuery || undefined,
       org: name,
       mappable: mappable || undefined,
-      limit: 20,
+      limit: PAGE_SIZE,
       cursor,
     }),
-    [name, debouncedQuery, mappable]
+    [name, debouncedQuery, mappable],
+    Boolean(debouncedQuery || mappable)
   );
+  const { items, loading, error: searchError } = collection;
 
-  if (notFound) {
+  if (notFound || collection.notFound) {
     return <div className="text-center py-28"><h1 className="text-2xl font-bold font-display">{t('common.organization_not_found')}</h1></div>;
   }
   if (error) return <div className="max-w-5xl mx-auto px-4 py-8"><div className="alert alert-error">{error.message}</div></div>;
@@ -128,20 +132,7 @@ export default function OrganizationPage() {
             items.length === 0 ? <div className="text-center py-14 text-base-content/50">{t('orgs.no_datasets')}</div> :
               items.map(dataset => <DatasetRow key={dataset.id} dataset={dataset} />)}
       </section>
-      {hasMore && (
-        <div className="text-center mt-6">
-          <button
-            className="btn btn-outline btn-sm rounded-full px-7"
-            onClick={() => {
-              track('catalog_filter', { action: 'load_more', organization: name });
-              loadMore();
-            }}
-            disabled={loadingMore}
-          >
-            {loadingMore ? t('home.loading') : t('home.load_more')}
-          </button>
-        </div>
-      )}
+      {!searchError && !collection.notFound && <CatalogPagination {...collection} />}
     </div>
   );
 }

--- a/client/src/pages/OrganizationPage.test.jsx
+++ b/client/src/pages/OrganizationPage.test.jsx
@@ -46,7 +46,7 @@ describe('OrganizationPage', () => {
     expect(screen.getByText('8 mappable')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Example' })).toHaveAttribute('href', '/places/example-on');
     expect(await screen.findByText('Road network')).toBeInTheDocument();
-    expect(searchDatasets).toHaveBeenCalledWith(expect.objectContaining({ org: 'city-works', limit: 20 }));
+    expect(searchDatasets).toHaveBeenCalledWith(expect.objectContaining({ org: 'city-works', limit: 50 }));
 
     fireEvent.click(screen.getByRole('button', { name: 'Has a map' }));
     await waitFor(() => expect(searchDatasets).toHaveBeenLastCalledWith(expect.objectContaining({

--- a/client/src/pages/OrganizationsPage.jsx
+++ b/client/src/pages/OrganizationsPage.jsx
@@ -1,20 +1,22 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import usePaginatedCollection from '../hooks/usePaginatedCollection';
+import useCatalogPage from '../hooks/useCatalogPage';
+import CatalogPagination from '../components/CatalogPagination.jsx';
+import { PAGE_SIZE } from '../utils/catalogPagination.js';
 import { fetchOrganizations } from '../api/catalog';
 import { useLang } from '../i18n.jsx';
 import { SearchIcon } from '../components/Icons.jsx';
 import useDebouncedValue from '../hooks/useDebouncedValue.js';
 import { track } from '../utils/analytics.js';
 
-function OrgCard({ org, t }) {
-  const title = org.title.en || org.name;
+function OrgCard({ org, t, lang }) {
+  const title = org.title?.[lang] || org.title?.en || org.title?.fr || org.name;
   return (
     <Link
       key={org.id}
       to={'/organizations/' + encodeURIComponent(org.name)}
       title={'See every dataset from ' + title}
-      className="cq-card p-4 flex items-center gap-3.5 group"
+      className="cq-card p-4 grid grid-cols-[2.5rem_minmax(0,1fr)] items-center gap-x-3.5 gap-y-2 lg:flex lg:gap-3.5 group"
       data-analytics-event="organization_open"
       data-analytics-organization={org.name}
       data-analytics-dataset-count={org.dataset_count}
@@ -29,7 +31,7 @@ function OrgCard({ org, t }) {
         </div>
         <div className="text-xs text-base-content/35 font-mono truncate mt-0.5">{org.name}</div>
       </div>
-      <span className="cq-chip cq-chip-mono shrink-0">
+      <span className="cq-chip cq-chip-mono shrink-0 col-start-2 justify-self-start">
         {org.dataset_count} {t('orgs.datasets')}
       </span>
     </Link>
@@ -37,37 +39,35 @@ function OrgCard({ org, t }) {
 }
 
 export default function OrganizationsPage() {
-  const { t } = useLang();
+  const { t, lang } = useLang();
   const [filter, setFilter] = useState('');
   const debouncedFilter = useDebouncedValue(filter, 250);
-  const { items, loading, loadingMore, error, hasMore, loadMore } = usePaginatedCollection(
-    (cursor) => fetchOrganizations({ limit: 100, cursor }),
-    []
+  const collection = useCatalogPage(
+    cursor => fetchOrganizations({ q: debouncedFilter || undefined, limit: PAGE_SIZE, cursor }),
+    [debouncedFilter], Boolean(debouncedFilter)
   );
+  const { items, loading, error } = collection;
 
   useEffect(() => {
     if (debouncedFilter) track('catalog_filter', { filter: 'organization_search', value: debouncedFilter });
   }, [debouncedFilter]);
 
-  const visible = items.filter(o =>
-    !filter || (o.title.en || o.name).toLowerCase().includes(filter.toLowerCase())
-  );
-
   return (
     <div className="max-w-6xl mx-auto px-4 py-8 cq-fade">
       <h1 className="text-3xl font-bold font-display tracking-tight pb-6">
-        {t('nav.organizations')}
+        {collection.notFound ? t('common.not_found') : t('nav.organizations')}
       </h1>
       <div className="cq-search cq-search-sm w-full max-w-md">
         <SearchIcon size={14} className="opacity-40 shrink-0" />
         <input
           placeholder={t('orgs.filter_placeholder')}
+          aria-label={t('orgs.filter_placeholder')}
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
         />
       </div>
       {loading ? (
-        <div className="grid gap-3 mt-5 sm:grid-cols-2" aria-label={t('orgs.loading')}>
+        <div className="grid grid-cols-1 gap-3 mt-5 sm:grid-cols-2" aria-label={t('orgs.loading')}>
           {[...Array(6)].map((_, i) => (
             <div key={i} className="cq-skel h-[74px]" />
           ))}
@@ -76,22 +76,12 @@ export default function OrganizationsPage() {
         <div className="alert alert-error mt-5">{error.message}</div>
       ) : (
         <>
-          <div className="grid gap-3 mt-5 sm:grid-cols-2">
-            {visible.map(o => (
-              <OrgCard key={o.id} org={o} t={t} />
+          <div className="grid grid-cols-1 gap-3 mt-5 sm:grid-cols-2">
+            {items.map(o => (
+              <OrgCard key={o.id} org={o} t={t} lang={lang} />
             ))}
           </div>
-          {hasMore && (
-            <div className="text-center mt-6">
-              <button
-                className="btn btn-outline btn-sm rounded-full px-7 border-base-content/20"
-                onClick={() => { track('catalog_filter', { action: 'load_more', source: 'organizations' }); loadMore(); }}
-                disabled={loadingMore}
-              >
-                {loadingMore ? t('home.loading') : t('home.load_more')}
-              </button>
-            </div>
-          )}
+          {!collection.notFound && <CatalogPagination {...collection} />}
         </>
       )}
     </div>

--- a/client/src/pages/PlacePage.jsx
+++ b/client/src/pages/PlacePage.jsx
@@ -4,7 +4,9 @@ import { Link, useParams } from 'react-router-dom';
 import { fetchPlace, fetchSources, searchDatasets } from '../api/catalog.js';
 import { NotFoundError } from '../api/client.js';
 import useDebouncedValue from '../hooks/useDebouncedValue.js';
-import usePaginatedCollection from '../hooks/usePaginatedCollection.js';
+import useCatalogPage from '../hooks/useCatalogPage.js';
+import CatalogPagination from '../components/CatalogPagination.jsx';
+import { PAGE_SIZE } from '../utils/catalogPagination.js';
 import { writePlace } from '../utils/placeStore.js';
 import { track } from '../utils/analytics.js';
 import { useLang } from '../i18n.jsx';
@@ -46,16 +48,18 @@ export default function PlacePage() {
     return () => { cancelled = true; };
   }, [slug]);
 
-  const { items, meta, loading, loadingMore, error: searchError, hasMore, loadMore } = usePaginatedCollection(
+  const collection = useCatalogPage(
     cursor => searchDatasets({
       q: debouncedQuery || undefined,
       place: slug,
       mappable: mappable || undefined,
-      limit: 20,
+      limit: PAGE_SIZE,
       cursor
     }),
-    [slug, debouncedQuery, mappable]
+    [slug, debouncedQuery, mappable],
+    Boolean(debouncedQuery || mappable)
   );
+  const { items, meta, loading, error: searchError } = collection;
 
   const reportedSearch = useRef(null);
   useEffect(() => {
@@ -66,7 +70,7 @@ export default function PlacePage() {
     });
   }, [loading, searchError, debouncedQuery, slug, lang, items.length, meta]);
 
-  if (notFound) return <div className="text-center py-28"><h1 className="text-2xl font-bold font-display">{t('places.not_found')}</h1></div>;
+  if (notFound || collection.notFound) return <div className="text-center py-28"><h1 className="text-2xl font-bold font-display">{t('places.not_found')}</h1></div>;
   if (error) return <div className="max-w-5xl mx-auto px-4 py-8"><div className="alert alert-error">{error.message}</div></div>;
   if (!place) return <LoadingSpinner label={t('places.loading')} />;
 
@@ -189,7 +193,7 @@ export default function PlacePage() {
               </div> :
               items.map(dataset => <DatasetRow key={dataset.id} dataset={dataset} />)}
       </section>
-      {hasMore && <div className="text-center mt-6"><button className="btn btn-outline btn-sm rounded-full px-7" onClick={() => { track('catalog_filter', { action: 'load_more', place: slug }); loadMore(); }} disabled={loadingMore}>{loadingMore ? t('home.loading') : t('home.load_more')}</button></div>}
+      {!searchError && !collection.notFound && <CatalogPagination {...collection} />}
     </div>
   );
 }

--- a/client/src/pages/PlacePage.test.jsx
+++ b/client/src/pages/PlacePage.test.jsx
@@ -48,7 +48,7 @@ describe('PlacePage', () => {
     expect(within(breadcrumb).getByText('Oshawa')).toHaveAttribute('aria-current', 'page');
     expect(screen.getByText('Oshawa Hub')).toBeInTheDocument();
     expect(await screen.findByText('Road network')).toBeInTheDocument();
-    expect(searchDatasets).toHaveBeenCalledWith(expect.objectContaining({ place: 'oshawa-on', limit: 20 }));
+    expect(searchDatasets).toHaveBeenCalledWith(expect.objectContaining({ place: 'oshawa-on', limit: 50 }));
   });
 
   test('localizes the place breadcrumb in French', async () => {

--- a/client/src/pages/PlacesPage.jsx
+++ b/client/src/pages/PlacesPage.jsx
@@ -1,17 +1,17 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { fetchFeaturedPlaces, fetchPlaces } from '../api/catalog.js';
+import { fetchPlaces } from '../api/catalog.js';
 import { useLang } from '../i18n.jsx';
 import { MapPinIcon, ArrowRightIcon, MapIcon, SearchIcon } from '../components/Icons.jsx';
+import CatalogPagination from '../components/CatalogPagination.jsx';
+import useCatalogPage from '../hooks/useCatalogPage.js';
+import { PAGE_SIZE } from '../utils/catalogPagination.js';
 import LoadingSpinner from '../components/LoadingSpinner.jsx';
 import useDebouncedValue from '../hooks/useDebouncedValue.js';
 import { track } from '../utils/analytics.js';
 
 export default function PlacesPage() {
   const { lang, t } = useLang();
-  const [places, setPlaces] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebouncedValue(query, 250);
 
@@ -19,23 +19,11 @@ export default function PlacesPage() {
     if (debouncedQuery) track('place_search', { query: debouncedQuery, language: lang });
   }, [debouncedQuery, lang]);
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    const request = debouncedQuery
-      ? fetchPlaces({ q: debouncedQuery, limit: 100 })
-      : fetchFeaturedPlaces();
-    request
-      .then(env => {
-        if (!cancelled) {
-          setPlaces(env.data || []);
-          setError(null);
-        }
-      })
-      .catch(err => { if (!cancelled) setError(err); })
-      .finally(() => { if (!cancelled) setLoading(false); });
-    return () => { cancelled = true; };
-  }, [debouncedQuery]);
+  const collection = useCatalogPage(cursor => fetchPlaces({
+    q: debouncedQuery || undefined, featured: debouncedQuery ? undefined : true,
+    limit: PAGE_SIZE, cursor
+  }), [debouncedQuery], Boolean(debouncedQuery));
+  const { items: places, loading, error } = collection;
 
   const placeCard = (place) => (
     <Link
@@ -53,6 +41,7 @@ export default function PlacesPage() {
       </div>
       <h2 className="font-display font-semibold text-lg mt-4">{place.name?.[lang] || place.name?.en}</h2>
       <p className="text-xs uppercase tracking-wider text-base-content/40 mt-1">{place.type?.[lang] || place.type?.en || place.kind}</p>
+      {place.parent && <p className="text-sm text-base-content/55 mt-2">{place.parent.name?.[lang] || place.parent.name?.en}</p>}
       <div className="flex flex-wrap gap-2 mt-4">
         <span className="cq-chip cq-chip-mono">{place.dataset_count} {t('places.datasets')}</span>
         {place.direct_dataset_count === 0 && place.dataset_count > 0 && (
@@ -72,7 +61,7 @@ export default function PlacesPage() {
     <div className="max-w-6xl mx-auto px-4 py-8 cq-fade">
       <div className="max-w-3xl">
         <span className="cq-chip cq-chip-mono"><MapPinIcon size={11} />{t('places.local_data')}</span>
-        <h1 className="text-3xl sm:text-4xl font-bold font-display tracking-tight mt-4">{t('places.title')}</h1>
+        <h1 className="text-3xl sm:text-4xl font-bold font-display tracking-tight mt-4">{collection.notFound ? t('common.not_found') : t('places.title')}</h1>
         <p className="text-base-content/60 mt-3 leading-relaxed">{t('places.subtitle')}</p>
       </div>
       <div className="cq-search cq-search-sm max-w-lg mt-7">
@@ -125,6 +114,7 @@ export default function PlacesPage() {
             <h2 className="font-display font-semibold text-xl mb-3">{t('places.other_places')}</h2>
             <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-3">{otherPlaces.map(placeCard)}</div>
           </section>}
+          {!collection.notFound && <CatalogPagination {...collection} />}
           {places.length === 0 && debouncedQuery && (
             <p className="text-center py-12 text-base-content/50">{t('places.not_found')}</p>
           )}

--- a/client/src/pages/PlacesPage.test.jsx
+++ b/client/src/pages/PlacesPage.test.jsx
@@ -126,9 +126,9 @@ describe('PlacesPage', () => {
     expect(screen.getByRole('link', { name: /Ottawa/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Toronto/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Montréal/ })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /Québec/ })).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: /Québec/ })[0]).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Laval/ })).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: /Vancouver/ })).toHaveLength(1);
+    expect(screen.getAllByRole('link', { name: /^Vancouver/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Calgary/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Edmonton/ })).toHaveLength(1);
     expect(screen.getAllByRole('link', { name: /Winnipeg/ })).toHaveLength(1);
@@ -139,12 +139,12 @@ describe('PlacesPage', () => {
     expect(screen.getByRole('link', { name: /Mississauga/ })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /Caledon/ })).toBeInTheDocument();
     expect(screen.getAllByText('Broader-area coverage')).toHaveLength(2);
-    await waitFor(() => expect(fetchFeaturedPlaces).toHaveBeenCalledTimes(1));
-    expect(fetchPlaces).not.toHaveBeenCalled();
+    await waitFor(() => expect(fetchPlaces).toHaveBeenCalledWith(expect.objectContaining({ featured: true, limit: 50, cursor: '0' })));
+    expect(fetchFeaturedPlaces).not.toHaveBeenCalled();
 
     fireEvent.change(screen.getByRole('textbox', { name: 'Find a city, region or province...' }), {
       target: { value: 'Toronto' }
     });
-    await waitFor(() => expect(fetchPlaces).toHaveBeenCalledWith({ q: 'Toronto', limit: 100 }));
+    await waitFor(() => expect(fetchPlaces).toHaveBeenCalledWith(expect.objectContaining({ q: 'Toronto', limit: 50, cursor: '0' })));
   });
 });

--- a/client/src/pages/ResourcePage.jsx
+++ b/client/src/pages/ResourcePage.jsx
@@ -389,7 +389,7 @@ function ResourceExplorer({ id }) {
           <Breadcrumbs
             label={t('breadcrumbs.label')}
             items={[
-              { label: t('nav.datasets'), to: '/' },
+              { label: t('nav.datasets'), to: '/datasets' },
               {
                 label: resource.dataset.title?.[lang] || resource.dataset.title?.en || resource.dataset.name,
                 to: `/datasets/${resource.dataset.name || resource.dataset.id}`
@@ -430,6 +430,7 @@ function ResourceExplorer({ id }) {
           )}
           {resource.last_modified && <p className="text-xs text-base-content/60">{t('preview.resource_updated')} {new Date(resource.last_modified).toLocaleDateString(lang === 'fr' ? 'fr-CA' : 'en-CA')}</p>}
           <Provenance provenance={resource.provenance} compact />
+          {resource.presentation?.context?.[lang] && <p className="max-w-3xl whitespace-pre-wrap break-words text-base-content/70">{resource.presentation.context[lang]}</p>}
           <CatalogOverview presentation={resource.presentation} />
         </div>
       )}

--- a/client/src/pages/ResourcePage.test.jsx
+++ b/client/src/pages/ResourcePage.test.jsx
@@ -70,7 +70,7 @@ describe('ResourcePage navigation', () => {
     );
 
     const breadcrumb = await screen.findByRole('navigation', { name: ariaLabel });
-    expect(within(breadcrumb).getByRole('link', { name: rootLabel })).toHaveAttribute('href', '/');
+    expect(within(breadcrumb).getByRole('link', { name: rootLabel })).toHaveAttribute('href', '/datasets');
     expect(within(breadcrumb).getByRole('link', { name: datasetLabel }))
       .toHaveAttribute('href', '/datasets/dataset-slug-a');
     expect(within(breadcrumb).getByText(resourceLabel)).toHaveAttribute('aria-current', 'page');

--- a/client/src/utils/catalogPagination.js
+++ b/client/src/utils/catalogPagination.js
@@ -1,0 +1,13 @@
+export const PAGE_SIZE = 50;
+
+export function pageNumber(params) {
+  const values = params.getAll('page');
+  if (!values.length) return 1;
+  if (values.length !== 1 || !/^[1-9]\d*$/.test(values[0])) return null;
+  const page = Number(values[0]);
+  return Number.isSafeInteger(page) && page <= Math.floor(Number.MAX_SAFE_INTEGER / PAGE_SIZE) ? page : null;
+}
+
+export function pagePath(path, page) {
+  return path + (page > 1 ? '?page=' + page : '');
+}

--- a/client/src/utils/routeHead.js
+++ b/client/src/utils/routeHead.js
@@ -30,7 +30,8 @@ export function readSeoElements(html, responseUrl) {
   }
   const canonical = new URL(canonicals[0].getAttribute('href'), responseUrl);
   if (!['http:', 'https:'].includes(canonical.protocol) ||
-      canonical.pathname !== new URL(responseUrl).pathname) {
+      canonical.pathname !== new URL(responseUrl).pathname ||
+      JSON.stringify(canonical.searchParams.getAll('page')) !== JSON.stringify(new URL(responseUrl).searchParams.getAll('page'))) {
     throw new Error('SEO response belongs to a different page');
   }
   return elements.map(node => {

--- a/deploy/RELEASE_RUNBOOK_catalogue_discovery.md
+++ b/deploy/RELEASE_RUNBOOK_catalogue_discovery.md
@@ -1,0 +1,64 @@
+# Catalogue discovery release
+
+This release exposes all existing public dataset and resource detail pages in
+the sitemaps, including download-only files. It adds `/datasets` and 50-item
+pagination to catalogue, publisher, place and dataset resource lists. Existing
+detail URLs remain canonical; page continuations use `?page=N` and their own
+canonical URLs. Page one redirects to the base URL. Invalid and out-of-range
+pages return 404 with noindex; catalogue failures retain retryable 503 responses.
+
+The organizations API accepts optional `q` for literal, case-insensitive search
+across publisher names and English/French titles. Existing `limit`/`cursor`
+interfaces and response envelopes remain compatible. Local search filters use
+buttons for pagination and do not add filter links to the crawl graph.
+
+Resource titles always link to their details, original-file links appear before
+JavaScript runs, and resource overviews include recorded parent descriptions.
+Date-only titles include the dataset subject while retaining the file period,
+language and format. These changes neither ingest files nor merge language
+editions. There are no dependency, schema, source-admission or analytics changes.
+
+## Verification
+
+- Run `npm run verify` in `server/` and all four integration suites in CI against
+  disposable PostgreSQL 16/PostGIS 3.5. The discovery integration suite covers
+  file-only records, metadata-only datasets, orphan exclusion, directory search
+  and complete traversal across tied ordering values.
+- Check initial HTML and the interactive app in Chromium and WebKit, including
+  narrow English/French layouts, keyboard navigation, Back, direct page-two
+  links, filter buttons and a resource highlight beyond the first page.
+- Compare sitemap counts and distinct URLs with the catalogue in a stable
+  observation window. Each chunk remains bounded to 25,000 URLs. Query variants
+  and removed records must not enter the sitemap. Check the last chunk and the
+  first nonexistent chunk of each family.
+
+## Deployment and rollback
+
+Use a clean worktree and the application account for Git/build operations.
+Freeze private indexing counts and representative URL inspections separately
+from existing SEO baselines. Complete fresh validated catalogue and analytics
+backups, including the established encrypted, hash-verified off-host copies.
+
+Install and verify the reviewed commit in an isolated release directory. Match
+its built assets against the browser-verified build. Preserve the previous
+commit and frontend, promote assets with `index.html` last, retain older hashed
+assets and restart only the API service. Verify public health, operations,
+representative catalogue pages, sitemap families and ownership. Confirm other
+services retained their process IDs.
+
+Rollback by selecting the preserved compatible commit as the application user,
+restoring its matching frontend with the index last, and restarting the API.
+No database restore is required for this code rollback.
+
+## Search Console follow-up
+
+Submit the updated sitemap once after successful verification and inspect a
+small representative set of URLs. Do not validate intentional redirect,
+duplicate or removed-page exclusions as defects. Compare the frozen indexing
+cohort weekly and at 7/28 days when reports have caught up. Preserve existing
+SEO cohorts and annotate this release separately using Search Console's Pacific
+dates and the exact UTC deployment timestamp.
+
+Broader discovery may initially increase the not-indexed count. Assess indexed
+canonical pages, inspected cohort transitions, crawl response times and host
+errors together; successful deployment does not establish indexing gains.

--- a/server/__tests__/catalogDiscovery.test.js
+++ b/server/__tests__/catalogDiscovery.test.js
@@ -1,0 +1,107 @@
+jest.mock('../db/pool', () => ({ query: jest.fn() }));
+const express = require('express');
+const request = require('supertest');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const catalogRead = require('../db/catalogReadQueries');
+const { resolvePage, serveSpa } = require('../controllers/spaController');
+const { resourceSnapshot } = require('../services/seoSnapshot');
+const { resourcePresentation } = require('../services/catalogPresentation');
+const { resourceMeta } = require('../services/seoMeta');
+
+const records = Array.from({ length: 101 }, (_, i) => ({
+    id: 'record-' + i, name: 'record-' + i, slug: 'record-' + i,
+    title_en: 'Catalogue record ' + i, name_en: 'Catalogue record ' + i,
+    kind: 'municipality', dataset_count: 1
+}));
+const files = records.map(row => ({ ...row, format: 'PDF', url: 'https://example.test/' + row.id + '.pdf' }));
+const listing = ({ limit, offset }) => Promise.resolve(records.slice(offset, offset + limit));
+const dependencies = () => ({
+    searchDatasets: jest.fn(listing), listOrganizations: jest.fn(listing), listPlaces: jest.fn(listing),
+    getDatasetByIdOrName: jest.fn().mockResolvedValue({ id: 'd', name: 'example', title_en: 'Example data' }),
+    listResourcesForDataset: jest.fn().mockResolvedValue(files),
+    getOrganizationByName: jest.fn().mockResolvedValue({ name: 'example', title_en: 'Example publisher', dataset_count: 101 }),
+    getPlaceByIdOrSlug: jest.fn().mockResolvedValue({ id: 'p', slug: 'example', name_en: 'Example place', dataset_count: 101 })
+});
+
+test.each([
+    ['/datasets', 'datasets'], ['/organizations/example', 'datasets'], ['/places/example', 'datasets'],
+    ['/organizations', 'organizations'], ['/places', 'places'], ['/datasets/example', 'resources']
+])('initial HTML exposes the complete %s list through canonical page links', async (route, family) => {
+    const deps = dependencies();
+    const seen = [];
+    for (let number = 1; number <= 3; number++) {
+        const url = route + (number > 1 ? '?page=' + number : '');
+        const page = await resolvePage(url, deps);
+        expect(page.status).toBe(200);
+        expect(page.meta.canonical).toBe('https://canquery.com' + url);
+        const collection = page.meta.jsonLd?.find(item => item['@type'] === 'CollectionPage');
+        if (collection) {
+            expect(collection.url).toBe(page.meta.canonical);
+            expect(collection.mainEntity.itemListElement[0].position).toBe((number - 1) * 50 + 1);
+        }
+        const matches = [...page.body.matchAll(new RegExp('href="/' + family + '/(record-\\d+)"', 'g'))];
+        expect(matches).toHaveLength(number === 3 ? 1 : 50);
+        seen.push(...matches.map(match => match[1]));
+        if (number < 3) expect(page.body).toContain('href="' + route + '?page=' + (number + 1) + '"');
+        if (number > 1) expect(page.body).toContain('aria-current="page">Page ' + number);
+    }
+    expect(new Set(seen).size).toBe(101);
+    expect((await resolvePage(route + '?page=4', deps)).status).toBe(404);
+});
+
+test.each(['0', '-1', '01', '1.5', 'abc', '9007199254740991', '2&page=3'])('rejects invalid page %s before querying', async value => {
+    const deps = dependencies();
+    const page = await resolvePage('/datasets?page=' + value, deps);
+    expect(page.status).toBe(404);
+    expect(page.meta.noindex).toBe(true);
+    expect(deps.searchDatasets).not.toHaveBeenCalled();
+});
+
+test('normalizes page one and aliases together, preserving unrelated deep-link state', async () => {
+    const deps = dependencies();
+    const spies = Object.entries(deps).map(([key, value]) => jest.spyOn(catalogRead, key).mockImplementation(value));
+    const dist = fs.mkdtempSync(path.join(os.tmpdir(), 'canquery-discovery-'));
+    fs.writeFileSync(path.join(dist, 'index.html'), '<html><head><!-- seo:start --><!-- seo:end --></head><body><div id="root"></div></body></html>');
+    try {
+        const app = express();
+        app.get(/.*/, serveSpa(dist));
+        const first = await request(app).get('/datasets/d?page=1&highlight=record-60');
+        expect(first.status).toBe(301);
+        expect(first.headers.location).toBe('/datasets/example?highlight=record-60');
+        const next = await request(app).get('/datasets/example?page=2');
+        expect(next.status).toBe(200);
+        expect(next.text).toContain('rel="canonical" href="https://canquery.com/datasets/example?page=2"');
+        const absent = await request(app).get('/datasets/example?page=4');
+        expect(absent.status).toBe(404);
+        expect(absent.text).toContain('name="robots" content="noindex');
+    } finally {
+        spies.forEach(spy => spy.mockRestore());
+        fs.rmSync(dist, { recursive: true, force: true });
+    }
+});
+
+test('download-only initial HTML contains a usable original link and cleaned publisher context', () => {
+    const row = { id: 'r', dataset_id: 'd', dataset_name: 'example', name_en: 'Report', format: 'PDF',
+        url: 'https://example.test/report.pdf?a=1&b=2', dataset_notes_en: '<p>Quarterly <b>waiting times</b>.</p><script>bad()</script>' };
+    const html = resourceSnapshot(row);
+    expect(html).toContain('href="https://example.test/report.pdf?a=1&amp;b=2"');
+    expect(html).toMatch(/Quarterly waiting times\s*\./);
+    expect(html).not.toContain('<script>');
+    expect(resourceSnapshot({ ...row, url: 'javascript:alert(1)' })).not.toContain('href="javascript:');
+    expect(resourceSnapshot({ ...row, url: 'https://user:secret@example.test/file' })).not.toContain('user:secret');
+});
+
+test('date-only files retain subject, period, language and format without merging editions', () => {
+    const row = { id: 'r-en', name_en: '2020-04-01 to 2020-06-30', dataset_title_en: 'Wait Time Tool',
+        dataset_title_fr: 'Outil de délais', language: 'en', format: 'CSV' };
+    const en = resourcePresentation(row);
+    const fr = resourcePresentation({ ...row, id: 'r-fr', language: 'fr' });
+    expect(en.title.en).toBe('Wait Time Tool — 2020-04-01 to 2020-06-30 (English, CSV)');
+    expect(fr.title.fr).toContain('Outil de délais — 2020-04-01 to 2020-06-30 (français, CSV)');
+    const meta = resourceMeta({ ...row, dataset_title_en: 'A lengthy publisher dataset title '.repeat(10) });
+    expect(meta.title.length).toBeLessThanOrEqual(80);
+    expect(meta.title).toContain('2020-04-01 to 2020-06-30 (English, CSV)');
+    expect(resourceMeta(row).canonical).not.toBe(resourceMeta({ ...row, id: 'r-fr' }).canonical);
+});

--- a/server/__tests__/catalogDiscoveryIntegration.test.js
+++ b/server/__tests__/catalogDiscoveryIntegration.test.js
@@ -1,0 +1,62 @@
+const { Pool } = require('pg');
+const queries = require('../db/catalogReadQueries');
+const url = process.env.SPATIAL_TEST_DATABASE_URL;
+const integrationDescribe = url ? describe : describe.skip;
+
+integrationDescribe('complete catalogue discovery PostgreSQL integration', () => {
+    let pool, db, datasetCount, resourceCount;
+    const prefix = 'discovery_test_' + process.pid;
+    const id = name => prefix + '_' + name;
+    beforeAll(async () => {
+        pool = new Pool({ connectionString: url });
+        db = await pool.connect();
+        await db.query('BEGIN');
+        datasetCount = await queries.countSitemapDatasets(db);
+        resourceCount = await queries.countSitemapResources(db);
+        await db.query(`INSERT INTO organizations (id, name, title_fr) VALUES
+            ($1, $1, 'Organisme principal'), ($2, $2, 'ÉTUDES DU NORD')`, [prefix, id('publisher')]);
+        await db.query(`INSERT INTO datasets (id, name, title_en, org_id, metadata_modified)
+            SELECT $1 || lpad(n::text, 3, '0'), $1 || lpad(n::text, 3, '0'), 'Example data ' || n,
+                   $2, '2026-08-01'::timestamptz FROM generate_series(0, 100) n`, [id('dataset'), prefix]);
+        await db.query('UPDATE datasets SET org_id = $1 WHERE id = $2', [id('publisher'), id('dataset100')]);
+        await db.query(`INSERT INTO resources (id, dataset_id, format, url, datastore_active)
+            SELECT $1 || n, $2 || lpad(n::text, 3, '0'), CASE WHEN n=0 THEN 'PDF' ELSE 'CSV' END,
+                   'https://example.test/data', n=2 FROM generate_series(0, 4) n`, [id('resource'), id('dataset')]);
+        await db.query(`INSERT INTO ingested_resources (resource_id, table_name, status) VALUES ($1, $2, 'ready')`, [id('resource3'), id('table')]);
+        await db.query(`INSERT INTO resource_maps (resource_id, provider, service_url, geometry_type)
+            VALUES ($1, 'arcgis', 'https://example.test/FeatureServer/0', 'polygon')`, [id('resource4')]);
+        await db.query(`INSERT INTO resources (id, dataset_id) VALUES ($1, $2)`, [id('orphan'), id('missing')]);
+    });
+    afterAll(async () => {
+        if (db) { await db.query('ROLLBACK'); db.release(); }
+        if (pool) await pool.end();
+    });
+    test('includes metadata-only datasets and all five resource capabilities, excluding orphan resources', async () => {
+        expect(await queries.countSitemapDatasets(db)).toBe(datasetCount + 101);
+        expect(await queries.countSitemapResources(db)).toBe(resourceCount + 5);
+        const datasets = await queries.listDatasetSitemap({ limit: 25000, offset: 0 }, db);
+        expect(datasets.filter(row => row.id.startsWith(prefix))).toHaveLength(101);
+        const resources = await queries.listResourceSitemap({ limit: 25000, offset: 0 }, db);
+        expect(resources.filter(row => row.id.startsWith(prefix)).map(row => row.id)).toEqual(
+            [0, 1, 2, 3, 4].map(n => id('resource' + n)));
+        expect(resources.find(row => row.id === id('resource0')).metadata_modified.toISOString()).toBe('2026-08-01T00:00:00.000Z');
+    });
+    test('pages through tied dataset dates without losing or repeating records', async () => {
+        const search = offset => queries.searchDatasets({ org: prefix, q: null, limit: 50, offset }, db);
+        const pages = [...await search(0), ...await search(50)];
+        expect(pages).toHaveLength(100);
+        expect(new Set(pages.map(row => row.id)).size).toBe(100);
+        expect(await search(100)).toHaveLength(0);
+    });
+    test('publisher search covers the directory with literal bilingual matching', async () => {
+        const search = q => queries.listOrganizations({ q, limit: 50, offset: 0 }, db);
+        expect((await search('études du nord')).map(row => row.name)).toEqual([id('publisher')]);
+        expect(await search('%études%')).toHaveLength(0);
+    });
+    test('sitemap chunk offsets partition resources without duplicate joins', async () => {
+        const all = await queries.listResourceSitemap({ limit: 25000, offset: 0 }, db);
+        const first = await queries.listResourceSitemap({ limit: 2, offset: 0 }, db);
+        const rest = await queries.listResourceSitemap({ limit: 25000, offset: 2 }, db);
+        expect([...first, ...rest]).toEqual(all);
+    });
+});

--- a/server/__tests__/seoMeta.test.js
+++ b/server/__tests__/seoMeta.test.js
@@ -138,7 +138,7 @@ describe('seoMeta - dataset meta + JSON-LD', () => {
         expect(meta.description.length).toBeLessThanOrEqual(160);
         const breadcrumb = meta.jsonLd.find(item => item['@type'] === 'BreadcrumbList');
         expect(breadcrumb.itemListElement).toEqual([
-            expect.objectContaining({ position: 1, name: 'Datasets', item: 'https://canquery.com/' }),
+            expect.objectContaining({ position: 1, name: 'Datasets', item: 'https://canquery.com/datasets' }),
             expect.objectContaining({
                 position: 2,
                 item: 'https://canquery.com/datasets/water-quality'
@@ -198,7 +198,7 @@ describe('seoMeta - resource titles, capabilities and breadcrumbs', () => {
         const meta = seo.resourceMeta(base);
         const breadcrumb = meta.jsonLd.find(item => item['@type'] === 'BreadcrumbList');
         expect(breadcrumb.itemListElement).toEqual([
-            expect.objectContaining({ position: 1, name: 'Datasets', item: 'https://canquery.com/' }),
+            expect.objectContaining({ position: 1, name: 'Datasets', item: 'https://canquery.com/datasets' }),
             expect.objectContaining({
                 position: 2, name: 'Water Quality',
                 item: 'https://canquery.com/datasets/water-quality'

--- a/server/__tests__/sitemapQueries.test.js
+++ b/server/__tests__/sitemapQueries.test.js
@@ -6,16 +6,15 @@ const queries = require('../db/catalogReadQueries');
 beforeEach(() => jest.clearAllMocks());
 
 describe('resource sitemap queries', () => {
-    it('counts only resources with a live table, local table, or map capability', async () => {
+    it('counts public resource pages with a parent dataset', async () => {
         pool.query.mockResolvedValue({ rows: [{ n: 13 }] });
 
         await expect(queries.countSitemapResources()).resolves.toBe(13);
 
         const sql = pool.query.mock.calls[0][0];
         expect(sql).toContain('FROM resources r');
-        expect(sql).toContain('r.datastore_active');
-        expect(sql).toContain("ir.status = 'ready'");
-        expect(sql).toContain('resource_maps');
+        expect(sql).toContain('JOIN datasets d ON d.id = r.dataset_id');
+        expect(sql).not.toMatch(/datastore_active|ingested_resources|resource_maps/);
     });
 
     it('lists each qualifying resource once with its parent dataset modification time', async () => {
@@ -26,11 +25,9 @@ describe('resource sitemap queries', () => {
             .resolves.toEqual(rows);
 
         const [sql, params] = pool.query.mock.calls[0];
-        expect(sql).toContain('WITH eligible_resources AS MATERIALIZED');
-        expect(sql).toContain('JOIN datasets d ON d.id = eligible.dataset_id');
-        expect(sql).toContain('ORDER BY eligible.id LIMIT $1 OFFSET $2');
-        expect(sql).toContain('EXISTS (SELECT 1 FROM ingested_resources');
-        expect(sql).toContain('EXISTS (SELECT 1 FROM resource_maps');
+        expect(sql).toContain('JOIN datasets d ON d.id = r.dataset_id');
+        expect(sql).toContain('ORDER BY r.id LIMIT $1 OFFSET $2');
+        expect(sql).not.toMatch(/datastore_active|ingested_resources|resource_maps/);
         expect(params).toEqual([25000, 50000]);
     });
 });

--- a/server/controllers/catalogController.js
+++ b/server/controllers/catalogController.js
@@ -56,6 +56,7 @@ const getResource = async (req, res) => {
 
 const listOrganizations = async (req, res) => {
     const result = await catalogService.listOrganizations({
+        q: cleanStr(req.query.q),
         source: cleanStr(req.query.source),
         place: cleanStr(req.query.place),
         limit: req.query.limit,

--- a/server/controllers/sitemapController.js
+++ b/server/controllers/sitemapController.js
@@ -50,8 +50,8 @@ const robots = (req, res) => {
     res.send('User-agent: *\nAllow: /\n\nSitemap: ' + SITE_URL + '/sitemap.xml\n');
 };
 
-// GET /sitemap.xml - the index: static/place pages plus quality-gated dataset
-// and interactive-resource chunks.
+// GET /sitemap.xml - the index: static/place pages plus complete dataset
+// and resource catalogue chunks.
 const sitemapIndex = catchAsync(async (req, res) => {
     const [datasetTotal, resourceTotal] = await Promise.all([
         catalogRead.countSitemapDatasets(),
@@ -84,6 +84,7 @@ const sitemapPages = (req, res) => {
     res.send(
         urlset([
             { loc: SITE_URL + '/', changefreq: 'daily', priority: '1.0' },
+            { loc: SITE_URL + '/datasets', changefreq: 'daily', priority: '0.9' },
             { loc: SITE_URL + '/insights', changefreq: 'daily', priority: '0.9' },
             { loc: SITE_URL + '/organizations', changefreq: 'weekly', priority: '0.7' },
             { loc: SITE_URL + '/places', changefreq: 'weekly', priority: '0.8' },
@@ -142,9 +143,7 @@ const sitemapDatasets = catchAsync(async (req, res, next) => {
     res.send(urlset(entries));
 });
 
-// GET /sitemap-resources-:n.xml - datastore, locally ingested, and mapped
-// resource pages only. Loadable/file-only resources remain discoverable through
-// their dataset page without expanding the crawl surface.
+// GET /sitemap-resources-:n.xml - all public resource detail pages.
 const sitemapResources = catchAsync(async (req, res, next) => {
     const n = chunkNumber(req.params.n);
     if (n === null) return next(new AppError('Not found', 404));

--- a/server/controllers/spaController.js
+++ b/server/controllers/spaController.js
@@ -4,6 +4,7 @@ const seoMeta = require('../services/seoMeta');
 const seoSnapshot = require('../services/seoSnapshot');
 const { resolveBlogPage } = require('../services/blogPresentation');
 const catalogRead = require('../db/catalogReadQueries');
+const { PAGE_SIZE, pageNumber, pagePath, pageSlice } = require('../services/catalogPagination');
 
 // The built index.html is immutable for the life of the process (a deploy
 // restarts the API), so read it once and reuse.
@@ -28,24 +29,51 @@ function injectAnalytics(template, websiteId = process.env.ANALYTICS_WEBSITE_ID)
 }
 
 const STATIC_PATHS = Object.freeze({
-    home: '/', insights: '/insights', organizations: '/organizations',
+    home: '/', datasets: '/datasets', insights: '/insights', organizations: '/organizations',
     places: '/places', docs: '/docs', privacy: '/privacy'
 });
 
 function searchArgs(overrides) {
     return {
         q: null, org: null, format: null, keyword: null, place: null,
-        source: null, mappable: null, limit: 12, offset: 0, ...overrides
+        source: null, mappable: null, limit: PAGE_SIZE + 1, offset: 0, ...overrides
     };
 }
 
 // Resolve the head, semantic initial body, canonical path and response status
 // in one pass. The same HTML is sent to every user agent; React replaces the
 // bounded snapshot when the application starts.
-async function resolvePage(reqPath, deps = catalogRead) {
+function missingPage(path) {
+    return { status: 404, meta: seoMeta.notFoundMeta(path),
+        body: seoSnapshot.errorSnapshot('Page not found', 'This catalogue page does not exist.') };
+}
+
+function paginatedPage(path, meta, rows, page, render) {
+    const pagination = pageSlice(rows, page, path);
+    if (page > 1 && !pagination.items.length) return missingPage(pagePath(path, page));
+    const canonical = seoMeta.SITE_URL + pagePath(path, page);
+    const jsonLd = meta.jsonLd?.map(item => item['@type'] === 'CollectionPage' ? {
+        ...item, url: canonical,
+        mainEntity: { ...item.mainEntity,
+            itemListElement: item.mainEntity.itemListElement.map(entry => ({
+                ...entry, position: entry.position + (page - 1) * PAGE_SIZE
+            })) }
+    } : item);
+    return { status: 200, canonicalPath: path, paginated: true,
+        meta: { ...meta, canonical, ...(jsonLd ? { jsonLd } : {}) },
+        body: render(pagination) };
+}
+
+async function resolvePage(requestTarget, deps = catalogRead) {
+    const [reqPath, ...query] = requestTarget.split('?');
+    const params = new URLSearchParams(query.join('?'));
     const blog = resolveBlogPage(reqPath);
     if (blog) return blog;
     const route = seoMeta.classifyRoute(reqPath);
+    const paginated = ['dataset', 'datasets', 'organization', 'organizations', 'place', 'places'].includes(route.type);
+    const page = paginated ? pageNumber(params) : 1;
+    if (page === null) return missingPage(requestTarget);
+    const offset = (page - 1) * PAGE_SIZE;
     if (route.type === 'dataset') {
         const dataset = await deps.getDatasetByIdOrName(route.id);
         if (!dataset) return {
@@ -55,12 +83,9 @@ async function resolvePage(reqPath, deps = catalogRead) {
         };
         const resources = await deps.listResourcesForDataset(dataset.id);
         const canonicalPath = '/datasets/' + encodeURIComponent(dataset.name || dataset.id);
-        return {
-            status: 200,
-            canonicalPath,
-            meta: seoMeta.datasetMeta(dataset, resources),
-            body: seoSnapshot.datasetSnapshot(dataset, resources)
-        };
+        return paginatedPage(canonicalPath, seoMeta.datasetMeta(dataset, resources),
+            resources.slice(offset, offset + PAGE_SIZE + 1), page,
+            pagination => seoSnapshot.datasetSnapshot(dataset, resources, pagination));
     }
     if (route.type === 'resource') {
         const resource = await deps.getResourceById(route.id);
@@ -84,14 +109,10 @@ async function resolvePage(reqPath, deps = catalogRead) {
             meta: seoMeta.notFoundMeta(reqPath),
             body: seoSnapshot.errorSnapshot('Place not found', 'The requested place is not available in the CanQuery directory.')
         };
-        const datasets = await deps.searchDatasets(searchArgs({ place: place.slug || place.id }));
+        const datasets = await deps.searchDatasets(searchArgs({ place: place.slug || place.id, offset }));
         const canonicalPath = '/places/' + encodeURIComponent(place.slug || place.id);
-        return {
-            status: 200,
-            canonicalPath,
-            meta: seoMeta.placeMeta(place, datasets),
-            body: seoSnapshot.placeSnapshot(place, datasets)
-        };
+        return paginatedPage(canonicalPath, seoMeta.placeMeta(place, datasets), datasets, page,
+            pagination => seoSnapshot.placeSnapshot(place, pagination.items, pagination));
     }
     if (route.type === 'organization') {
         const organization = await deps.getOrganizationByName(route.id);
@@ -100,14 +121,10 @@ async function resolvePage(reqPath, deps = catalogRead) {
             meta: seoMeta.notFoundMeta(reqPath),
             body: seoSnapshot.errorSnapshot('Organization not found', 'The requested organization is not available in the CanQuery directory.')
         };
-        const datasets = await deps.searchDatasets(searchArgs({ org: organization.name }));
+        const datasets = await deps.searchDatasets(searchArgs({ org: organization.name, offset }));
         const canonicalPath = '/organizations/' + encodeURIComponent(organization.name);
-        return {
-            status: 200,
-            canonicalPath,
-            meta: seoMeta.organizationMeta(organization, datasets),
-            body: seoSnapshot.organizationSnapshot(organization, datasets)
-        };
+        return paginatedPage(canonicalPath, seoMeta.organizationMeta(organization, datasets), datasets, page,
+            pagination => seoSnapshot.organizationSnapshot(organization, pagination.items, pagination));
     }
     if (route.type === 'other') {
         return {
@@ -117,13 +134,17 @@ async function resolvePage(reqPath, deps = catalogRead) {
         };
     }
     let items = [];
-    if (route.type === 'organizations') {
-        items = (await deps.listOrganizations({ source: null, place: null, limit: 12, offset: 0 })).slice(0, 12);
+    if (route.type === 'datasets') {
+        items = await deps.searchDatasets(searchArgs({ offset }));
+    } else if (route.type === 'organizations') {
+        items = await deps.listOrganizations({ q: null, source: null, place: null, limit: PAGE_SIZE + 1, offset });
     } else if (route.type === 'places') {
         items = await deps.listPlaces({
-            q: null, kind: null, parent: null, featured: true, limit: 12, offset: 0
+            q: null, kind: null, parent: null, featured: true, limit: PAGE_SIZE + 1, offset
         });
     }
+    if (paginated) return paginatedPage(STATIC_PATHS[route.type], seoMeta.staticMeta(route.type, reqPath), items, page,
+        pagination => seoSnapshot.staticSnapshot(route.type, pagination.items, pagination));
     return {
         status: 200,
         canonicalPath: STATIC_PATHS[route.type],
@@ -154,7 +175,7 @@ function serveSpa(distDir) {
         const template = loadTemplate(distDir);
         let page;
         try {
-            page = await resolvePage(req.path);
+            page = await resolvePage(req.originalUrl);
         } catch (err) {
             console.error('SPA page resolution failed:', err.message);
             page = {
@@ -166,9 +187,16 @@ function serveSpa(distDir) {
                 )
             };
         }
-        if (page.status === 200 && page.canonicalPath && requestPath(req) !== page.canonicalPath) {
+        const query = new URLSearchParams(querySuffix(req));
+        const normalizeFirst = page.paginated && query.get('page') === '1';
+        if (page.status === 200 && page.canonicalPath && (requestPath(req) !== page.canonicalPath || normalizeFirst)) {
+            let suffix = querySuffix(req);
+            if (normalizeFirst) {
+                query.delete('page');
+                suffix = query.size ? '?' + query.toString() : '';
+            }
             res.set('Cache-Control', 'public, max-age=3600');
-            return res.redirect(301, page.canonicalPath + querySuffix(req));
+            return res.redirect(301, page.canonicalPath + suffix);
         }
         let html = seoMeta.renderHtml(template, page.meta, page.body);
         html = injectAnalytics(html);

--- a/server/db/catalogReadQueries.js
+++ b/server/db/catalogReadQueries.js
@@ -170,6 +170,7 @@ async function getResourceById(id) {
         SELECT r.id, r.dataset_id, r.name_en, r.name_fr, r.format, r.url, r.size_bytes, r.raw,
                r.datastore_active, r.language, r.last_modified,
                d.name AS dataset_name, d.title_en AS dataset_title_en, d.title_fr AS dataset_title_fr,
+               d.notes_en AS dataset_notes_en, d.notes_fr AS dataset_notes_fr,
                o.name AS org_name, o.title_en AS org_title_en, o.title_fr AS org_title_fr,
                ir.status AS ingest_status, ir.table_name, ir.row_count AS ingested_row_count,
                ir.byte_size AS ingested_byte_size, ir.columns AS ingested_columns,
@@ -242,8 +243,8 @@ async function getResourceMapById(id) {
     return result.rows[0] || null;
 }
 
-async function listOrganizations({ source, place, limit, offset }) {
-    const result = await pool.query(`WITH RECURSIVE selected_place AS (
+async function listOrganizations({ q, source, place, limit, offset }, db = pool) {
+    const result = await db.query(`WITH RECURSIVE selected_place AS (
         SELECT p.id, p.parent_id, 0 AS depth FROM places p
         WHERE $2::text IS NOT NULL AND (p.id = $2 OR p.slug = $2)
         UNION ALL
@@ -275,9 +276,10 @@ async function listOrganizations({ source, place, limit, offset }) {
             JOIN selected_place sp ON sp.id = dp.place_id
             WHERE d.org_id = o.id AND (sp.depth = 0 OR dp.includes_descendants)
         ))
+        AND ($5::text IS NULL OR position(lower($5) in lower(concat_ws(' ', o.name, o.title_en, o.title_fr))) > 0)
         ORDER BY dataset_count DESC, o.name ASC
         LIMIT $3 OFFSET $4
-    `, [source || null, place || null, limit, offset]);
+    `, [source || null, place || null, limit, offset, q || null]);
     return result.rows;
 }
 
@@ -373,7 +375,7 @@ async function listPlaces({ q, kind, parent, featured, limit, offset }) {
         LEFT JOIN places parent_place ON parent_place.id = p.parent_id
         ORDER BY CASE p.kind WHEN 'region' THEN 0 WHEN 'municipality' THEN 1
                      WHEN 'province' THEN 2 WHEN 'territory' THEN 2 ELSE 3 END,
-                 p.name_en
+                 p.name_en, p.id
         LIMIT $5 OFFSET $6
     `, [q || null, kind || null, parent || null, featured, limit, offset]);
     return result.rows;
@@ -439,52 +441,33 @@ async function getStats() {
     return result.rows[0];
 }
 
-const SITEMAP_DATASET_PREDICATE = `EXISTS (
-        SELECT 1 FROM resources r
-        WHERE r.dataset_id = d.id
-          AND (r.datastore_active
-               OR EXISTS (SELECT 1 FROM ingested_resources ir
-                          WHERE ir.resource_id = r.id AND ir.status = 'ready')
-               OR EXISTS (SELECT 1 FROM resource_maps rm WHERE rm.resource_id = r.id)))`;
-
-const SITEMAP_RESOURCE_PREDICATE = `(r.datastore_active
-        OR EXISTS (SELECT 1 FROM ingested_resources ir
-                   WHERE ir.resource_id = r.id AND ir.status = 'ready')
-        OR EXISTS (SELECT 1 FROM resource_maps rm WHERE rm.resource_id = r.id))`;
-
-async function countSitemapDatasets() {
-    const result = await pool.query(`SELECT count(*)::int AS n FROM datasets d WHERE ${SITEMAP_DATASET_PREDICATE}`);
+// Every public catalogue detail page is eligible, including download-only files.
+// Resource pages require a parent dataset, matching getResourceById's join.
+async function countSitemapDatasets(db = pool) {
+    const result = await db.query('SELECT count(*)::int AS n FROM datasets');
     return result.rows[0].n;
 }
 
-async function listDatasetSitemap({ limit, offset }) {
-    const result = await pool.query(`
+async function listDatasetSitemap({ limit, offset }, db = pool) {
+    const result = await db.query(`
         SELECT d.id, d.name, d.metadata_modified FROM datasets d
-        WHERE ${SITEMAP_DATASET_PREDICATE}
         ORDER BY d.id LIMIT $1 OFFSET $2
     `, [limit, offset]);
     return result.rows;
 }
 
-async function countSitemapResources() {
-    const result = await pool.query(`
-        SELECT count(*)::int AS n FROM resources r
-        WHERE ${SITEMAP_RESOURCE_PREDICATE}
+async function countSitemapResources(db = pool) {
+    const result = await db.query(`
+        SELECT count(*)::int AS n FROM resources r JOIN datasets d ON d.id = r.dataset_id
     `);
     return result.rows[0].n;
 }
 
-async function listResourceSitemap({ limit, offset }) {
-    const result = await pool.query(`
-        WITH eligible_resources AS MATERIALIZED (
-            SELECT r.id, r.dataset_id
-            FROM resources r
-            WHERE ${SITEMAP_RESOURCE_PREDICATE}
-        )
-        SELECT eligible.id, d.metadata_modified
-        FROM eligible_resources eligible
-        JOIN datasets d ON d.id = eligible.dataset_id
-        ORDER BY eligible.id LIMIT $1 OFFSET $2
+async function listResourceSitemap({ limit, offset }, db = pool) {
+    const result = await db.query(`
+        SELECT r.id, d.metadata_modified FROM resources r
+        JOIN datasets d ON d.id = r.dataset_id
+        ORDER BY r.id LIMIT $1 OFFSET $2
     `, [limit, offset]);
     return result.rows;
 }

--- a/server/services/catalogPagination.js
+++ b/server/services/catalogPagination.js
@@ -1,0 +1,19 @@
+const PAGE_SIZE = 50;
+
+function pageNumber(params = new URLSearchParams()) {
+    const values = params.getAll('page');
+    if (!values.length) return 1;
+    if (values.length !== 1 || !/^[1-9]\d*$/.test(values[0])) return null;
+    const page = Number(values[0]);
+    return Number.isSafeInteger(page) && page <= Math.floor(Number.MAX_SAFE_INTEGER / PAGE_SIZE) ? page : null;
+}
+
+function pagePath(path, page) {
+    return path + (page > 1 ? '?page=' + page : '');
+}
+
+function pageSlice(rows, page, path) {
+    return { page, path, items: rows.slice(0, PAGE_SIZE), hasMore: rows.length > PAGE_SIZE };
+}
+
+module.exports = { PAGE_SIZE, pageNumber, pagePath, pageSlice };

--- a/server/services/catalogPresentation.js
+++ b/server/services/catalogPresentation.js
@@ -28,6 +28,8 @@ function resourcePresentation(row) {
     }
     return {
         title, summary,
+        context: { en: truncate(localized(row, 'dataset_notes', 'en'), 1200),
+            fr: truncate(localized(row, 'dataset_notes', 'fr'), 1200) },
         formats: row.format ? [plainText(row.format).toUpperCase()] : [],
         languages: resourceLanguages(row),
         capabilities: { table: ['datastore', 'ingested'].includes(mode) ? 'ready' : mode === 'ingestable' ? 'loadable' : null,

--- a/server/services/catalogService.js
+++ b/server/services/catalogService.js
@@ -223,10 +223,10 @@ const getOrganization = async (name) => {
     };
 };
 
-const listOrganizations = async ({ source, place, limit, cursor }) => {
+const listOrganizations = async ({ q, source, place, limit, cursor }) => {
     const lim = clampLimit(limit, 50, 100);
     const offset = parseCursor(cursor);
-    const rows = await catalogReadQueries.listOrganizations({ source, place, limit: lim + 1, offset });
+    const rows = await catalogReadQueries.listOrganizations({ q, source, place, limit: lim + 1, offset });
     const hasMore = rows.length > lim;
     const page = rows.slice(0, lim);
     const items = page.map((r) => ({

--- a/server/services/seoMeta.js
+++ b/server/services/seoMeta.js
@@ -63,6 +63,18 @@ function isGenericResourceName(value, format) {
         (normalizedFormat && normalized === normalizedFormat);
 }
 
+function isPeriodName(name) {
+    return /^\d{4}(?:-\d{2}(?:-\d{2})?)?(?:\s*(?:to|au|à|[-–—/])\s*\d{4}(?:-\d{2}(?:-\d{2})?)?)?$/i.test(name) ||
+        /^(?:[QT][1-4]\s+\d{4}|\d{4}\s+[QT][1-4])$/i.test(name);
+}
+
+function resourceSubject(resource) {
+    const name = pick(resource.name_en, resource.name_fr);
+    const datasetTitle = pick(resource.dataset_title_en, resource.dataset_title_fr);
+    if (datasetTitle && isPeriodName(name)) return datasetTitle + ' — ' + name;
+    return (isGenericResourceName(name, resource.format) ? datasetTitle : name) || datasetTitle;
+}
+
 function titleContainsFormat(value, format) {
     const normalizedFormat = collapse(format);
     if (!normalizedFormat) return true;
@@ -74,11 +86,15 @@ function resourceTitleBase(resource, max = null, lang = 'en') {
     const name = pick(resource.name_en, resource.name_fr);
     const datasetTitle = pick(resource.dataset_title_en, resource.dataset_title_fr);
     const format = collapse(resource.format).toUpperCase();
-    const base = (isGenericResourceName(name, format) ? datasetTitle : name) || datasetTitle || 'Resource';
+    let base = resourceSubject(resource) || 'Resource';
     const languages = resourceLanguages(resource).map(code => lang === 'fr'
         ? (code === 'fr' ? 'français' : 'anglais') : (code === 'fr' ? 'French' : 'English'));
     const suffixParts = [...languages, format && !titleContainsFormat(base, format) ? format : ''].filter(Boolean);
     const suffix = suffixParts.length ? ' (' + suffixParts.join(', ') + ')' : '';
+    if (max && datasetTitle && isPeriodName(name)) {
+        const period = ' — ' + name;
+        base = truncate(datasetTitle, Math.max(12, max - suffix.length - period.length)) + period;
+    }
     return (max ? truncate(base, Math.max(12, max - suffix.length)) : base) + suffix;
 }
 
@@ -146,6 +162,7 @@ function classifyRoute(pathname) {
         const id = decodePathSegment(m[1]);
         return id == null ? { type: 'other' } : { type: 'organization', id };
     }
+    if (/^\/datasets\/?$/.test(p)) return { type: 'datasets' };
     if (/^\/places\/?$/.test(p)) return { type: 'places' };
     if (/^\/insights\/?$/.test(p)) return { type: 'insights' };
     if (/^\/organizations\/?$/.test(p)) return { type: 'organizations' };
@@ -155,6 +172,8 @@ function classifyRoute(pathname) {
 }
 
 const STATIC_META = {
+    datasets: { path: '/datasets', title: 'Browse all Canadian datasets - CanQuery',
+        description: 'Browse the complete Canadian open data catalogue: downloadable files, live tables and maps from federal, provincial and municipal publishers.' },
     home: { title: DEFAULT_TITLE, description: DEFAULT_DESC, path: '/' },
     insights: {
         title: 'Insights: Top 100 downloaded datasets - CanQuery',
@@ -394,7 +413,7 @@ function datasetMeta(dataset, resources) {
         jsonLd: [
             buildDatasetJsonLd(dataset, resources),
             buildBreadcrumbJsonLd([
-                { name: 'Datasets', path: '/' },
+                { name: 'Datasets', path: '/datasets' },
                 { name: title, path: '/datasets/' + encodeURIComponent(slug) }
             ])
         ],
@@ -403,9 +422,7 @@ function datasetMeta(dataset, resources) {
 
 function resourceDescription(resource, { lang = 'en', max = DESCRIPTION_MAX } = {}) {
     const capability = classifyResource(resource).capability;
-    const name = pick(resource.name_en, resource.name_fr);
-    const datasetTitle = pick(resource.dataset_title_en, resource.dataset_title_fr);
-    const subject = (isGenericResourceName(name, resource.format) ? datasetTitle : name) || datasetTitle || 'open data';
+    const subject = resourceSubject(resource) || 'open data';
     const language = resourceLanguages(resource).map(lang => lang === 'fr' ? 'French' : 'English').join('/');
     const format = [language, plainText(resource.format).toUpperCase()].filter(Boolean).join(' ');
     const mapped = Boolean(resource.map_provider || resource.map?.available);
@@ -475,7 +492,7 @@ function resourceMeta(resource) {
         canonical: SITE_URL + '/resources/' + encodeURIComponent(resource.id),
         ogType: 'website',
         jsonLd: [buildResourceJsonLd(resource, description), buildBreadcrumbJsonLd([
-            { name: 'Datasets', path: '/' },
+            { name: 'Datasets', path: '/datasets' },
             datasetSlug && ds ? {
                 name: ds,
                 path: '/datasets/' + encodeURIComponent(datasetSlug)

--- a/server/services/seoSnapshot.js
+++ b/server/services/seoSnapshot.js
@@ -3,6 +3,8 @@ const { listArticles } = require('./blogContent');
 const { classifyResource } = require('./resourceCapabilities');
 const { datasetPresentation, resourcePresentation } = require('./catalogPresentation');
 
+const { PAGE_SIZE, pagePath } = require('./catalogPagination');
+const { toAbsoluteUrl } = require('../utils/resolveUrl');
 const MAX_LINKS = 12;
 const MAX_SUMMARY = 1200;
 
@@ -34,19 +36,28 @@ function factList(facts) {
         '</dd></div>').join('') + '</dl>';
 }
 
-function linkList(title, links) {
-    const entries = (links || []).filter(link => link && link.path && link.label).slice(0, MAX_LINKS);
+function linkList(title, links, limit = MAX_LINKS) {
+    const entries = (links || []).filter(link => link && link.path && link.label).slice(0, limit);
     if (!entries.length) return '';
     return '<section><h2>' + text(title) + '</h2><ul>' + entries.map(link =>
         '<li>' + pathLink(link.path, link.label) + (link.detail ? ' <span>' + text(link.detail) + '</span>' : '') + '</li>'
     ).join('') + '</ul></section>';
 }
 
-function shell({ breadcrumbs, title, summary, facts, linksTitle, links, relatedLinks, overviewHtml = '', sources = [], guides = [] }) {
+function paginationLinks(pagination) {
+    if (!pagination || (pagination.page === 1 && !pagination.hasMore)) return '';
+    const { page, path, hasMore } = pagination;
+    return '<nav aria-label="Catalogue pages">' +
+        (page > 1 ? pathLink(pagePath(path, page - 1), 'Previous') + ' ' + pathLink(path, '1') + ' ' : '') +
+        '<span aria-current="page">Page ' + page + '</span>' +
+        (hasMore ? ' ' + pathLink(pagePath(path, page + 1), String(page + 1)) + ' ' + pathLink(pagePath(path, page + 1), 'Next') : '') + '</nav>';
+}
+
+function shell({ breadcrumbs, title, summary, facts, linksTitle, links, relatedLinks, overviewHtml = '', sources = [], guides = [], pagination }) {
     return '<main class="cq-seo-snapshot max-w-5xl mx-auto px-4 py-8" data-cq-seo-snapshot="true">' +
         breadcrumb(breadcrumbs) + '<article><h1>' + text(title) + '</h1>' +
         (summary ? '<p>' + text(seo.truncate(summary, MAX_SUMMARY)) + '</p>' : '') +
-        factList(facts) + overviewHtml + linkList('Official sources and licences', sources) + linkList(linksTitle, links) +
+        factList(facts) + overviewHtml + linkList('Official sources and licences', sources) + linkList(linksTitle, links, pagination ? PAGE_SIZE : MAX_LINKS) + paginationLinks(pagination) +
         linkList('Related open data', relatedLinks) + linkList('Data guides', guides) + '</article></main>';
 }
 
@@ -91,11 +102,11 @@ function overviewSnapshot(presentation, dataset = false) {
     ]) + table + '</section>';
 }
 
-function datasetSnapshot(dataset, resources) {
+function datasetSnapshot(dataset, resources, pagination) {
     const presentation = datasetPresentation(dataset, resources);
     const title = seo.plainText(dataset.title_en) || seo.plainText(dataset.title_fr) || dataset.name || dataset.id;
     const organization = seo.plainText(dataset.org_title_en) || seo.plainText(dataset.org_title_fr);
-    const links = (resources || []).slice(0, MAX_LINKS).map(resource => ({
+    const links = (pagination?.items || (resources || []).slice(0, MAX_LINKS)).map(resource => ({
         path: '/resources/' + encodeURIComponent(resource.id),
         label: resourcePresentation({ ...resource, dataset_title_en: dataset.title_en, dataset_title_fr: dataset.title_fr }).title.en,
         detail: resource.format || classifyResource(resource).capability
@@ -109,7 +120,8 @@ function datasetSnapshot(dataset, resources) {
         label: organization
     }] : [];
     return shell({
-        breadcrumbs: [{ label: 'Datasets', path: '/' }, { label: title }],
+        pagination,
+        breadcrumbs: [{ label: 'Datasets', path: '/datasets' }, { label: title }],
         title,
         summary: presentation.summary.en,
         overviewHtml: overviewSnapshot(presentation, true),
@@ -132,6 +144,14 @@ function datasetSnapshot(dataset, resources) {
     });
 }
 
+function originalFileLink(resource) {
+    try {
+        const url = new URL(toAbsoluteUrl(resource.url));
+        if (!['https:', 'http:'].includes(url.protocol) || url.username || url.password) return '';
+        return '<p>' + pathLink(url.href, 'Access original file') + '</p>';
+    } catch { return ''; }
+}
+
 function resourceSnapshot(resource) {
     const presentation = resourcePresentation(resource);
     const name = presentation.title.en;
@@ -151,13 +171,14 @@ function resourceSnapshot(resource) {
     }
     return shell({
         breadcrumbs: [
-            { label: 'Datasets', path: '/' },
+            { label: 'Datasets', path: '/datasets' },
             { label: datasetName, path: '/datasets/' + encodeURIComponent(datasetSlug) },
             { label: name }
         ],
         title: name,
         summary: presentation.summary.en,
-        overviewHtml: overviewSnapshot(presentation),
+        overviewHtml: (presentation.context.en ? '<p>' + text(presentation.context.en) + '</p>' : '') +
+            originalFileLink(resource) + overviewSnapshot(presentation),
         sources: sourceLinks(resource),
         guides: resource.dataset_id || resource.dataset_name ? listArticles({ dataset: resource.dataset_id || resource.dataset_name }).map(article => ({ path: article.path, label: article.title })) : [],
         facts: [
@@ -171,7 +192,7 @@ function resourceSnapshot(resource) {
     });
 }
 
-function placeSnapshot(place, datasets) {
+function placeSnapshot(place, datasets, pagination) {
     const name = seo.plainText(place.name_en) || seo.plainText(place.name_fr) || place.slug || place.id;
     const ancestors = (Array.isArray(place.ancestors) ? place.ancestors : [])
         .filter(ancestor => ancestor.id !== place.id)
@@ -191,6 +212,7 @@ function placeSnapshot(place, datasets) {
     const count = Number(place.dataset_count) || 0;
     const maps = Number(place.mappable_dataset_count) || 0;
     return shell({
+        pagination,
         breadcrumbs: [{ label: 'Places', path: '/places' }, ...ancestors, { label: name }],
         title: name + ' open data',
         summary: 'Explore ' + count.toLocaleString('en-CA') + ' open dataset' + (count === 1 ? '' : 's') +
@@ -206,7 +228,7 @@ function placeSnapshot(place, datasets) {
     });
 }
 
-function organizationSnapshot(organization, datasets) {
+function organizationSnapshot(organization, datasets, pagination) {
     const name = seo.plainText(organization.title_en) || seo.plainText(organization.title_fr) || organization.name;
     const links = (datasets || []).map(dataset => ({
         path: '/datasets/' + encodeURIComponent(dataset.name || dataset.id),
@@ -221,6 +243,7 @@ function organizationSnapshot(organization, datasets) {
     }
     const total = Number(organization.dataset_count) || 0;
     return shell({
+        pagination,
         breadcrumbs: [{ label: 'Organizations', path: '/organizations' }, { label: name }],
         title: name + ' open data',
         summary: 'Browse ' + total.toLocaleString('en-CA') + ' open dataset' + (total === 1 ? '' : 's') +
@@ -241,12 +264,17 @@ const STATIC_COPY = {
         title: "Search Canada's open data",
         summary: 'Find federal, provincial, territorial and municipal datasets, query live tables, and explore spatial resources on maps.',
         links: [
+            { path: '/datasets', label: 'Browse all datasets' },
             { path: '/places', label: 'Browse open data by place' },
             { path: '/blog', label: 'Read data guides' },
             { path: '/organizations', label: 'Browse publishing organizations' },
             { path: '/insights', label: 'Explore popular dataset insights' },
             { path: '/docs', label: 'Use the CanQuery API' }
         ]
+    },
+    datasets: {
+        title: 'Browse all Canadian datasets',
+        summary: 'Browse the complete CanQuery catalogue, including downloadable files, live tables and maps.'
     },
     insights: {
         title: 'Top downloaded Canadian datasets',
@@ -273,9 +301,20 @@ const STATIC_COPY = {
     }
 };
 
-function staticSnapshot(type, items = []) {
+function staticSnapshot(type, items = [], pagination) {
     const copy = STATIC_COPY[type] || STATIC_COPY.home;
-    const dynamicLinks = items.map(item => {
+    const regions = items.filter(item => item.kind === 'region');
+    const regionIds = new Set(regions.map(item => item.id));
+    const ordered = type === 'places' ? [
+        ...regions.flatMap(region => [region, ...items.filter(item => item.kind === 'municipality' && item.parent_id === region.id)]),
+        ...items.filter(item => item.kind === 'municipality' && !regionIds.has(item.parent_id)),
+        ...items.filter(item => !['region', 'municipality'].includes(item.kind))
+    ] : items;
+    const dynamicLinks = ordered.map(item => {
+        if (type === 'datasets') return {
+            path: '/datasets/' + encodeURIComponent(item.name || item.id),
+            label: seo.plainText(item.title_en) || seo.plainText(item.title_fr) || item.name || item.id
+        };
         if (type === 'organizations') {
             return {
                 path: '/organizations/' + encodeURIComponent(item.name),
@@ -293,10 +332,11 @@ function staticSnapshot(type, items = []) {
         return null;
     }).filter(Boolean);
     return shell({
+        pagination,
         breadcrumbs: type === 'home' ? [] : [{ label: 'CanQuery', path: '/' }, { label: copy.title }],
         title: copy.title,
         summary: copy.summary,
-        linksTitle: dynamicLinks.length ? (type === 'places' ? 'Featured places' : 'Publishing organizations') : 'Explore CanQuery',
+        linksTitle: dynamicLinks.length ? (type === 'places' ? 'Featured places' : type === 'datasets' ? 'Open datasets' : 'Publishing organizations') : 'Explore CanQuery',
         links: dynamicLinks.length ? dynamicLinks : copy.links
     });
 }


### PR DESCRIPTION
## What & why

Catalogue previews exposed only a small first slice, and sitemaps omitted download-only records. Add a Browse catalogue directory and crawlable 50-item pagination across catalogue, publisher, place and resource lists, and include every public canonical dataset/resource in the existing chunked sitemaps.

Resource headings now link to their detail pages, which show recorded dataset context and original-download links before JavaScript runs. Date-only resource titles retain their period, language and format while identifying the dataset. Keyword actions and filtered pagination keep search usable without adding crawlable filter combinations; publisher search covers the full bilingual directory.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any
- [x] No secrets, credentials, or production-specific details added

## Notes

Validation: 614 ordinary server tests, 151 client tests, and 26 PostgreSQL/PostGIS integration tests passed; all 12 guide editions validate. Chromium and WebKit checks covered English/French, light/dark themes, 320/390/1440-pixel layouts, pagination and Back, filtered publisher search, download-only details, and JavaScript-disabled HTML. Browser previews used recorded catalogue metadata; live verification follows deployment.

No migration or dependency change. The release runbook documents backup, exact-build verification, API-only promotion and rollback. Google indexing changes require subsequent crawling and observation.