### PR TITLE
Keep catalogue request state internal and stabilize highlight verification

### DIFF
--- a/client/src/hooks/useCatalogPage.js
+++ b/client/src/hooks/useCatalogPage.js
@@ -42,7 +42,8 @@ export default function useCatalogPage(fetchPage, deps, filtered = false) {
   }, [requestKey]);
 
   const current = state.key === requestKey ? state : { items: [], loading: page !== null, error: null, meta: null, hasMore: false };
-  return { ...current, page, path: pathname,
+  return { items: current.items, loading: current.loading, error: current.error,
+    meta: current.meta, hasMore: current.hasMore, page, path: pathname,
     notFound: page === null || (!current.loading && !current.error && page > 1 && current.items.length === 0),
     onPage: filtered ? number => setSelection({ key: filterKey, page: number }) : undefined };
 }

--- a/client/src/pages/DatasetPage.test.jsx
+++ b/client/src/pages/DatasetPage.test.jsx
@@ -95,11 +95,13 @@ describe('DatasetPage ingestion', () => {
     fetchDataset.mockReset();
     fetchDataset.mockResolvedValue(env);
 
-    render(
-      <MemoryRouter initialEntries={['/datasets/dataset-a?highlight=resource-55']}>
-        <Routes><Route path="/datasets/:idOrName" element={<DatasetPage />} /></Routes>
-      </MemoryRouter>
-    );
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/datasets/dataset-a?highlight=resource-55']}>
+          <Routes><Route path="/datasets/:idOrName" element={<DatasetPage />} /></Routes>
+        </MemoryRouter>
+      );
+    });
 
     expect(await screen.findByText('Resource 55')).toBeInTheDocument();
     expect(screen.getByText('Page 2')).toHaveAttribute('aria-current', 'page');


### PR DESCRIPTION
## What & why

Keep the catalogue hook’s internal request key out of its public return value so spreading pagination props does not pass React’s reserved `key`. In the highlight regression, explicitly settle the mocked fetch and subsequent navigation with async `act` before inspecting the selected resource page. This removes a one-second query timeout observed on the slower release host without changing highlight behavior or increasing test timeouts.

## Checklist

- [x] `server`: `npm run lint && npm test` pass (unchanged from #49)
- [x] `client`: `npm run lint && npm test && npm run build` pass
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any — none changed
- [x] No secrets, credentials, or production-specific details added

## Notes

All 151 client tests pass. The isolated highlight test reproduced its timeout before this change and passes with the mocked updates explicitly settled. No dependency or schema change.