### PR TITLE
Bound catalogue enrichment before serving deep pagination

### DIFF
--- a/server/__tests__/catalogDiscoveryIntegration.test.js
+++ b/server/__tests__/catalogDiscoveryIntegration.test.js
@@ -53,6 +53,20 @@ integrationDescribe('complete catalogue discovery PostgreSQL integration', () =>
         expect((await search('études du nord')).map(row => row.name)).toEqual([id('publisher')]);
         expect(await search('%études%')).toHaveLength(0);
     });
+    test('filters before pagination and retains resource capabilities on the selected page', async () => {
+        const page = await queries.searchDatasets({ org: prefix, format: 'CSV', limit: 2, offset: 1 }, db);
+        expect(page.map(row => row.id)).toEqual([id('dataset002'), id('dataset003')]);
+        for (const [index, row] of page.entries()) {
+            expect(row.resource_count).toBe(1);
+            expect(row.queryable_count).toBe(1);
+            expect(row.preview_table_id).toBe(id('resource' + (index + 2)));
+            expect(row.org_name).toBe(prefix);
+        }
+        const maps = await queries.searchDatasets({ org: prefix, mappable: true, limit: 1, offset: 0 }, db);
+        expect(maps.map(row => row.id)).toEqual([id('dataset004')]);
+        expect(maps[0].mappable_count).toBe(1);
+        expect(maps[0].preview_map_id).toBe(id('resource4'));
+    });
     test('sitemap chunk offsets partition resources without duplicate joins', async () => {
         const all = await queries.listResourceSitemap({ limit: 25000, offset: 0 }, db);
         const first = await queries.listResourceSitemap({ limit: 2, offset: 0 }, db);

--- a/server/db/catalogReadQueries.js
+++ b/server/db/catalogReadQueries.js
@@ -66,7 +66,40 @@ const PLACE_CTES = `WITH RECURSIVE selected_place AS (
 )`;
 
 async function searchDatasets({ q, org, format, keyword, place, source, mappable, limit, offset }, db = pool) {
-    const result = await db.query(`${PLACE_CTES}
+    // Select the requested identities before evaluating resource/provenance
+    // subqueries. Otherwise OFFSET enriches every skipped dataset as well.
+    const result = await db.query(`${PLACE_CTES}, dataset_page AS MATERIALIZED (
+        SELECT d.id AS dataset_id, pm.depth,
+               pm.matched_place_id, pm.matched_place_slug,
+               pm.matched_place_name_en, pm.matched_place_name_fr, pm.place_relationship,
+               CASE WHEN $1::text IS NULL THEN 0 ELSE (SELECT coalesce(sum(
+                    CASE WHEN concat_ws(' ', d.title_en, d.title_fr) ~* pattern THEN 8 ELSE 0 END +
+                    CASE WHEN concat_ws(' ', array_to_string(d.keywords_en, ' '), array_to_string(d.keywords_fr, ' ')) ~* pattern THEN 4 ELSE 0 END +
+                    CASE WHEN concat_ws(' ', d.notes_en, d.notes_fr) ~* pattern THEN 1 ELSE 0 END
+                ), 0) FROM unnest($11::text[]) AS pattern) END AS literal_rank,
+               CASE WHEN $1::text IS NULL THEN NULL
+                    ELSE ts_rank(d.search_tsv, to_tsquery('english', $10) || to_tsquery('french', $10))
+               END AS search_rank,
+               d.metadata_modified
+        FROM datasets d
+        LEFT JOIN organizations o ON o.id = d.org_id
+        LEFT JOIN place_matches pm ON pm.dataset_id = d.id
+        WHERE ($1::text IS NULL OR d.search_tsv @@ (to_tsquery('english', $10) || to_tsquery('french', $10)))
+          AND ($2::text IS NULL OR o.name = $2)
+          AND ($3::text IS NULL OR EXISTS (
+               SELECT 1 FROM resources r2
+               WHERE r2.dataset_id = d.id AND r2.format = upper($3)))
+          AND ($4::text IS NULL OR $4 = ANY(d.keywords_en) OR $4 = ANY(d.keywords_fr))
+          AND ($5::text IS NULL OR pm.dataset_id IS NOT NULL)
+          AND ($6::text IS NULL OR EXISTS (
+               SELECT 1 FROM dataset_sources ds2 WHERE ds2.dataset_id = d.id AND ds2.source_id = $6))
+          AND ($7::boolean IS NULL OR EXISTS (
+               SELECT 1 FROM resources r3 JOIN resource_maps rm3 ON rm3.resource_id = r3.id
+               WHERE r3.dataset_id = d.id))
+        ORDER BY pm.depth ASC NULLS LAST, literal_rank DESC, search_rank DESC NULLS LAST,
+                 d.metadata_modified DESC NULLS LAST, d.id ASC
+        LIMIT $8 OFFSET $9
+    )
         SELECT d.id, d.name, d.title_en, d.title_fr, d.metadata_modified,
                d.notes_en, d.notes_fr,
                (SELECT r.id FROM resources r JOIN resource_maps rm ON rm.resource_id = r.id
@@ -74,11 +107,7 @@ async function searchDatasets({ q, org, format, keyword, place, source, mappable
                (SELECT r.id FROM resources r LEFT JOIN ingested_resources ir ON ir.resource_id = r.id
                 WHERE r.dataset_id = d.id AND (r.datastore_active OR ir.status = 'ready')
                 ORDER BY (ir.status = 'ready') DESC NULLS LAST, r.id LIMIT 1) AS preview_table_id,
-               CASE WHEN $1::text IS NULL THEN 0 ELSE (SELECT coalesce(sum(
-                    CASE WHEN concat_ws(' ', d.title_en, d.title_fr) ~* pattern THEN 8 ELSE 0 END +
-                    CASE WHEN concat_ws(' ', array_to_string(d.keywords_en, ' '), array_to_string(d.keywords_fr, ' ')) ~* pattern THEN 4 ELSE 0 END +
-                    CASE WHEN concat_ws(' ', d.notes_en, d.notes_fr) ~* pattern THEN 1 ELSE 0 END
-                ), 0) FROM unnest($11::text[]) AS pattern) END AS literal_rank,
+               pm.literal_rank,
                o.name AS org_name, o.title_en AS org_title_en, o.title_fr AS org_title_fr,
                (SELECT count(*)::int FROM resources r WHERE r.dataset_id = d.id) AS resource_count,
                (SELECT count(*)::int FROM resources r
@@ -95,29 +124,14 @@ async function searchDatasets({ q, org, format, keyword, place, source, mappable
                pm.matched_place_id, pm.matched_place_slug,
                pm.matched_place_name_en, pm.matched_place_name_fr,
                pm.place_relationship
-        FROM datasets d
+        FROM dataset_page pm
+        JOIN datasets d ON d.id = pm.dataset_id
         LEFT JOIN organizations o ON o.id = d.org_id
-        LEFT JOIN place_matches pm ON pm.dataset_id = d.id
-        WHERE ($1::text IS NULL OR d.search_tsv @@ (to_tsquery('english', $10) || to_tsquery('french', $10)))
-          AND ($2::text IS NULL OR o.name = $2)
-          AND ($3::text IS NULL OR EXISTS (
-               SELECT 1 FROM resources r2
-               WHERE r2.dataset_id = d.id AND r2.format = upper($3)))
-          AND ($4::text IS NULL OR $4 = ANY(d.keywords_en) OR $4 = ANY(d.keywords_fr))
-          AND ($5::text IS NULL OR pm.dataset_id IS NOT NULL)
-          AND ($6::text IS NULL OR EXISTS (
-               SELECT 1 FROM dataset_sources ds2 WHERE ds2.dataset_id = d.id AND ds2.source_id = $6))
-          AND ($7::boolean IS NULL OR EXISTS (
-               SELECT 1 FROM resources r3 JOIN resource_maps rm3 ON rm3.resource_id = r3.id
-               WHERE r3.dataset_id = d.id))
         ORDER BY pm.depth ASC NULLS LAST,
-                 literal_rank DESC,
-                 CASE WHEN $1::text IS NULL THEN NULL
-                      ELSE ts_rank(d.search_tsv, to_tsquery('english', $10) || to_tsquery('french', $10))
-                 END DESC NULLS LAST,
+                 pm.literal_rank DESC,
+                 pm.search_rank DESC NULLS LAST,
                  d.metadata_modified DESC NULLS LAST,
                  d.id ASC
-        LIMIT $8 OFFSET $9
     `, [q || null, org || null, format || null, keyword || null, place || null, source || null, mappable || null, limit, offset, searchExpression(q) || null, literalPatterns(q)]);
     return result.rows;
 }


### PR DESCRIPTION
## What & why

Deep catalogue pages timed out because resource previews, counts and provenance were calculated for rows discarded by `OFFSET`. Select the filtered, ordered page of dataset identities first, then enrich only those records. Keep ranking, place coverage, stable ordering and response fields unchanged.

## Checklist

- [x] `server`: `npm run lint && npm test` pass
- [x] `client`: `npm run lint && npm test && npm run build` pass (unchanged from #50)
- [x] Added/updated tests for the changed behavior
- [x] User-facing strings added to `client/src/i18n.jsx` (EN + FR), if any — none changed
- [x] No secrets, credentials, or production-specific details added

## Notes

614 ordinary server tests and all 27 PostgreSQL/PostGIS integration tests passed. The new regression verifies that filtering precedes pagination and selected rows retain live/local table and map capabilities. Read-only query plans against a full catalogue returned its last page in 287 ms and an out-of-range page in 195 ms, within a five-second statement budget. No migration or dependency change.